### PR TITLE
DIAGNOSTIC [MNT] Break some objects to check validity of tests

### DIFF
--- a/skpro/distributions/__init__.py
+++ b/skpro/distributions/__init__.py
@@ -10,5 +10,5 @@ __all__ = [
 ]
 
 from skpro.distributions.laplace import Laplace
-from skpro.distributions.normal import Mixture
+from skpro.distributions.mixture import Mixture
 from skpro.distributions.normal import Normal

--- a/skpro/distributions/__init__.py
+++ b/skpro/distributions/__init__.py
@@ -3,7 +3,12 @@
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 # adapted from sktime
 
-__all__ = ["Laplace", "Normal"]
+__all__ = [
+    "Laplace",
+    "Mixture",
+    "Normal",
+]
 
 from skpro.distributions.laplace import Laplace
+from skpro.distributions.normal import Mixture
 from skpro.distributions.normal import Normal

--- a/skpro/distributions/mixture.py
+++ b/skpro/distributions/mixture.py
@@ -27,6 +27,7 @@ class Mixture(BaseMetaObject, BaseDistribution):
     Example
     -------
     >>> from skpro.distributions.mixture import Mixture
+    >>> from skpro.distributions.normal import Normal
 
     >>> n1 = Normal(mu=[[0, 1], [2, 3], [4, 5]], sigma=1)
     >>> n2 = Normal(mu=3, sigma=2, index=n1.index, columns=n1.columns)

--- a/skpro/distributions/mixture.py
+++ b/skpro/distributions/mixture.py
@@ -172,6 +172,6 @@ class Mixture(BaseMetaObject, BaseDistribution):
 
         dists = [("normal1", normal1), ("normal2", normal2)]
 
-        params1 = {"distributions": dists1}
+        params1 = {"distributions": dists}
         params2 = {"distributions": dists, "weights": [0.3, 0.7]}
         return [params1, params2]

--- a/skpro/distributions/mixture.py
+++ b/skpro/distributions/mixture.py
@@ -76,6 +76,7 @@ class Mixture(BaseMetaObject, BaseDistribution):
         pd.DataFrame with same rows, columns as `self`
         expected value of distribution (entry-wise)
         """
+        raise ValueError("break for diagnosing tests")
         return self._average("mean")
 
     def var(self):

--- a/skpro/distributions/mixture.py
+++ b/skpro/distributions/mixture.py
@@ -76,7 +76,7 @@ class Mixture(BaseMetaObject, BaseDistribution):
         pd.DataFrame with same rows, columns as `self`
         expected value of distribution (entry-wise)
         """
-        return self._average(self, "mean")
+        return self._average("mean")
 
     def var(self):
         r"""Return element/entry-wise variance of the distribution.

--- a/skpro/distributions/mixture.py
+++ b/skpro/distributions/mixture.py
@@ -26,7 +26,7 @@ class Mixture(BaseMetaObject, BaseDistribution):
 
     Example
     -------
-    >>> from skpro.distributions.mixtures import Mixture
+    >>> from skpro.distributions.mixture import Mixture
 
     >>> n1 = Normal(mu=[[0, 1], [2, 3], [4, 5]], sigma=1)
     >>> n2 = Normal(mu=3, sigma=2, index=n1.index, columns=n1.columns)

--- a/skpro/distributions/mixture.py
+++ b/skpro/distributions/mixture.py
@@ -1,0 +1,177 @@
+# -*- coding: utf-8 -*-
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+"""Mixture distribution."""
+
+__author__ = ["fkiraly"]
+
+import numpy as np
+import pandas as pd
+from skbase.base import BaseMetaObject
+
+from skpro.distributions.base import BaseDistribution
+
+
+class Mixture(BaseMetaObject, BaseDistribution):
+    """Mixture of distributions.
+
+    Parameters
+    ----------
+    distributions : list of tuples (str, BaseDistribution) or BaseDistribution
+        list of mixture components
+    weights : list of float, optional, default = None
+        list of mixture weights, will be normalized to sum to 1
+        if not provided, uniform mixture is assumed
+    index : pd.Index, optional, default = inferred from component distributions
+    columns : pd.Index, optional, default = inferred from component distributions
+
+    Example
+    -------
+    >>> from skpro.distributions.mixtures import Mixture
+
+    >>> n1 = Normal(mu=[[0, 1], [2, 3], [4, 5]], sigma=1)
+    >>> n2 = Normal(mu=3, sigma=2, index=n1.index, columns=n1.columns)
+    >>> m = Mixture(distributions=[("n1", n1), ("n2", n2)], weights=[0.3, 0.7])
+    >>> mixture_sample = m.sample(n_samples=10)
+    """
+
+    _tags = {
+        "capabilities:approx": ["pdfnorm", "energy"],
+        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf"],
+        "distr:measuretype": "mixed",
+        "named_object_parameters": "_distributions",
+    }
+
+    def __init__(self, distributions, weights=None, index=None, columns=None):
+
+        self.distributions = distributions
+        self.weights = weights
+        self.index = index
+        self.columns = columns
+
+        self._distributions = self._coerce_to_named_object_tuples(distributions)
+        n_dists = len(self._distributions)
+
+        if weights is None:
+            self._weights = np.ones(n_dists) / len(n_dists)
+        else:
+            self._weights = np.array(weights) / np.sum(weights)
+
+        if index is None:
+            index = self._distributions[0][1].index
+
+        if columns is None:
+            columns = self._distributions[0][1].columns
+
+        super().__init__(index=index, columns=columns)
+
+    def mean(self):
+        r"""Return expected value of the distribution.
+
+        Let :math:`X` be a random variable with the distribution of `self`.
+        Returns the expectation :math:`\mathbb{E}[X]`
+
+        Returns
+        -------
+        pd.DataFrame with same rows, columns as `self`
+        expected value of distribution (entry-wise)
+        """
+        return self._average(self, "mean")
+
+    def var(self):
+        r"""Return element/entry-wise variance of the distribution.
+
+        Let :math:`X` be a random variable with the distribution of `self`.
+        Returns :math:`\mathbb{V}[X] = \mathbb{E}\left(X - \mathbb{E}[X]\right)^2`
+
+        Returns
+        -------
+        pd.DataFrame with same rows, columns as `self`
+        variance of distribution (entry-wise)
+        """
+        weights = self._weights
+        var_mean = self._average("var")
+        mixture_mean = self._average("mean")
+
+        means = [d.mu() for _, d in self._distributions]
+        mean_var = [(m - mixture_mean) ** 2 for m in means]
+        var_mean_var = self._average_df(mean_var, weights=weights)
+
+        return var_mean + var_mean_var
+
+    def _average(self, method, x=None, weights=None):
+
+        if x is None:
+            args = ()
+        else:
+            args = (x,)
+
+        vals = [getattr(d, method)(*args) for _, d in self._distributions]
+
+        return self._average_df(vals, weights=weights)
+
+    def _average_df(self, df_list, weights=None):
+
+        if weights is None:
+            weights = self._weights
+
+        n_df = len(df_list)
+        df_weighted = [df * w for df, w in zip(df_list, weights)]
+        df_concat = pd.concat(df_weighted, axis=1, keys=range(n_df))
+        df_res = df_concat.groupby(level=-1, axis=1).sum()
+        return df_res
+
+    def pdf(self, x):
+        """Probability density function."""
+        return self._average("pdf", x)
+
+    def cdf(self, x):
+        """Cumulative distribution function."""
+        return self._average("cdf", x)
+
+    def sample(self, n_samples=None):
+        """Sample from the distribution.
+
+        Parameters
+        ----------
+        n_samples : int, optional, default = None
+
+        Returns
+        -------
+        if `n_samples` is `None`:
+        returns a sample that contains a single sample from `self`,
+        in `pd.DataFrame` mtype format convention, with `index` and `columns` as `self`
+        if n_samples is `int`:
+        returns a `pd.DataFrame` that contains `n_samples` i.i.d. samples from `self`,
+        in `pd-multiindex` mtype format convention, with same `columns` as `self`,
+        and `MultiIndex` that is product of `RangeIndex(n_samples)` and `self.index`
+        """
+        if n_samples is None:
+            N = 1
+        else:
+            N = n_samples
+
+        n_dist = len(self._distributions)
+        selector = np.random.choice(n_dist, size=N, p=self._weights)
+
+        samples = [self._distributions[i][1].sample() for i in selector]
+
+        if n_samples is None:
+            return samples[0]
+        else:
+            return pd.concat(samples, axis=1, keys=range(N))
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator."""
+        from skpro.distributions.normal import Normal
+
+        index = pd.RangeIndex(3)
+        columns = pd.Index(["a", "b"])
+        normal1 = Normal(mu=0, sigma=1, index=index, columns=columns)
+        normal2 = Normal(mu=[[0, 1], [2, 3], [4, 5]], sigma=1)
+
+        dists = [("normal1", normal1), ("normal2", normal2)]
+
+        params1 = {"distributions": dists1}
+        params2 = {"distributions": dists, "weights": [0.3, 0.7]}
+        return [params1, params2]

--- a/skpro/distributions/mixture.py
+++ b/skpro/distributions/mixture.py
@@ -52,7 +52,7 @@ class Mixture(BaseMetaObject, BaseDistribution):
         n_dists = len(self._distributions)
 
         if weights is None:
-            self._weights = np.ones(n_dists) / len(n_dists)
+            self._weights = np.ones(n_dists) / n_dists
         else:
             self._weights = np.array(weights) / np.sum(weights)
 

--- a/skpro/distributions/mixture.py
+++ b/skpro/distributions/mixture.py
@@ -99,7 +99,7 @@ class Mixture(BaseMetaObject, BaseDistribution):
         return var_mean + var_mean_var
 
     def _average(self, method, x=None, weights=None):
-
+        """Average a method over the mixture components."""
         if x is None:
             args = ()
         else:
@@ -110,7 +110,7 @@ class Mixture(BaseMetaObject, BaseDistribution):
         return self._average_df(vals, weights=weights)
 
     def _average_df(self, df_list, weights=None):
-
+        """Average a list of `pd.DataFrame` objects, with weights."""
         if weights is None:
             weights = self._weights
 

--- a/skpro/distributions/normal.py
+++ b/skpro/distributions/normal.py
@@ -107,6 +107,7 @@ class Normal(BaseDistribution):
         pd.DataFrame with same rows, columns as `self`
         expected value of distribution (entry-wise)
         """
+        raise ValueError("break for diagnosing tests")
         mean_arr = self._mu
         return pd.DataFrame(mean_arr, index=self.index, columns=self.columns)
 
@@ -121,6 +122,7 @@ class Normal(BaseDistribution):
         pd.DataFrame with same rows, columns as `self`
         variance of distribution (entry-wise)
         """
+        raise ValueError("break for diagnosing tests")
         sd_arr = self._sigma
         return pd.DataFrame(sd_arr, index=self.index, columns=self.columns) ** 2
 

--- a/skpro/distributions/tests/test_all_distrs.py
+++ b/skpro/distributions/tests/test_all_distrs.py
@@ -12,6 +12,7 @@ from skbase.testing import BaseFixtureGenerator, QuickTester
 
 from skpro.datatypes import check_is_mtype
 from skpro.distributions.base import BaseDistribution
+from skpro.tests.test_all_estimators import PackageConfig
 
 
 class DistributionFixtureGenerator(BaseFixtureGenerator):
@@ -56,7 +57,7 @@ METHODS_P = ["ppf"]
 METHODS_ROWWISE = ["energy"]  # results in one column
 
 
-class TestAllDistributions(DistributionFixtureGenerator, QuickTester):
+class TestAllDistributions(PackageConfig, DistributionFixtureGenerator, QuickTester):
     """Module level tests for all sktime parameter fitters."""
 
     def test_sample(self, object_instance):

--- a/skpro/regression/residual.py
+++ b/skpro/regression/residual.py
@@ -132,7 +132,7 @@ class ResidualDouble(BaseProbaRegressor):
             labels predicted for `X`
         """
         est = self.estimator_
-
+        raise ValueError("break for diagnosing tests")
         y_pred = est.predict(X)
         y_pred = pd.DataFrame(y_pred, columns=self._y_cols, index=X.index)
 

--- a/skpro/tests/test_all_estimators.py
+++ b/skpro/tests/test_all_estimators.py
@@ -44,6 +44,8 @@ class PackageConfig:
         "approx_spl",  # int, sample size used in other MC estimates
         "scitype:y_pred",  # str, expected input type for y_pred in performance metric
         "lower_is_better",  # bool, whether lower (True) or higher (False) is better
+        # BaseMetaObject reserved tags
+        "named_object_parameters",  # name of component list attribute for meta-objects
     ]
 
 


### PR DESCRIPTION
This PR intentionally breaks some methods of objecets to check whethere the tests find the broken methods:

* `Mixture.mean`
* `Normal.mean` and `Normal.var`
* `ResidualDouble.predict`