### PR TITLE
[BUG] fix distribution suite test class missing package config

### DIFF
--- a/skpro/distributions/tests/test_all_distrs.py
+++ b/skpro/distributions/tests/test_all_distrs.py
@@ -12,6 +12,7 @@ from skbase.testing import BaseFixtureGenerator, QuickTester
 
 from skpro.datatypes import check_is_mtype
 from skpro.distributions.base import BaseDistribution
+from skpro.tests.test_all_estimators import PackageConfig
 
 
 class DistributionFixtureGenerator(BaseFixtureGenerator):
@@ -56,7 +57,7 @@ METHODS_P = ["ppf"]
 METHODS_ROWWISE = ["energy"]  # results in one column
 
 
-class TestAllDistributions(DistributionFixtureGenerator, QuickTester):
+class TestAllDistributions(PackageConfig, DistributionFixtureGenerator, QuickTester):
     """Module level tests for all sktime parameter fitters."""
 
     def test_sample(self, object_instance):


### PR DESCRIPTION
The distribution suite test class `TestAllDistributions` did not test any of the distributions in `skpro`, as the `PackageConfig` configuration was not present by inheritance.

This is now fixed, so all distributions are properly tested.