### PR TITLE
[MNT] remove deprecated `load_boston` loader from `sklearn`

### DIFF
--- a/examples/custom_model.py
+++ b/examples/custom_model.py
@@ -3,7 +3,7 @@ from random import randint
 
 import numpy as np
 from scipy.stats import norm
-from sklearn.datasets.base import load_boston
+from sklearn.datasets.base import load_diabetes
 from sklearn.model_selection import train_test_split
 
 from skpro.base import ProbabilisticEstimator
@@ -50,7 +50,7 @@ class MyCustomModel(ProbabilisticEstimator):
 # Use custom model
 model = MyCustomModel()
 
-X, y = load_boston(return_X_y=True)
+X, y = load_diabetes(return_X_y=True)
 X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.3)
 y_pred = model.fit(X_train, y_train).predict(X_test)
 print("Loss: %f+-%f" % log_loss(y_test, y_pred, return_std=True))

--- a/examples/parametric/hyperparameters.py
+++ b/examples/parametric/hyperparameters.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # LEGACY MODULE - TODO: remove or refactor
-from sklearn.datasets.base import load_boston
+from sklearn.datasets.base import load_diabetes
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.model_selection import GridSearchCV
 
@@ -14,7 +14,7 @@ parameters = {"point__max_depth": [None, 5, 10, 15]}
 clf = GridSearchCV(model, parameters)
 
 # Optimize hyperparameters
-X, y = load_boston(return_X_y=True)
+X, y = load_diabetes(return_X_y=True)
 clf.fit(X, y)
 
 print("Best score is %f for parameter: %s" % (clf.best_score_, clf.best_params_))

--- a/examples/parametric/simple.py
+++ b/examples/parametric/simple.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # LEGACY MODULE - TODO: remove or refactor
-from sklearn.datasets.base import load_boston
+from sklearn.datasets.base import load_diabetes
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.model_selection import train_test_split
 
@@ -14,7 +14,7 @@ model = ParametricEstimator(
 )
 
 # Train and predict on boston housing data
-X, y = load_boston(return_X_y=True)
+X, y = load_diabetes(return_X_y=True)
 X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.3)
 y_pred = model.fit(X_train, y_train).predict(X_test)
 

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-from sklearn.datasets.base import load_boston
+from sklearn.datasets.base import load_diabetes
 from sklearn.model_selection import train_test_split
 
 from skpro.baselines import DensityBaseline
 from skpro.metrics import log_loss
 
 # Load boston housing data
-X, y = load_boston(return_X_y=True)
+X, y = load_diabetes(return_X_y=True)
 X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.3)
 
 # Train and predict on boston housing data using a baseline model

--- a/skpro/workflow/manager/data.py
+++ b/skpro/workflow/manager/data.py
@@ -6,7 +6,7 @@ import os
 import urllib.request
 
 import numpy as np
-from sklearn.datasets import load_boston, load_diabetes
+from sklearn.datasets import load_diabetes, load_diabetes
 from sklearn.model_selection import train_test_split
 
 
@@ -70,7 +70,7 @@ class DataManager:
             # autoload sklearn datasets, urls and files
             name = X
             if name.lower() == "boston":
-                X, y = load_boston(return_X_y=True)
+                X, y = load_diabetes(return_X_y=True)
             elif name.lower() == "diabetes":
                 X, y = load_diabetes(return_X_y=True)
             elif name.startswith("http"):

--- a/skpro/workflow/manager/data.py
+++ b/skpro/workflow/manager/data.py
@@ -6,7 +6,7 @@ import os
 import urllib.request
 
 import numpy as np
-from sklearn.datasets import load_diabetes, load_diabetes
+from sklearn.datasets import load_diabetes
 from sklearn.model_selection import train_test_split
 
 


### PR DESCRIPTION
This PR removes imports of deprecated `load_boston` loader from `sklearn` from the legacy modules. This is required to upgrade `sklearn` to 1.2.0 or higher.