### PR TITLE
[BUG] fix missing `np.abs` in `ResidualDouble`

### DIFF
--- a/skpro/regression/residual.py
+++ b/skpro/regression/residual.py
@@ -4,6 +4,7 @@
 
 __author__ = ["fkiraly"]
 
+import numpy as np
 import pandas as pd
 from sklearn import clone
 
@@ -104,7 +105,7 @@ class ResidualDouble(BaseProbaRegressor):
         y = y.values.flatten()
 
         est.fit(X, y)
-        resids = y - est.predict(X)
+        resids = np.abs(y - est.predict(X))
 
         resids = resids.flatten()
 


### PR DESCRIPTION
This PR fixes an unreported bug, a missing `np.abs` in `ResidualDouble`.

Acknowledging that the estimator does not have all its features migrated yet, but the abs operator was missing.

Tests did not catch this as this would just result in bad predictions.