### PR TITLE
[DOC] replace leftover `sktime` references in docstrings and utilities with `skpro`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
 
-      - name: Install sktime and dependencies
+      - name: Install skpro and dependencies
         run: |
           python -m pip install .[dev] --no-cache-dir
 
@@ -114,7 +114,7 @@ jobs:
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
 
-      - name: Install sktime and dependencies
+      - name: Install skpro and dependencies
         run: |
           python -m pip install .[all_extras,dev] --no-cache-dir
 

--- a/extension_templates/regression.py
+++ b/extension_templates/regression.py
@@ -2,7 +2,7 @@
 """Extension template for regressors."""
 # todo: write an informative docstring for the file or module, remove the above
 # todo: add an appropriate copyright notice for your estimator
-#       estimators contributed to sktime should have the copyright notice at the top
+#       estimators contributed to skpro should have the copyright notice at the top
 #       estimators of your own do not need to have permissive or BSD-3 copyright
 
 # todo: uncomment the following line, enter authors' GitHub IDs
@@ -12,7 +12,7 @@ from skpro.regression.base import BaseProbaRegressor
 
 # todo: add any necessary imports here
 
-# todo: if any imports are sktime soft dependencies:
+# todo: if any imports are skpro soft dependencies:
 # make sure to fill in the "python_dependencies" tag with the package import name
 
 
@@ -179,7 +179,7 @@ class ClassName(BaseProbaRegressor):
         #
         # this can, if required, use:
         #   class properties (e.g., inherited); parent class test case
-        #   imported objects such as estimators from sktime or sklearn
+        #   imported objects such as estimators from skpro or sklearn
         # important: all such imports should be *inside get_test_params*, not at the top
         #            since imports are used only at testing time
         #

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ addopts =
     --doctest-modules
     --durations 10
     --timeout 600
-    --cov sktime
+    --cov skpro
     --cov-report xml
     --cov-report html
     --showlocals
@@ -30,7 +30,7 @@ ignore = E121, E123, E126, E226, E24, E704, W503, W504
 # inline with Black code formatter
 max-line-length = 88
 exclude =
-    sktime/_contrib/*
+    skpro/_contrib/*
 extend-ignore =
     # See https://github.com/PyCQA/pycodestyle/issues/373
     E203

--- a/skpro/base/__init__.py
+++ b/skpro/base/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Base module with base classes BaseObject, BaseEstimator."""
-# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 
 __all__ = ["BaseEstimator", "BaseMetaEstimator", "BaseObject"]
 

--- a/skpro/benchmarking/evaluate.py
+++ b/skpro/benchmarking/evaluate.py
@@ -71,14 +71,14 @@ def evaluate(
     Parameters
     ----------
     estimator : skpro BaseProbaRegressor descendant (concrete estimator)
-        sktime estimator to benchmark
+        skpro estimator to benchmark
     cv : sklearn splitter
         determines split of ``X`` and ``y`` into test and train folds
     X : pandas DataFrame
         Feature instances to use in evaluation experiment
     y : pd.DataFrame, must be same length as X
         Labels to used in the evaluation experiment
-    scoring : subclass of sktime.performance_metrics.BaseMetric or list of same,
+    scoring : subclass of skpro.performance_metrics.BaseMetric or list of same,
         default=None. Used to get a score function that takes y_pred and y_test
         arguments and accept y_train as keyword argument.
         If None, then uses scoring = MeanAbsolutePercentageError(symmetric=True).

--- a/skpro/datatypes/_check.py
+++ b/skpro/datatypes/_check.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Machine type checkers for scitypes.
 
 Exports

--- a/skpro/datatypes/_common.py
+++ b/skpro/datatypes/_common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Common private utilities for checkers and converters."""
 
 __author__ = ["fkiraly"]

--- a/skpro/datatypes/_convert.py
+++ b/skpro/datatypes/_convert.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Machine type converters for scitypes.
 
 Exports

--- a/skpro/datatypes/_examples.py
+++ b/skpro/datatypes/_examples.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Example fixtures for mtypes/scitypes.
 
 Exports

--- a/skpro/datatypes/_registry.py
+++ b/skpro/datatypes/_registry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Registry of mtypes and scitypes.
 
 Note for extenders: new mtypes for an existing scitypes
@@ -13,7 +13,7 @@ This module exports the following:
 SCITYPE_REGISTER - list of tuples
 
 each tuple corresponds to an mtype tag, elements as follows:
-    0 : string - name of the scitype as used throughout sktime and in datatypes
+    0 : string - name of the scitype as used throughout skpro and in datatypes
     1 : string - plain English description of the scitype
 
 ---
@@ -21,7 +21,7 @@ each tuple corresponds to an mtype tag, elements as follows:
 MTYPE_REGISTER - list of tuples
 
 each tuple corresponds to an mtype, elements as follows:
-    0 : string - name of the mtype as used throughout sktime and in datatypes
+    0 : string - name of the mtype as used throughout skpro and in datatypes
     1 : string - name of the scitype the mtype is for, must be in SCITYPE_REGISTER
     2 : string - plain English description of the scitype
 

--- a/skpro/distributions/base.py
+++ b/skpro/distributions/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Base classes for probability distribution objects."""
 
 __author__ = ["fkiraly"]

--- a/skpro/distributions/empirical.py
+++ b/skpro/distributions/empirical.py
@@ -11,7 +11,7 @@ from skpro.distributions.base import BaseDistribution
 
 
 class Empirical(BaseDistribution):
-    """Empirical distribution (sktime native).
+    """Empirical distribution (skpro native).
 
     Parameters
     ----------

--- a/skpro/distributions/normal.py
+++ b/skpro/distributions/normal.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Normal/Gaussian probability distribution."""
 
 __author__ = ["fkiraly"]
@@ -12,7 +12,7 @@ from skpro.distributions.base import BaseDistribution
 
 
 class Normal(BaseDistribution):
-    """Normal distribution (sktime native).
+    """Normal distribution (skpro native).
 
     Parameters
     ----------

--- a/skpro/distributions/tests/__init__.py
+++ b/skpro/distributions/tests/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-"""Tests for sktime probability distribution objects."""
+"""Tests for skpro probability distribution objects."""

--- a/skpro/distributions/tests/test_all_distrs.py
+++ b/skpro/distributions/tests/test_all_distrs.py
@@ -59,7 +59,7 @@ METHODS_ROWWISE = ["energy"]  # results in one column
 
 
 class TestAllDistributions(PackageConfig, DistributionFixtureGenerator, QuickTester):
-    """Module level tests for all sktime parameter fitters."""
+    """Module level tests for all skpro parameter fitters."""
 
     @pytest.mark.parametrize("shuffled", [False, True])
     def test_sample(self, object_instance, shuffled):

--- a/skpro/metrics/_coerce.py
+++ b/skpro/metrics/_coerce.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Output coercion utilities for metric classes."""
-# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 # adapted from sktime
 
 import pandas as pd

--- a/skpro/metrics/base.py
+++ b/skpro/metrics/base.py
@@ -18,7 +18,7 @@ __author__ = ["fkiraly", "euanenticott-shell"]
 
 
 class BaseProbaMetric(BaseObject):
-    """Base class for probabilistic supervised error metrics in sktime.
+    """Base class for probabilistic supervised error metrics in skpro.
 
     Parameters
     ----------
@@ -423,7 +423,7 @@ class BaseDistrMetric(BaseProbaMetric):
         y_true : pd.Series, pd.DataFrame, 1D np.array, or 2D np.ndarray
             Ground truth (correct) target values.
 
-        y_pred : sktime BaseDistribution of same shape as y_true
+        y_pred : skpro BaseDistribution of same shape as y_true
             Predictive distribution.
             Must have same index and columns as y_true.
         """

--- a/skpro/registry/_lookup.py
+++ b/skpro/registry/_lookup.py
@@ -206,7 +206,7 @@ def _get_return_tags(object, return_tags):
 
     Parameters
     ----------
-    object:  Baseobject, an sktime object
+    object: BaseObject, an skpro object
     return_tags: list of str,
         names of tags to get values for the object
 
@@ -224,7 +224,7 @@ def _check_tag_cond(object, filter_tags=None, as_dataframe=True):
 
     Parameters
     ----------
-    object: Baseobject, an sktime object
+    object: BaseObject, an skpro object
     filter_tags: dict of (str or list of str), default=None
         subsets the returned objects as follows:
             each key/value pair is statement in "and"/conjunction
@@ -257,7 +257,7 @@ def all_tags(
     object_types=None,
     as_dataframe=False,
 ):
-    """Get a list of all tags from sktime.
+    """Get a list of all tags from skpro.
 
     Retrieves tags directly from `_tags`, offers filtering functionality.
 

--- a/skpro/utils/_maint/_show_versions.py
+++ b/skpro/utils/_maint/_show_versions.py
@@ -59,7 +59,7 @@ def _get_deps_info(deps=None):
     Parameters
     ----------
     deps : optional, list of strings with import names
-        if None, behaves as deps = ["sktime"]
+        if None, behaves as deps = ["skpro"]
 
     Returns
     -------
@@ -69,7 +69,7 @@ def _get_deps_info(deps=None):
         of the import as present in the current python environment
     """
     if deps is None:
-        deps = ["sktime"]
+        deps = ["skpro"]
 
     def get_version(module):
         return module.__version__
@@ -91,7 +91,7 @@ def _get_deps_info(deps=None):
 
 
 def show_versions():
-    """Print python version, OS version, sktime version, selected dependency versions.
+    """Print python version, OS version, skpro version, selected dependency versions.
 
     Pretty prints:
 

--- a/skpro/utils/_maint/tests/test_show_versions.py
+++ b/skpro/utils/_maint/tests/test_show_versions.py
@@ -19,7 +19,7 @@ def test_deps_info():
     """Test that _get_deps_info returns package/version dict as per contract."""
     deps_info = _get_deps_info()
     assert isinstance(deps_info, dict)
-    assert set(deps_info.keys()) == set(["sktime"])
+    assert set(deps_info.keys()) == set(["skpro"])
 
     deps_info_default = _get_deps_info(DEFAULT_DEPS_TO_SHOW)
     assert isinstance(deps_info_default, dict)

--- a/skpro/utils/validation/_dependencies.py
+++ b/skpro/utils/validation/_dependencies.py
@@ -122,20 +122,20 @@ def _check_soft_dependencies(
             if obj is None:
                 msg = (
                     f"{e}. '{package}' is a soft dependency and not included in the "
-                    f"base sktime installation. Please run: `pip install {package}` to "
+                    f"base skpro installation. Please run: `pip install {package}` to "
                     f"install the {package} package. "
                     f"To install all soft dependencies, run: `pip install "
-                    f"sktime[all_extras]`"
+                    f"skpro[all_extras]`"
                 )
             else:
                 msg = (
                     f"{class_name} requires package '{package}' to be present "
                     f"in the python environment, but '{package}' was not found. "
                     f"'{package}' is a soft dependency and not included in the base "
-                    f"sktime installation. Please run: `pip install {package}` to "
+                    f"skpro installation. Please run: `pip install {package}` to "
                     f"install the {package} package. "
                     f"To install all soft dependencies, run: `pip install "
-                    f"sktime[all_extras]`"
+                    f"skpro[all_extras]`"
                 )
             if severity == "error":
                 raise ModuleNotFoundError(msg) from e
@@ -162,7 +162,7 @@ def _check_soft_dependencies(
             )
             if obj is not None:
                 msg = msg + (
-                    f"This version requirement is not one by sktime, but specific "
+                    f"This version requirement is not one by skpro, but specific "
                     f"to the module, class or object with name {obj}."
                 )
 
@@ -190,7 +190,7 @@ def _check_python_version(obj, package=None, msg=None, severity="error"):
 
     Parameters
     ----------
-    obj : sktime estimator, BaseObject descendant
+    obj : skpro estimator, BaseObject descendant
         used to check python version
     package : str, default = None
         if given, will be used in error message as package name
@@ -268,7 +268,7 @@ def _check_estimator_deps(obj, msg=None, severity="error"):
 
     Parameters
     ----------
-    obj : `sktime` object, `BaseObject` descendant, or list/tuple thereof
+    obj : `skpro` object, `BaseObject` descendant, or list/tuple thereof
         object(s) that this function checks compatibility of, with the python env
     msg : str, optional, default = default message (msg below)
         error message to be returned in the `ModuleNotFoundError`, overrides default


### PR DESCRIPTION
This PR replaces some erroneous references to `sktime` with `skpro`:

* docstring references to classes
* copyright - this should be accompanied with a credit to `sktime` in prominent locations, or where copy-paste has taken place
* `show_versions` utility
* code coverage target

The rst documentation is untouched for now, this will be a later effort.