### PR TITLE
[ENH] residual double regressor - feature complete implementation

### DIFF
--- a/skpro/regression/residual.py
+++ b/skpro/regression/residual.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Residual regression - one regressor for mean, one for scale."""
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 
@@ -132,7 +131,6 @@ class ResidualDouble(BaseProbaRegressor):
         cv=None,
         min_scale=1e-10,
     ):
-
         self.estimator = estimator
         self.estimator_resid = estimator_resid
         self.residual_trafo = residual_trafo
@@ -143,7 +141,7 @@ class ResidualDouble(BaseProbaRegressor):
         self.cv = cv
         self.min_scale = min_scale
 
-        super(ResidualDouble, self).__init__()
+        super().__init__()
 
         self.estimator_ = clone(estimator)
 
@@ -333,7 +331,8 @@ class ResidualDouble(BaseProbaRegressor):
         params.update(ix)
         # location and scale
         loc_scale = {
-            distr_loc_scale_name[0]: y_pred_loc, distr_loc_scale_name[1]: y_pred_scale
+            distr_loc_scale_name[0]: y_pred_loc,
+            distr_loc_scale_name[1]: y_pred_scale,
         }
         params.update(loc_scale)
 

--- a/skpro/regression/residual.py
+++ b/skpro/regression/residual.py
@@ -318,12 +318,12 @@ class ResidualDouble(BaseProbaRegressor):
             from skpro.distributions.laplace import Laplace
 
             distr_type = Laplace
-            distr_loc_scale_name = ("mean", "scale")
+            distr_loc_scale_name = ("mu", "scale")
         elif distr_type in ["Cauchy", "t"]:
             from skpro.distributions.t import TDistribution
 
             distr_type = TDistribution
-            distr_loc_scale_name = ("mean", "sd")
+            distr_loc_scale_name = ("mu", "sigma")
 
         # collate all parameters for the distribution constructor
         # distribution params, if passed

--- a/skpro/regression/residual.py
+++ b/skpro/regression/residual.py
@@ -225,7 +225,8 @@ class ResidualDouble(BaseProbaRegressor):
         resids = resids.flatten()
 
         if use_y_pred:
-            X_r = pd.concat([X, y_pred], axis=1)
+            y_ix = {"index": X.index, "columns": self._y_cols}
+            X_r = pd.concat([X, pd.DataFrame(y_pred, **y_ix)], axis=1)
         else:
             X_r = X
 
@@ -296,7 +297,8 @@ class ResidualDouble(BaseProbaRegressor):
         # predict scale
         # if use_y_pred, use predicted location as feature
         if use_y_pred:
-            X_r = pd.concat([X, y_pred_loc], axis=1)
+            y_ix = {"index": X.index, "columns": self._y_cols}
+            X_r = pd.concat([X, pd.DataFrame(y_pred_loc, **y_ix)], axis=1)
         # if not use_y_pred, use only original features
         else:
             X_r = X

--- a/skpro/regression/residual.py
+++ b/skpro/regression/residual.py
@@ -75,7 +75,6 @@ class ResidualDouble(BaseProbaRegressor):
     distr_type : str or BaseDistribution, default = "Normal"
         type of distribution to predict
         str options are "Normal", "Laplace", "Cauchy", "t"
-        if BaseDistribution, must be a subclass of skpro.base.BaseDistribution
     distr_loc_scale_name : tuple of length two, default = ("loc", "scale")
         names of the parameters in the distribution to use for location and scale
         if ``distr_type`` is a string, this is overridden to the correct parameters

--- a/skpro/regression/residual.py
+++ b/skpro/regression/residual.py
@@ -21,14 +21,11 @@ class ResidualDouble(BaseProbaRegressor):
 
     Parameters
     ----------
-    estimator : skpro estimator, BaseProbaRegressor descendant
+    estimator : sklearn regressor
         estimator predicting the mean or location
-    estimator_resid : skpro estimator, BaseProbaRegressor descendant, optional
+    estimator_resid : sklearn regressor
         estimator predicting the scale of the residual
         default = sklearn DummyRegressor(strategy="mean")
-
-    TODO - add
-    estimator_resid : skpro estimator or dict of estimators with str keys
     residual_trafo : str, or transformer, default="absolute"
         determines the labels predicted by ``estimator_resid``
         absolute = absolute residuals
@@ -42,7 +39,8 @@ class ResidualDouble(BaseProbaRegressor):
         if passed, will be used to obtain out-of-sample residuals according to cv
         instead of in-sample residuals in ``fit`` of this estimator
     min_scale : float, default=1e-10
-        minimum scale parameter if ``estimator_resid`` is an estimator (not dict)
+        minimum scale parameter. If smaller scale parameter is predicted by
+        ``estimator_resid``, will be clipped to this value
 
     Example
     -------


### PR DESCRIPTION
This completes the implementation of `ResidualDouble`, in parts relying on the set of distributions implemented now - in parts, thanks to @Alex-JG3! 

The functionality is now on par with the `skpro` version 1 features and upgraded to the new interface.
A comprehensive docstring with a formal summary of the algorithm has also been added.