### PR TITLE
[ENH] enable default for `predict` in probabilistic regressors if only interval predictions are possible

### DIFF
--- a/skpro/regression/base/_base.py
+++ b/skpro/regression/base/_base.py
@@ -140,11 +140,9 @@ class BaseProbaRegressor(BaseEstimator):
         """
         implements_interval = self._has_implementation_of("_predict_interval")
         implements_quantiles = self._has_implementation_of("_predict_quantiles")
-        implements_var = self._has_implementation_of("_predict_var")
         implements_proba = self._has_implementation_of("_predict_proba")
 
-        can_do_proba = implements_interval or implements_quantiles or implements_var
-        can_do_proba = can_do_proba or implements_proba
+        can_do_proba = implements_interval or implements_quantiles or implements_proba
 
         if not can_do_proba:
             raise NotImplementedError

--- a/skpro/regression/base/_base.py
+++ b/skpro/regression/base/_base.py
@@ -138,15 +138,20 @@ class BaseProbaRegressor(BaseEstimator):
         y : pandas DataFrame, same length as `X`
             labels predicted for `X`
         """
+        implements_interval = self._has_implementation_of("_predict_interval")
+        implements_quantiles = self._has_implementation_of("_predict_quantiles")
+        implements_var = self._has_implementation_of("_predict_var")
         implements_proba = self._has_implementation_of("_predict_proba")
 
-        if not implements_proba:
+        can_do_proba = implements_interval or implements_quantiles or implements_var
+        can_do_proba = can_do_proba or implements_proba
+
+        if not can_do_proba:
             raise NotImplementedError
 
-        if implements_proba:
-            pred_proba = self._predict_proba(X=X)
-            pred_mean = pred_proba.mean()
-            return pred_mean
+        pred_proba = self._predict_proba(X=X)
+        pred_mean = pred_proba.mean()
+        return pred_mean
 
     def predict_proba(self, X):
         """Predict distribution over labels for data from features.


### PR DESCRIPTION
This adds a default for `predict` if only interval/quantile predictions are possible, but not full distribution predictions.