### PR TITLE
[BUG] fix `test_plot_crossplot_interval` for interval predictions

### DIFF
--- a/skpro/utils/plotting.py
+++ b/skpro/utils/plotting.py
@@ -59,7 +59,7 @@ def plot_crossplot_interval(y_true, y_pred, coverage=None, ax=None):
 
     from matplotlib import pyplot
 
-    if hasattr(y_pred, "quantile"):
+    if hasattr(y_pred, "quantile") and not isinstance(y_pred, pd.DataFrame):
         if coverage is None:
             coverage = 0.9
         quantile_pts = [0.5 - coverage / 2, 0.5, 0.5 + coverage / 2]

--- a/skpro/utils/tests/test_plots.py
+++ b/skpro/utils/tests/test_plots.py
@@ -27,9 +27,13 @@ def test_plot_crossplot_interval():
     reg_proba = ResidualDouble(reg_mean, reg_resid)
 
     reg_proba.fit(X, y)
-    y_pred = reg_proba.predict_proba(X)
+    y_pred_proba = reg_proba.predict_proba(X)
 
-    plot_crossplot_interval(y, y_pred)
+    plot_crossplot_interval(y, y_pred_proba, coverage=0.8)
+    plot_crossplot_interval(y, y_pred_proba)
+
+    y_pred_interval = reg_proba.predict_interval(X, coverage=0.7)
+    plot_crossplot_interval(y, y_pred_interval)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
This PR fixes an unreported bug with `test_plot_crossplot_interval` - it would fail for interval predictions as internally the input would be incorrectly identified as a distribution - as the check checks whether a `quantiles` method is present, and `DataFrame`-s have this too, not just distributions.

This is rectified by an explicit type check.

Tests for the input case are also added.