### PR TITLE
[BUG] add forgotten `__init__` export of `SquaredDistrLoss`

### DIFF
--- a/skpro/metrics/__init__.py
+++ b/skpro/metrics/__init__.py
@@ -10,6 +10,7 @@ __all__ = [
     "ConstraintViolation",
     "CRPS",
     "LogLoss",
+    "SquaredDistrLoss",
 ]
 
 from skpro.metrics._classes import (
@@ -18,4 +19,5 @@ from skpro.metrics._classes import (
     EmpiricalCoverage,
     LogLoss,
     PinballLoss,
+    SquaredDistrLoss,
 )


### PR DESCRIPTION
This PR adds a forgotten `__init__` export of `SquaredDistrLoss` - due ot this, previously, the metric was neither accessible to the registry, nor tested.