### PR TITLE
[BUG] in `ResidualDouble`, fix out-of-sample residual prediction if residual estimator is default

### DIFF
--- a/skpro/regression/residual.py
+++ b/skpro/regression/residual.py
@@ -169,7 +169,7 @@ class ResidualDouble(BaseProbaRegressor):
         y_pred : pandas DataFrame, same length as `X`, same columns as `y` in `fit`
             labels predicted for `X`
         """
-        est = self.estimator_resid
+        est = self.estimator_resid_
         method = "predict"
         y_pred = y.copy()
 
@@ -382,5 +382,6 @@ class ResidualDouble(BaseProbaRegressor):
             "distr_params": {"df": 3},
             "cv": KFold(n_splits=3),
         }
+        params4 = {"estimator": RandomForestRegressor(), "cv": KFold(n_splits=3)}
 
-        return [params1, params2, params3]
+        return [params1, params2, params3, params4]


### PR DESCRIPTION
This fixes an unreported bug in `ResidualDouble` where `fit` would break if the default residual estimator is used.

This was due to the non-underscore parameter being referenced instead of the underscored one.