### PR TITLE
[BUG] fix `plot_crossplot_std` for `predict_var` return

### DIFF
--- a/skpro/utils/plotting.py
+++ b/skpro/utils/plotting.py
@@ -141,8 +141,10 @@ def plot_crossplot_std(y_true, y_pred, ax=None):
 
     from matplotlib import pyplot
 
-    if hasattr(y_pred, "_tags"):
+    if hasattr(y_pred, "_tags") and not isinstance(y_pred, pd.DataFrame):
         y_var = y_pred.var()
+    else:
+        y_var = y_pred
 
     y_std = np.sqrt(y_var)
 

--- a/skpro/utils/tests/test_plots.py
+++ b/skpro/utils/tests/test_plots.py
@@ -61,6 +61,9 @@ def test_plot_crossplot_std():
 
     plot_crossplot_std(y, y_pred)
 
+    y_pred_var = reg_proba.predict_var(X)
+    plot_crossplot_std(y, y_pred_var)
+
 
 @pytest.mark.skipif(
     not _check_soft_dependencies("matplotlib", severity="none"),


### PR DESCRIPTION
This PR fixes an unreported bug where `plot_crossplot_std` would crash for for a `predict_var` return (as opposed to a full distributional prediction).

This is fixed, and a test is added.