### PR TITLE
[BUG] fix subsetting of empirical distribution if no row subsetting takes place

### DIFF
--- a/skpro/distributions/empirical.py
+++ b/skpro/distributions/empirical.py
@@ -145,6 +145,7 @@ class Empirical(BaseDistribution):
             subs_rowidx = index[rowidx]
         else:
             subs_rowidx = index
+            weights_subset = weights
 
         if colidx is not None:
             spl_subset = spl_subset.iloc[:, colidx]


### PR DESCRIPTION
This fixes a bug in the empirical distribution's subsetting routine if no row subsetting takes place, but column subsetting does.

In this case, the variable `weights_subset` would not be set but is referenced later.

Not sure why the tests didn't catch this, the subsetting test should test this case.