### PR TITLE
[BUG] avoid `numpy` strangeness in `energy` calculation in `Empirical`

### DIFF
--- a/skpro/distributions/empirical.py
+++ b/skpro/distributions/empirical.py
@@ -367,7 +367,7 @@ def _energy_np(spl, x=None, weights=None, assume_sorted=False):
 
     if x is None:
         cum_fwd = np.cumsum(weights[:-1])
-        cum_back = np.cumsum(weights[1::-1])[::-1]
+        cum_back = np.cumsum(weights[1:][::-1])[::-1]
         energy = 2 * np.sum(cum_fwd * cum_back * spl_diff)
     else:
         spl_diff = np.abs(spl - x)


### PR DESCRIPTION
Sometimes the `Empirical` `energy` calculation crashes, the reason as it seems is that `numpy` sometimes interprets `array[1::-1]` as returning `array[1], array[0]` rather than `array[-1], array[-2], .., array[1]` which is really odd, either way, this is now replaced by safer syntax.