### PR TITLE
[ENH] pass targets to `sklearn` as 1D and not 2D if univariate column vector

### DIFF
--- a/skpro/regression/bootstrap.py
+++ b/skpro/regression/bootstrap.py
@@ -9,6 +9,7 @@ from sklearn import clone
 
 from skpro.distributions.empirical import Empirical
 from skpro.regression.base import BaseProbaRegressor
+from skpro.utils.numpy import flatten_to_1D_if_colvector
 
 
 class BootstrapRegressor(BaseProbaRegressor):
@@ -120,8 +121,7 @@ class BootstrapRegressor(BaseProbaRegressor):
             Xi = Xi.reset_index(drop=True)
 
             yi = y.loc[inst_ix_i].values
-            if len(yi.shape) > 1 and yi.shape[1] == 1:
-                yi = yi.flatten()
+            yi = flatten_to_1D_if_colvector(yi)
 
             self.estimators_ += [esti.fit(Xi, yi)]
 

--- a/skpro/regression/bootstrap.py
+++ b/skpro/regression/bootstrap.py
@@ -119,7 +119,7 @@ class BootstrapRegressor(BaseProbaRegressor):
             Xi = X.loc[inst_ix_i]
             Xi = Xi.reset_index(drop=True)
 
-            yi = y.loc[inst_ix_i].reset_index(drop=True)
+            yi = y.loc[inst_ix_i].values.flatten()
 
             self.estimators_ += [esti.fit(Xi, yi)]
 

--- a/skpro/regression/bootstrap.py
+++ b/skpro/regression/bootstrap.py
@@ -119,7 +119,9 @@ class BootstrapRegressor(BaseProbaRegressor):
             Xi = X.loc[inst_ix_i]
             Xi = Xi.reset_index(drop=True)
 
-            yi = y.loc[inst_ix_i].values.flatten()
+            yi = y.loc[inst_ix_i].values
+            if len(yi.shape) > 1 and yi.shape[1] == 1:
+                yi = yi.flatten()
 
             self.estimators_ += [esti.fit(Xi, yi)]
 

--- a/skpro/regression/residual.py
+++ b/skpro/regression/residual.py
@@ -8,6 +8,7 @@ import pandas as pd
 from sklearn import clone
 
 from skpro.regression.base import BaseProbaRegressor
+from skpro.utils.numpy import flatten_to_1D_if_colvector
 
 
 class ResidualDouble(BaseProbaRegressor):
@@ -206,7 +207,10 @@ class ResidualDouble(BaseProbaRegressor):
         use_y_pred = self.use_y_pred
 
         self._y_cols = y.columns
-        y = y.values.flatten()
+        y = y.values
+
+        # flatten column vector to 1D array to avoid sklearn complaints
+        y = flatten_to_1D_if_colvector(y)
 
         est.fit(X, y)
 
@@ -222,7 +226,7 @@ class ResidualDouble(BaseProbaRegressor):
         else:
             resids = residual_trafo.fit_transform(y - y_pred)
 
-        resids = resids.flatten()
+        resids = flatten_to_1D_if_colvector(resids)
 
         if use_y_pred:
             y_ix = {"index": X.index, "columns": self._y_cols}
@@ -287,12 +291,14 @@ class ResidualDouble(BaseProbaRegressor):
         distr_params = self.distr_params
         min_scale = self.min_scale
 
+        n_cols = len(self._y_cols)
+
         if distr_params is None:
             distr_params = {}
 
         # predict location - this is the same as in _predict
         y_pred_loc = est.predict(X)
-        y_pred_loc = y_pred_loc.reshape(-1, 1)
+        y_pred_loc = y_pred_loc.reshape(-1, n_cols)
 
         # predict scale
         # if use_y_pred, use predicted location as feature
@@ -305,7 +311,7 @@ class ResidualDouble(BaseProbaRegressor):
 
         y_pred_scale = est_r.predict(X_r)
         y_pred_scale = y_pred_scale.clip(min=min_scale)
-        y_pred_scale = y_pred_scale.reshape(-1, 1)
+        y_pred_scale = y_pred_scale.reshape(-1, n_cols)
 
         # create distribution with predicted scale and location
         # we deal with string distr_types by getting class and param names

--- a/skpro/utils/numpy.py
+++ b/skpro/utils/numpy.py
@@ -1,0 +1,25 @@
+"""Utility functions for numpy/sklearn related matters."""
+
+__authors__ = ["fkiraly"]
+
+
+def flatten_to_1D_if_colvector(y):
+    """Flattens a numpy array to 1D if it is a 2D column vector.
+
+    Parameters
+    ----------
+    y : numpy array, 1D or 2D
+        Array to flatten
+
+    Returns
+    -------
+    y_flat : numpy array
+        1D flattened array if y was 2D column vector, or 1D already
+        otherwise, returne y unchanged
+    """
+    if len(y.shape) == 2 and y.shape[1] == 1:
+        y_flat = y.flatten()
+    else:
+        y_flat = y
+
+    return y_flat


### PR DESCRIPTION
`sklearn` estimators wrapped in `BootstrapRegressor` or `ResidualDouble` complain if uni-output target variables are passed as 2D column array, not 1D.

In order to still allow multioutput regressors but avoid the warning, this PR introduces a utility and applies it to flatten uni-output 2D arrays (column vectors) to 1D, but leave multivariate 2D arrays untouched.