### PR TITLE
[MNT] various deprecation fixes

### DIFF
--- a/skpro/datatypes/_proba/_registry.py
+++ b/skpro/datatypes/_proba/_registry.py
@@ -1,4 +1,7 @@
-# -*- coding: utf-8 -*-
+"""Registry of mtypes for Proba scitype.
+
+See datatypes._registry for API.
+"""
 
 import pandas as pd
 

--- a/skpro/datatypes/_registry.py
+++ b/skpro/datatypes/_registry.py
@@ -1,4 +1,5 @@
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+# based on sktime datatypes registry
 """Registry of mtypes and scitypes.
 
 Note for extenders: new mtypes for an existing scitypes

--- a/skpro/datatypes/_table/_registry.py
+++ b/skpro/datatypes/_table/_registry.py
@@ -1,4 +1,7 @@
-# -*- coding: utf-8 -*-
+"""Registry of mtypes for Table scitype.
+
+See datatypes._registry for API.
+"""
 
 import pandas as pd
 

--- a/skpro/distributions/base.py
+++ b/skpro/distributions/base.py
@@ -269,7 +269,11 @@ class BaseDistribution(BaseObject):
             )
             warn(self._method_error_msg("log_pdf", fill_in=approx_method))
 
-            return self.pdf(x=x).map(np.log)
+            pdf_res = self.pdf(x=x)
+            if hasattr(pdf_res, "map"):
+                return pdf_res.map(np.log)
+            else:
+                return pdf_res.applymap(np.log)
 
         raise NotImplementedError(self._method_error_msg("log_pdf", "error"))
 

--- a/skpro/distributions/base.py
+++ b/skpro/distributions/base.py
@@ -270,6 +270,8 @@ class BaseDistribution(BaseObject):
             warn(self._method_error_msg("log_pdf", fill_in=approx_method))
 
             pdf_res = self.pdf(x=x)
+            # safe deprecation of applymap, renamed to map in pandas 2 versions
+            # this if/else ensures compatibility with a wider range of pandas versions
             if hasattr(pdf_res, "map"):
                 return pdf_res.map(np.log)
             else:

--- a/skpro/distributions/base.py
+++ b/skpro/distributions/base.py
@@ -269,7 +269,7 @@ class BaseDistribution(BaseObject):
             )
             warn(self._method_error_msg("log_pdf", fill_in=approx_method))
 
-            return self.pdf(x=x).applymap(np.log)
+            return self.pdf(x=x).map(np.log)
 
         raise NotImplementedError(self._method_error_msg("log_pdf", "error"))
 

--- a/skpro/distributions/mixture.py
+++ b/skpro/distributions/mixture.py
@@ -134,7 +134,7 @@ class Mixture(BaseMetaObject, BaseDistribution):
         n_df = len(df_list)
         df_weighted = [df * w for df, w in zip(df_list, weights)]
         df_concat = pd.concat(df_weighted, axis=1, keys=range(n_df))
-        df_res = df_concat.groupby(level=-1, axis=1).sum()
+        df_res = df_concat.T.groupby(level=-1).sum()
         return df_res
 
     def pdf(self, x):

--- a/skpro/distributions/mixture.py
+++ b/skpro/distributions/mixture.py
@@ -134,7 +134,7 @@ class Mixture(BaseMetaObject, BaseDistribution):
         n_df = len(df_list)
         df_weighted = [df * w for df, w in zip(df_list, weights)]
         df_concat = pd.concat(df_weighted, axis=1, keys=range(n_df))
-        df_res = df_concat.T.groupby(level=-1).T.sum()
+        df_res = df_concat.T.groupby(level=-1).sum().T
         return df_res
 
     def pdf(self, x):

--- a/skpro/distributions/mixture.py
+++ b/skpro/distributions/mixture.py
@@ -134,7 +134,7 @@ class Mixture(BaseMetaObject, BaseDistribution):
         n_df = len(df_list)
         df_weighted = [df * w for df, w in zip(df_list, weights)]
         df_concat = pd.concat(df_weighted, axis=1, keys=range(n_df))
-        df_res = df_concat.T.groupby(level=-1).sum()
+        df_res = df_concat.T.groupby(level=-1).T.sum()
         return df_res
 
     def pdf(self, x):

--- a/skpro/metrics/base.py
+++ b/skpro/metrics/base.py
@@ -114,11 +114,11 @@ class BaseProbaMetric(BaseObject):
         out = self._evaluate(y_true_inner, y_pred_inner, **kwargs)
 
         if self.score_average and multioutput == "uniform_average":
-            out = float(out.mean(axis=1))  # average over all
+            out = out.mean(axis=1).iloc[0]  # average over all
         if self.score_average and multioutput == "raw_values":
-            out = out.groupby(axis=1, level=0).mean()  # average over scores
+            out = out.T.groupby(level=0).mean()  # average over scores
         if not self.score_average and multioutput == "uniform_average":
-            out = out.groupby(axis=1, level=1).mean()  # average over variables
+            out = out.T.groupby(level=1).mean()  # average over variables
         if not self.score_average and multioutput == "raw_values":
             out = out  # don't average
 
@@ -202,9 +202,9 @@ class BaseProbaMetric(BaseObject):
         if self.score_average and multioutput == "uniform_average":
             out = out.mean(axis=1)  # average over all
         if self.score_average and multioutput == "raw_values":
-            out = out.groupby(axis=1, level=0).mean()  # average over scores
+            out = out.T.groupby(level=0).mean()  # average over scores
         if not self.score_average and multioutput == "uniform_average":
-            out = out.groupby(axis=1, level=1).mean()  # average over variables
+            out = out.T.groupby(level=1).mean()  # average over variables
         if not self.score_average and multioutput == "raw_values":
             out = out  # don't average
 

--- a/skpro/metrics/base.py
+++ b/skpro/metrics/base.py
@@ -116,9 +116,9 @@ class BaseProbaMetric(BaseObject):
         if self.score_average and multioutput == "uniform_average":
             out = out.mean(axis=1).iloc[0]  # average over all
         if self.score_average and multioutput == "raw_values":
-            out = out.T.groupby(level=0).mean()  # average over scores
+            out = out.T.groupby(level=0).T.mean()  # average over scores
         if not self.score_average and multioutput == "uniform_average":
-            out = out.T.groupby(level=1).mean()  # average over variables
+            out = out.T.groupby(level=1).T.mean()  # average over variables
         if not self.score_average and multioutput == "raw_values":
             out = out  # don't average
 
@@ -202,9 +202,9 @@ class BaseProbaMetric(BaseObject):
         if self.score_average and multioutput == "uniform_average":
             out = out.mean(axis=1)  # average over all
         if self.score_average and multioutput == "raw_values":
-            out = out.T.groupby(level=0).mean()  # average over scores
+            out = out.T.groupby(level=0).T.mean()  # average over scores
         if not self.score_average and multioutput == "uniform_average":
-            out = out.T.groupby(level=1).mean()  # average over variables
+            out = out.T.groupby(level=1).T.mean()  # average over variables
         if not self.score_average and multioutput == "raw_values":
             out = out  # don't average
 

--- a/skpro/metrics/base.py
+++ b/skpro/metrics/base.py
@@ -116,9 +116,9 @@ class BaseProbaMetric(BaseObject):
         if self.score_average and multioutput == "uniform_average":
             out = out.mean(axis=1).iloc[0]  # average over all
         if self.score_average and multioutput == "raw_values":
-            out = out.T.groupby(level=0).T.mean()  # average over scores
+            out = out.T.groupby(level=0).mean().T  # average over scores
         if not self.score_average and multioutput == "uniform_average":
-            out = out.T.groupby(level=1).T.mean()  # average over variables
+            out = out.T.groupby(level=1).mean().T  # average over variables
         if not self.score_average and multioutput == "raw_values":
             out = out  # don't average
 
@@ -202,9 +202,9 @@ class BaseProbaMetric(BaseObject):
         if self.score_average and multioutput == "uniform_average":
             out = out.mean(axis=1)  # average over all
         if self.score_average and multioutput == "raw_values":
-            out = out.T.groupby(level=0).T.mean()  # average over scores
+            out = out.T.groupby(level=0).mean().T  # average over scores
         if not self.score_average and multioutput == "uniform_average":
-            out = out.T.groupby(level=1).T.mean()  # average over variables
+            out = out.T.groupby(level=1).mean().T  # average over variables
         if not self.score_average and multioutput == "raw_values":
             out = out  # don't average
 

--- a/skpro/metrics/metrics.py
+++ b/skpro/metrics/metrics.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import numpy as np
 
 

--- a/skpro/metrics/metrics.py
+++ b/skpro/metrics/metrics.py
@@ -1,4 +1,4 @@
-# LEGACY MODULE - TODO: remove or refactor
+"""LEGACY MODULE - TODO: remove or refactor."""
 import numpy as np
 
 

--- a/skpro/metrics/metrics.py
+++ b/skpro/metrics/metrics.py
@@ -170,7 +170,7 @@ def log_loss(y_true, dist_pred, sample=True, return_std=False):
 
 
 def rank_probability_loss(y_true, dist_pred, sample=True, return_std=False):
-    """Rank probability loss
+    r"""Rank probability loss
 
     .. math::
         L(F,y) = \int_{-\infty}^{y} F(x)^2 dx + \int_{y}^{+\infty} (1-F(x))^2 dx

--- a/skpro/metrics/metrics.py
+++ b/skpro/metrics/metrics.py
@@ -1,8 +1,9 @@
+# LEGACY MODULE - TODO: remove or refactor
 import numpy as np
 
 
 def sample_loss(loss, return_std=False):
-    """Averages the loss of a sample
+    """Averages the loss of a sample.
 
     Parameters
     ----------
@@ -69,7 +70,7 @@ def make_scorer(score_func, greater_is_better=True):
 
 
 def gneiting_loss(y_true, dist_pred, sample=True, return_std=False):
-    """Gneiting loss
+    """Gneiting loss.
 
     Parameters
     ----------
@@ -101,7 +102,7 @@ def gneiting_loss(y_true, dist_pred, sample=True, return_std=False):
 
 
 def linearized_log_loss(y_true, dist_pred, range=1e-10, sample=True, return_std=False):
-    """Linearized log loss
+    """Linearized log loss.
 
     Parameters
     ----------
@@ -140,7 +141,7 @@ def linearized_log_loss(y_true, dist_pred, range=1e-10, sample=True, return_std=
 
 
 def log_loss(y_true, dist_pred, sample=True, return_std=False):
-    """Log loss
+    """Log loss.
 
     Parameters
     ----------
@@ -169,7 +170,7 @@ def log_loss(y_true, dist_pred, sample=True, return_std=False):
 
 
 def rank_probability_loss(y_true, dist_pred, sample=True, return_std=False):
-    r"""Rank probability loss
+    r"""Rank probability loss.
 
     .. math::
         L(F,y) = \int_{-\infty}^{y} F(x)^2 dx + \int_{y}^{+\infty} (1-F(x))^2 dx


### PR DESCRIPTION
This PR addresses various deprecation warnings:

* deprecation of `axis` arg in `pd.DataFrame.groupby`
* deprecation of `float` coercion of single-element `pd.Series`
* deprecation of `pd.DataFrame.applymap` in favour of `map`
* incorrect use of string escape parameters in legacy code
* fixing some linting issues in legacy code