### PR TITLE
[MNT] update `all_extras` dependency set and notebook CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install .[binder,dev]
+          python -m pip install .[all_extras,binder,dev]
       - name: Run example notebooks
         run: build_tools/run_examples.sh
         shell: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,9 @@ dependencies = [
 [project.optional-dependencies]
 all_extras = [
     "attrs",
+    "distfit",
     "matplotlib>=3.3.2",
-    "pymc3; python_version > '3.7'",
+    "ngboost",
     "statsmodels>=0.12.1",
     "tabulate",
     "uncertainties",


### PR DESCRIPTION
This PR conducts minor maintenance on the CI and dependency set.

* unused soft dependencies are removed from `all_extras`. `ngboost` and `distfit` are added in anticipation of estimators based on these.
* it is ensured that `all_extras` are available when testing the tutorial notebooks