### PR TITLE
[ENH public `all_tags` utility

### DIFF
--- a/skpro/registry/__init__.py
+++ b/skpro/registry/__init__.py
@@ -1,6 +1,6 @@
 """Registry and lookup functionality."""
 
-from skpro.registry._lookup import all_objects
+from skpro.registry._lookup import all_objects, all_tags
 from skpro.registry._tags import (
     OBJECT_TAG_LIST,
     OBJECT_TAG_REGISTER,
@@ -11,5 +11,6 @@ __all__ = [
     "OBJECT_TAG_LIST",
     "OBJECT_TAG_REGISTER",
     "all_objects",
+    "all_tags",
     "check_tag_is_valid",
 ]


### PR DESCRIPTION
This PR adds a public export of the `all_tags` utility to the `registry` module.

It already was present and fully functional, but not exported.