### PR TITLE
[MNT] Python 3.12 support - for release 2.1.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         os: [ubuntu-20.04, windows-latest, macOS-11]
     runs-on: ${{ matrix.os }}
     steps:
@@ -107,7 +107,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         os: [ubuntu-20.04, windows-latest, macOS-11]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macOS-11]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.11']
 
     steps:
       - uses: actions/checkout@v3
@@ -83,6 +83,11 @@ jobs:
           - os: windows-2019
             python: 311
             python-version: 3.11
+            bitness: 64
+            platform_id: win_amd64
+          - os: windows-2019
+            python: 312
+            python-version: 3.12
             bitness: 64
             platform_id: win_amd64
 

--- a/docs/source/get_started.rst
+++ b/docs/source/get_started.rst
@@ -13,7 +13,7 @@ Installation
 
 ``skpro`` currently supports:
 
-* environments with python version 3.8, 3.9, 3.10, or 3.11.
+* environments with python version 3.8, 3.9, 3.10, 3.11, or 3.12.
 * operating systems Mac OS X, Unix-like OS, Windows 8.1 and higher
 * installation via ``PyPi`` or ``conda``
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -6,7 +6,7 @@ Installation
 
 ``skpro`` currently supports:
 
-* environments with python version 3.8, 3.9, 3.10 or 3.11
+* environments with python version 3.8, 3.9, 3.10, 3.11, or 3.12
 * operating systems Mac OS X, Unix-like OS, Windows 8.1 and higher
 
 Checkout the full list of pre-compiled wheels on

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,13 +37,14 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
-requires-python = ">=3.8,<3.12"
+requires-python = ">=3.8,<3.13"
 dependencies = [
-    "numpy>=1.21.0,<1.25",
-    "pandas>=1.1.0",
+    "numpy>=1.21.0,<1.27",
+    "pandas>=1.1.0,<2.2.0",
     "packaging",
-    "scikit-base>=0.4.3",
+    "scikit-base>=0.4.3,<0.7.0",
     "scikit-learn>=0.24.0,<1.4.0",
     "scipy<2.0.0,>=1.2.0",
 ]


### PR DESCRIPTION
This PR introduces a version bump for the python 3.12 release:

* 3.12 allowed in `pyproject.toml`
* extended test CI coverage to 3.12

Also makes the following changes:

* upper version bounds in `pyproject.toml`
* bump `numpy` upper bound