### PR TITLE
[MNT] address deprecation of `skbase.testing.utils.deep_equals`

### DIFF
--- a/skpro/tests/test_all_estimators.py
+++ b/skpro/tests/test_all_estimators.py
@@ -147,7 +147,7 @@ class TestAllObjects(PackageConfig, BaseFixtureGenerator, _TestAllObjects):
         we use the other test parameter settings (which are assumed valid).
         This guarantees settings which play along with the __init__ content.
         """
-        from skbase.testing.utils.deep_equals import deep_equals
+        from skbase.utils.deep_equals import deep_equals
 
         estimator = object_class.create_test_instance()
         test_params = object_class.get_test_params()


### PR DESCRIPTION
This PR addresses deprecation (and removal in `skbase 0.6.0`) of `skbase.testing.utils.deep_equals`, by moving imports to the new location of the same module.