### PR TITLE
DIAGNOSTIC [MNT] test all estimators

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ addopts =
     --cov-report xml
     --cov-report html
     --showlocals
-    --only_changed_modules True
     -n auto
 filterwarnings =
     ignore::UserWarning


### PR DESCRIPTION
diagnostic PR that turns off the "only changed" flag to run tests for all estimators.