### PR TITLE
[MNT] simplify wheels test for release

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -27,14 +27,14 @@ jobs:
           name: wheels
           path: wheelhouse/*
 
-  test_unix_wheels:
+  test_wheels:
     needs: build_wheels
     name: Test wheels on ${{ matrix.os }} with ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macOS-11]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.11']
+        os: [ubuntu-latest, macOS-latest]
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v4
@@ -52,79 +52,6 @@ jobs:
 
       - name: Install wheel and extras
         run: python -m pip install "${{ env.WHEELNAME }}[all_extras,dev]"
-
-      - name: Run tests
-        run: |
-          python -m pytest
-
-  test_windows_wheels:
-    needs: build_wheels
-    name: Test wheels on ${{ matrix.os }} with ${{ matrix.python-version }}
-    runs-on: windows-2019
-    strategy:
-      matrix:
-        include:
-          # Window 64 bit
-          - os: windows-2019
-            python: 38
-            python-version: '3.8'
-            bitness: 64
-            platform_id: win_amd64
-          - os: windows-2019
-            python: 39
-            python-version: '3.9'
-            bitness: 64
-            platform_id: win_amd64
-          - os: windows-2019
-            python: 310
-            python-version: '3.10'
-            bitness: 64
-            platform_id: win_amd64
-          - os: windows-2019
-            python: 311
-            python-version: 3.11
-            bitness: 64
-            platform_id: win_amd64
-          - os: windows-2019
-            python: 312
-            python-version: 3.12
-            bitness: 64
-            platform_id: win_amd64
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          activate-environment: test
-          auto-update-conda: true
-          python-version: ${{ matrix.python-version }}
-          channels: anaconda, conda-forge,
-
-      - run: conda --version
-      - run: which python
-
-      - uses: actions/download-artifact@v3
-        with:
-          name: wheels
-          path: wheelhouse
-
-      - name: Install conda libpython
-        run: conda install -c anaconda -n test -y libpython
-
-      - name: Display downloaded artifacts
-        run: ls -l wheelhouse
-
-      - name: Get wheel filename
-        run: echo "WHEELNAME=$(ls ./wheelhouse/skpro-*none-any.whl)" >> $env:GITHUB_ENV
-
-      - name: Activate conda env
-        run: conda activate test
-
-      - name: Install wheel and extras
-        run: python -m pip install "${env:WHEELNAME}[all_extras,dev]"
-
-      - name: Show conda packages
-        run: conda list -n test
 
       - name: Run tests
         run: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -60,7 +60,7 @@ jobs:
   upload_wheels:
     name: Upload wheels to PyPI
     runs-on: ubuntu-latest
-    needs: [build_wheels,test_unix_wheels,test_windows_wheels]
+    needs: [build_wheels,test_wheels]
 
     steps:
       - uses: actions/download-artifact@v3


### PR DESCRIPTION
This PR simplifies the test of wheels for release, and removes the dependency on miniconda which seems to have issues with python 3.12.