### PR TITLE
[MNT] point readthedocs `json` switcher variable to GitHub

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -145,7 +145,7 @@ def linkcode_resolve(domain, info):
 html_theme = "pydata_sphinx_theme"
 
 # Define the json_url for our version switcher.
-json_url = "https://skpro.readthedocs.io/en/latest/_static/switcher.json"
+json_url = "https://github.com/sktime/skpro/blob/main/docs/source/_static/switcher.json"
 
 # This uses code from the py-data-sphinx theme's own conf.py
 # Define the version we use for matching in the version switcher.


### PR DESCRIPTION
Attempts to fix https://github.com/sktime/skpro/issues/122 by pointing the json switcher to the GitHub location.

Hypothesis: a broken `json` got uploaded to readthedocs, and it will prevent upload of a correct version.