### PR TITLE
[MNT] ensure pytest options are set in `make test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ test: ## Run unit tests
 	mkdir -p ${TEST_DIR}
 	cp .coveragerc ${TEST_DIR}
 	cp setup.cfg ${TEST_DIR}
-	python -m pytest
+	python -m pytest $(PYTESTOPTIONS)
 
 test_check_suite: ## run only estimator contract tests in TestAll classes
 	-rm -rf ${TEST_DIR}


### PR DESCRIPTION
`make test` does not seem to respect the pytest options - hypothesis, this is due to a lacking pytest options reference in the makefile.