### PR TITLE
[ENG] probabilistic regressors - input checks and support for more input types

### DIFF
--- a/skpro/registry/_tags.py
+++ b/skpro/registry/_tags.py
@@ -95,6 +95,18 @@ OBJECT_TAG_REGISTER = [
         "bool",
         "whether estimator supports missing values",
     ),
+    (
+        "X_inner_mtype",
+        "regressor_proba",
+        ("list", "str"),
+        "which machine type(s) is the internal _fit/_predict able to deal with?",
+    ),
+    (
+        "y_inner_mtype",
+        "regressor_proba",
+        ("list", "str"),
+        "which machine type(s) is the internal _fit/_predict able to deal with?",
+    ),
     # ----------------
     # BaseDistribution
     # ----------------

--- a/skpro/regression/base/_base.py
+++ b/skpro/regression/base/_base.py
@@ -8,7 +8,6 @@ from skpro.base import BaseEstimator
 from skpro.datatypes import check_is_mtype, convert
 from skpro.utils.validation._dependencies import _check_estimator_deps
 
-
 # allowed input mtypes
 ALLOWED_MTYPES = [
     "pd_DataFrame_Table",

--- a/skpro/regression/base/_base.py
+++ b/skpro/regression/base/_base.py
@@ -5,7 +5,17 @@ import numpy as np
 import pandas as pd
 
 from skpro.base import BaseEstimator
+from skpro.datatypes import check_is_mtype, convert
 from skpro.utils.validation._dependencies import _check_estimator_deps
+
+
+# allowed input mtypes
+ALLOWED_MTYPES = [
+    "pd_DataFrame_Table",
+    "pd_Series_Table",
+    "numpy1D",
+    "numpy2D",
+]
 
 
 class BaseProbaRegressor(BaseEstimator):
@@ -16,6 +26,8 @@ class BaseProbaRegressor(BaseEstimator):
         "estimator_type": "regressor_proba",  # type of estimator, e.g., "regressor"
         "capability:multioutput": False,
         "capability:missing": True,
+        "X_inner_mtype": "pd_DataFrame_Table",
+        "y_inner_mtype": "pd_DataFrame_Table",
     }
 
     def __init__(self, index=None, columns=None):
@@ -24,6 +36,8 @@ class BaseProbaRegressor(BaseEstimator):
 
         super().__init__()
         _check_estimator_deps(self)
+
+        self._X_converter_store = {}
 
     def __rmul__(self, other):
         """Magic * method, return (left) concatenated Pipeline.
@@ -521,36 +535,63 @@ class BaseProbaRegressor(BaseEstimator):
         return pred_var
 
     def _check_X_y(self, X, y):
-        X = self._check_X(X)
-        y = self._check_y(y)
+        X, X_metadata = self._check_X(X)
+        y, y_metadata = self._check_y(y)
+
+        len_X = X_metadata["n_insntances"]
+        len_y = y_metadata["n_instances"]
 
         # input check X vs y
-        if not len(X) == len(y):
+        if not len_X == len_y:
             raise ValueError(
                 f"X and y in fit of {self} must have same number of rows, "
-                f"but X had {len(X)} rows, and y had {len(y)} rows"
+                f"but X had {len_X} rows, and y had {len_y} rows"
             )
 
         return X, y
 
     def _check_X(self, X):
+        valid, msg, metadata = check_is_mtype(
+            X, ALLOWED_MTYPES, "Table", return_metadata=["n_instances"], var_name="X"
+        )
+
+        # update with clearer message
+        if not valid:
+            raise TypeError(msg)
+
         # if we have seen X before, check against columns
-        if hasattr(self, "_X_columns") and not (X.columns == self._X_columns).all():
-            raise ValueError(
-                "X in predict methods must have same columns as X in fit, "
-                f"columns in fit were {self._X_columns}, "
-                f"but in predict found X.columns = {X.columns}"
-            )
+        if hasattr(self, "_X_columns") and hasattr(X, "columns"):
+            if not (X.columns == self._X_columns).all():
+                raise ValueError(
+                    "X in predict methods must have same columns as X in fit, "
+                    f"columns in fit were {self._X_columns}, "
+                    f"but in predict found X.columns = {X.columns}"
+                )
         # if not, remember columns
         else:
             self._X_columns = X.columns
 
-        return X
+        return X, metadata
 
     def _check_y(self, y):
-        if isinstance(y, pd.Series):
-            y = pd.DataFrame(y)
-        return y
+        valid, msg, metadata = check_is_mtype(
+            y, ALLOWED_MTYPES, "Table", return_metadata=["n_instances"], var_name="y"
+        )
+
+        # update with clearer message
+        if not valid:
+            raise TypeError(msg)
+
+        y_inner_mtype = self.get_tag("X_inner_mtype")
+        y = convert(
+            obj=y,
+            from_type=metadata["mtype"],
+            to_type=y_inner_mtype,
+            as_scitype="Table",
+            store=self._X_converter_store,
+        )
+
+        return y, metadata
 
     def _check_alpha(self, alpha, name="alpha"):
         """Check that quantile or confidence level value, or list of values, is valid.

--- a/skpro/regression/base/_base.py
+++ b/skpro/regression/base/_base.py
@@ -538,7 +538,7 @@ class BaseProbaRegressor(BaseEstimator):
         X, X_metadata = self._check_X(X)
         y, y_metadata = self._check_y(y)
 
-        len_X = X_metadata["n_insntances"]
+        len_X = X_metadata["n_instances"]
         len_y = y_metadata["n_instances"]
 
         # input check X vs y
@@ -551,6 +551,7 @@ class BaseProbaRegressor(BaseEstimator):
         return X, y
 
     def _check_X(self, X):
+        # input validity check for X
         valid, msg, metadata = check_is_mtype(
             X, ALLOWED_MTYPES, "Table", return_metadata=["n_instances"], var_name="X"
         )
@@ -559,6 +560,7 @@ class BaseProbaRegressor(BaseEstimator):
         if not valid:
             raise TypeError(msg)
 
+        # convert X to X_inner_mtype
         X_inner_mtype = self.get_tag("X_inner_mtype")
         X = convert(
             obj=X,
@@ -583,6 +585,7 @@ class BaseProbaRegressor(BaseEstimator):
         return X, metadata
 
     def _check_y(self, y):
+        # input validity check for y
         valid, msg, metadata = check_is_mtype(
             y, ALLOWED_MTYPES, "Table", return_metadata=["n_instances"], var_name="y"
         )
@@ -591,6 +594,7 @@ class BaseProbaRegressor(BaseEstimator):
         if not valid:
             raise TypeError(msg)
 
+        # convert y to y_inner_mtype
         y_inner_mtype = self.get_tag("y_inner_mtype")
         y = convert(
             obj=y,

--- a/skpro/regression/base/_base.py
+++ b/skpro/regression/base/_base.py
@@ -544,7 +544,7 @@ class BaseProbaRegressor(BaseEstimator):
         return pred_var
 
     def _check_X_y(self, X, y):
-        X, X_metadata = self._check_X(X)
+        X, X_metadata = self._check_X(X, return_metadata=True)
         y, y_metadata = self._check_y(y)
 
         len_X = X_metadata["n_instances"]
@@ -559,10 +559,14 @@ class BaseProbaRegressor(BaseEstimator):
 
         return X, y
 
-    def _check_X(self, X):
+    def _check_X(self, X, return_metadata=False):
+        if return_metadata:
+            req_metadata = ["n_instances"]
+        else:
+            req_metadata = []
         # input validity check for X
         valid, msg, metadata = check_is_mtype(
-            X, ALLOWED_MTYPES, "Table", return_metadata=["n_instances"], var_name="X"
+            X, ALLOWED_MTYPES, "Table", return_metadata=req_metadata, var_name="X"
         )
 
         # update with clearer message
@@ -594,7 +598,10 @@ class BaseProbaRegressor(BaseEstimator):
         # remember input mtype
         self._X_input_mtype = metadata["mtype"]
 
-        return X, metadata
+        if return_metadata:
+            return X, metadata
+        else:
+            return X
 
     def _check_y(self, y):
         # input validity check for y

--- a/skpro/regression/base/_base.py
+++ b/skpro/regression/base/_base.py
@@ -559,6 +559,15 @@ class BaseProbaRegressor(BaseEstimator):
         if not valid:
             raise TypeError(msg)
 
+        X_inner_mtype = self.get_tag("X_inner_mtype")
+        X = convert(
+            obj=X,
+            from_type=metadata["mtype"],
+            to_type=X_inner_mtype,
+            as_scitype="Table",
+            store=self._X_converter_store,
+        )
+
         # if we have seen X before, check against columns
         if hasattr(self, "_X_columns") and hasattr(X, "columns"):
             if not (X.columns == self._X_columns).all():
@@ -582,13 +591,12 @@ class BaseProbaRegressor(BaseEstimator):
         if not valid:
             raise TypeError(msg)
 
-        y_inner_mtype = self.get_tag("X_inner_mtype")
+        y_inner_mtype = self.get_tag("y_inner_mtype")
         y = convert(
             obj=y,
             from_type=metadata["mtype"],
             to_type=y_inner_mtype,
             as_scitype="Table",
-            store=self._X_converter_store,
         )
 
         return y, metadata

--- a/skpro/regression/base/_base.py
+++ b/skpro/regression/base/_base.py
@@ -187,6 +187,16 @@ class BaseProbaRegressor(BaseEstimator):
         X = self._check_X(X)
 
         y_pred = self._predict_proba(X)
+
+        # output conversion
+        y_pred = convert(
+            y_pred,
+            from_type=self.get_tag("X_inner_mtype"),
+            to_type=self._X_input_mtype,
+            as_scitype="Table",
+            store=self._X_converter_store,
+        )
+
         return y_pred
 
     def _predict_proba(self, X):
@@ -581,6 +591,9 @@ class BaseProbaRegressor(BaseEstimator):
         # if not, remember columns
         else:
             self._X_columns = X.columns
+
+        # remember input mtype
+        self._X_input_mtype = metadata["mtype"]
 
         return X, metadata
 


### PR DESCRIPTION
This PR connects the `datatypes` module with the base class layer, and enables use of `numpy` arrays and `pd.Series` as possible inputs for `X` and `y`.

Further, tags `X_inner_mtype` and `y_inner_mtype` are introduced to allow use of different types internally.

This is also an architectural necessity (in the abstract sense) for allowing both `pandas` and `polars` later on, compare https://github.com/sktime/sktime/issues/5423