### PR TITLE
[ENH] integrate `check_estimator` with `TestAllEstimators` and `TestAllRegressors` for python command line estimator testing

### DIFF
--- a/skpro/tests/test_all_estimators.py
+++ b/skpro/tests/test_all_estimators.py
@@ -8,6 +8,7 @@ import joblib
 import numpy as np
 import pandas as pd
 from skbase.testing import BaseFixtureGenerator as _BaseFixtureGenerator
+from skbase.testing import QuickTester as _QuickTester
 from skbase.testing import TestAllObjects as _TestAllObjects
 from skbase.testing.utils.inspect import _get_args
 from skbase.utils import deep_equals
@@ -281,7 +282,7 @@ class TestAllObjects(PackageConfig, BaseFixtureGenerator, _TestAllObjects):
             assert is_equal, msg
 
 
-class TestAllEstimators(PackageConfig, BaseFixtureGenerator):
+class TestAllEstimators(PackageConfig, BaseFixtureGenerator, _QuickTester):
     """Package level tests for all sktime estimators, i.e., objects with fit."""
 
     def test_fit_updates_state(self, object_instance, scenario):

--- a/skpro/utils/estimator_checks.py
+++ b/skpro/utils/estimator_checks.py
@@ -153,9 +153,6 @@ def check_estimator(
     else:
         scitype_of_estimator = ""
 
-    print(scitype_of_estimator)
-    print(list(testclass_dict.keys()))
-
     if scitype_of_estimator in testclass_dict.keys():
         results_scitype = testclass_dict[scitype_of_estimator]().run_tests(
             estimator=estimator,

--- a/skpro/utils/estimator_checks.py
+++ b/skpro/utils/estimator_checks.py
@@ -112,11 +112,11 @@ def check_estimator(
     from skpro.base import BaseEstimator
     from skpro.distributions.tests.test_all_distrs import TestAllDistributions
     from skpro.regression.tests.test_all_regressors import TestAllRegressors
-    from skpro.tests.test_all_estimators import TestAllObjects
+    from skpro.tests.test_all_estimators import TestAllEstimators, TestAllObjects
 
     testclass_dict = dict()
 
-    testclass_dict["regressor"] = TestAllRegressors
+    testclass_dict["regressor_proba"] = TestAllRegressors
     testclass_dict["distribution"] = TestAllDistributions
 
     results = TestAllObjects().run_tests(
@@ -135,22 +135,26 @@ def check_estimator(
         else:
             return isinstance(obj, BaseEstimator)
 
-    # commented out for now - add when TestAllEstimators is added
-    # if is_estimator(estimator):
-    #     results_estimator = TestAllEstimators().run_tests(
-    #         obj=estimator,
-    #         raise_exceptions=raise_exceptions,
-    #         tests_to_run=tests_to_run,
-    #         fixtures_to_run=fixtures_to_run,
-    #         tests_to_exclude=tests_to_exclude,
-    #         fixtures_to_exclude=fixtures_to_exclude,
-    #     )
-    #     results.update(results_estimator)
+    if is_estimator(estimator):
+        results_estimator = TestAllEstimators().run_tests(
+            obj=estimator,
+            raise_exceptions=raise_exceptions,
+            tests_to_run=tests_to_run,
+            fixtures_to_run=fixtures_to_run,
+            tests_to_exclude=tests_to_exclude,
+            fixtures_to_exclude=fixtures_to_exclude,
+        )
+        results.update(results_estimator)
 
-    try:
+    if isclass(estimator) and hasattr(estimator, "get_class_tag"):
+        scitype_of_estimator = estimator.get_class_tag("object_type", "object")
+    elif hasattr(estimator, "get_tag"):
         scitype_of_estimator = estimator.get_tag("object_type", "object")
-    except Exception:
+    else:
         scitype_of_estimator = ""
+
+    print(scitype_of_estimator)
+    print(list(testclass_dict.keys()))
 
     if scitype_of_estimator in testclass_dict.keys():
         results_scitype = testclass_dict[scitype_of_estimator]().run_tests(

--- a/skpro/utils/estimator_checks.py
+++ b/skpro/utils/estimator_checks.py
@@ -155,7 +155,7 @@ def check_estimator(
 
     if scitype_of_estimator in testclass_dict.keys():
         results_scitype = testclass_dict[scitype_of_estimator]().run_tests(
-            estimator=estimator,
+            obj=estimator,
             raise_exceptions=raise_exceptions,
             tests_to_run=tests_to_run,
             fixtures_to_run=fixtures_to_run,


### PR DESCRIPTION
This PR properly integrates `TestAllEstimators` and `TestAllRegressors` with the `check_estimator` utility and fixes. These were so far not connected due to dependencies on the test scenarios which now have been added (and a bug in `scitype` name resolution).

The integration happens in three places:

* `TestAllEstimators` now inherits from `skbase` `QuickTester` to allow command line testing
* `check_estimator` now runs `TestAllEstimators` for estimators
* `TestAllRegressor` integration with `check_estimator` is fixed, the scitype string was erroneously `"regressor"` instead of, correctly, `"regressor_proba"`.