### PR TITLE
[BUG] fix test fixture generation logic

### DIFF
--- a/skpro/distributions/tests/test_all_distrs.py
+++ b/skpro/distributions/tests/test_all_distrs.py
@@ -7,11 +7,11 @@ __author__ = ["fkiraly", "Alex-JG3"]
 import numpy as np
 import pandas as pd
 import pytest
-from skbase.testing import BaseFixtureGenerator, QuickTester
+from skbase.testing import QuickTester
 
 from skpro.datatypes import check_is_mtype
 from skpro.distributions.base import BaseDistribution
-from skpro.tests.test_all_estimators import PackageConfig
+from skpro.tests.test_all_estimators import BaseFixtureGenerator, PackageConfig
 from skpro.utils.index import random_ss_ix
 
 

--- a/skpro/regression/tests/test_all_regressors.py
+++ b/skpro/regression/tests/test_all_regressors.py
@@ -1,12 +1,12 @@
 """Automated tests based on the skbase test suite template."""
 import pandas as pd
 import pytest
-from skbase.testing import BaseFixtureGenerator, QuickTester
+from skbase.testing import QuickTester
 
 from skpro.datatypes import check_is_mtype, check_raise
 from skpro.distributions.base import BaseDistribution
 from skpro.regression.base._base import BaseProbaRegressor
-from skpro.tests.test_all_estimators import PackageConfig
+from skpro.tests.test_all_estimators import BaseFixtureGenerator, PackageConfig
 
 TEST_ALPHAS = [0.05, [0.1], [0.25, 0.75], [0.3, 0.1, 0.9]]
 


### PR DESCRIPTION
This PR fixes the test fixture generation logic, and fixes https://github.com/sktime/skpro/issues/128.

The problem was that some `TestAll...` classes were inheriting from `skbase` `FixtureGenerator` and not from the `skpro` fixture generator `FixtureGenerator` (from `test_all-estimators`) which overrides `_all_objects` to test only incrementally, or objects with available dependencies.