### PR TITLE
[ENH] in proba regressors, ensure correct index treatment if `X: pd.DataFrame` and `y: np.ndarray` are passed

### DIFF
--- a/skpro/regression/base/_base.py
+++ b/skpro/regression/base/_base.py
@@ -560,10 +560,12 @@ class BaseProbaRegressor(BaseEstimator):
         # in case y gets an index through conversion and X already had one
         # we need to make sure that the index of y is the same as the index of X
         # example case: X was pd.DataFrame, y was np.ndarray
-        # but both get converted to pd.DataFrame, then y gets RangeIndex without this
+        # but both get converted to X_inner, y_inner: pd.DataFrame
+        # then y_inner would geta RangeIndex without this, but should have X_inner.index
         if hasattr(X_inner, "index") and not hasattr(y, "index"):
             if isinstance(y_inner, (pd.DataFrame, pd.Series)):
                 y_inner.index = X_inner.index
+
 
         return X_inner, y_inner
 

--- a/skpro/regression/base/_base.py
+++ b/skpro/regression/base/_base.py
@@ -544,8 +544,8 @@ class BaseProbaRegressor(BaseEstimator):
         return pred_var
 
     def _check_X_y(self, X, y):
-        X, X_metadata = self._check_X(X, return_metadata=True)
-        y, y_metadata = self._check_y(y)
+        X_inner, X_metadata = self._check_X(X, return_metadata=True)
+        y_inner, y_metadata = self._check_y(y)
 
         len_X = X_metadata["n_instances"]
         len_y = y_metadata["n_instances"]
@@ -557,7 +557,15 @@ class BaseProbaRegressor(BaseEstimator):
                 f"but X had {len_X} rows, and y had {len_y} rows"
             )
 
-        return X, y
+        # in case y gets an index through conversion and X already had one
+        # we need to make sure that the index of y is the same as the index of X
+        # example case: X was pd.DataFrame, y was np.ndarray
+        # but both get converted to pd.DataFrame, then y gets RangeIndex without this
+        if hasattr(X_inner, "index") and not hasattr(y, "index"):
+            if isinstance(y_inner, (pd.DataFrame, pd.Series)):
+                y_inner.index = X_inner.index
+
+        return X_inner, y_inner
 
     def _check_X(self, X, return_metadata=False):
         if return_metadata:

--- a/skpro/regression/base/_base.py
+++ b/skpro/regression/base/_base.py
@@ -566,7 +566,6 @@ class BaseProbaRegressor(BaseEstimator):
             if isinstance(y_inner, (pd.DataFrame, pd.Series)):
                 y_inner.index = X_inner.index
 
-
         return X_inner, y_inner
 
     def _check_X(self, X, return_metadata=False):


### PR DESCRIPTION
In proba regressors, if `X: pd.DataFrame` and `y: np.ndarray` are passed, and both are internally converted to `pandas`, `y` will acquire an index which should equal that of `X`.

However, currently `y` alsways gets a `RangeIndex`.
This PR rectifies handling in this combination case.

Test coverage is provided by https://github.com/sktime/skpro/pull/145.