### PR TITLE
[ENH] `sklearn` wrappers to str-coerce columns of `pd.DataFrame` before passing

### DIFF
--- a/skpro/regression/bootstrap.py
+++ b/skpro/regression/bootstrap.py
@@ -10,6 +10,7 @@ from sklearn import clone
 from skpro.distributions.empirical import Empirical
 from skpro.regression.base import BaseProbaRegressor
 from skpro.utils.numpy import flatten_to_1D_if_colvector
+from skpro.utils.sklearn import prep_skl_df
 
 
 class BootstrapRegressor(BaseProbaRegressor):
@@ -111,6 +112,9 @@ class BootstrapRegressor(BaseProbaRegressor):
         self.estimators_ = []
         self._cols = y.columns
 
+        # coerce X to pandas DataFrame with string column names
+        X = prep_skl_df(X, copy_df=True)
+
         for _i in range(n_bootstrap_samples):
             esti = clone(estimator)
             row_iloc = pd.RangeIndex(n)
@@ -147,6 +151,10 @@ class BootstrapRegressor(BaseProbaRegressor):
             labels predicted for `X`
         """
         cols = self._cols
+
+        # coerce X to pandas DataFrame with string column names
+        X = prep_skl_df(X, copy_df=True)
+
         y_preds = [est.predict(X) for est in self.estimators_]
 
         def _coerce_df(x):

--- a/skpro/regression/compose/_pipeline.py
+++ b/skpro/regression/compose/_pipeline.py
@@ -10,6 +10,7 @@ from sklearn import clone
 
 from skpro.base import BaseMetaEstimator
 from skpro.regression.base import BaseProbaRegressor
+from skpro.utils.sklearn import prep_skl_df
 
 
 class _Pipeline(BaseMetaEstimator, BaseProbaRegressor):
@@ -391,6 +392,9 @@ class Pipeline(_Pipeline):
         -------
         self : reference to self
         """
+        # coerce X to pandas DataFrame with string column names
+        X = prep_skl_df(X, copy_df=True)
+
         # transform X
         for step_idx, name, transformer in self._iter_transformers():
             t = transformer
@@ -530,6 +534,9 @@ class Pipeline(_Pipeline):
 
     def _transform(self, X, y=None):
         """Transform data."""
+        # coerce X to pandas DataFrame with string column names
+        X = prep_skl_df(X, copy_df=True)
+
         for _, _, transformer in self._iter_transformers():
             if self._has_y_arg(transformer.transform):
                 Xt = transformer.transform(X=X, y=y)

--- a/skpro/regression/residual.py
+++ b/skpro/regression/residual.py
@@ -318,7 +318,7 @@ class ResidualDouble(BaseProbaRegressor):
         else:
             X_r = X
 
-        y_pred_scale = est_r.predict(X_r, copy_df=True)
+        y_pred_scale = est_r.predict(X_r)
         y_pred_scale = y_pred_scale.clip(min=min_scale)
         y_pred_scale = y_pred_scale.reshape(-1, n_cols)
 

--- a/skpro/regression/residual.py
+++ b/skpro/regression/residual.py
@@ -219,7 +219,7 @@ class ResidualDouble(BaseProbaRegressor):
         est.fit(prep_skl_df(X, copy_df=True), y)
 
         if cv is None:
-            y_pred = est.predict()
+            y_pred = est.predict(X)
         else:
             y_pred = self._predict_residuals_cv(X, y, cv, est)
 

--- a/skpro/regression/residual.py
+++ b/skpro/regression/residual.py
@@ -318,6 +318,9 @@ class ResidualDouble(BaseProbaRegressor):
         else:
             X_r = X
 
+        # coerce X to pandas DataFrame with string column names
+        X_r = prep_skl_df(X_r, copy_df=True)
+
         y_pred_scale = est_r.predict(X_r)
         y_pred_scale = y_pred_scale.clip(min=min_scale)
         y_pred_scale = y_pred_scale.reshape(-1, n_cols)

--- a/skpro/regression/residual.py
+++ b/skpro/regression/residual.py
@@ -216,7 +216,7 @@ class ResidualDouble(BaseProbaRegressor):
         y = y.values
         y = flatten_to_1D_if_colvector(y)
 
-        est.fit(prep_skl_df(X, copy_df=True), y)
+        est.fit(X, y)
 
         if cv is None:
             y_pred = est.predict(X)

--- a/skpro/regression/residual.py
+++ b/skpro/regression/residual.py
@@ -238,6 +238,9 @@ class ResidualDouble(BaseProbaRegressor):
         else:
             X_r = X
 
+        # coerce X to pandas DataFrame with string column names
+        X_r = prep_skl_df(X_r, copy_df=True)
+
         est_r.fit(X_r, resids)
 
         return self

--- a/skpro/utils/sklearn.py
+++ b/skpro/utils/sklearn.py
@@ -1,0 +1,30 @@
+"""Utility functions for adapting to sklearn."""
+
+import numpy as np
+
+
+def prep_skl_df(df, copy_df=False):
+    """Make df compatible with sklearn input expectations.
+
+    Changes:
+    turns column index into a list of strings
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        list of indices to sample from
+    copy_df : bool, default=False
+        whether to mutate df or return a copy
+        if False, index of df is mutated
+        if True, original df is not mutated. If index is not a list of strings,
+        a copy is made and the copy is mutated. Otherwise, the original df is returned.
+    """
+    cols = df.columns
+    str_cols = cols.astype(str)
+
+    if not np.all(str_cols == cols):
+        if copy_df:
+            df = df.copy()
+        df.columns = str_cols
+
+    return df


### PR DESCRIPTION
This PR ensures that `sklearn` wrappers str-coerce columns of `pd.DataFrame` before passing them to `sklearn`, avoiding failures due to mixed column types.

Test coverage is provided in https://github.com/sktime/skpro/pull/145