### PR TITLE
[ENH] `n_features` and `feature_names` metadata field for table mtypes

### DIFF
--- a/skpro/datatypes/_adapter/polars.py
+++ b/skpro/datatypes/_adapter/polars.py
@@ -34,7 +34,7 @@ def check_polars_frame(obj, return_metadata=False, var_name="obj", lazy=False):
     if _req("n_features", return_metadata):
         metadata["n_features"] = obj.width
     if _req("feature_names", return_metadata):
-        metadata["feature_names"] = obj.columns.to_list()
+        metadata["feature_names"] = obj.columns
 
     # check if there are any nans
     #   compute only if needed

--- a/skpro/datatypes/_adapter/polars.py
+++ b/skpro/datatypes/_adapter/polars.py
@@ -31,6 +31,10 @@ def check_polars_frame(obj, return_metadata=False, var_name="obj", lazy=False):
             metadata["n_instances"] = obj.height
         else:
             metadata["n_instances"] = "NA"
+    if _req("n_features", return_metadata):
+        metadata["n_features"] = obj.width
+    if _req("feature_names", return_metadata):
+        metadata["feature_names"] = obj.columns.to_list()
 
     # check if there are any nans
     #   compute only if needed

--- a/skpro/datatypes/_table/_check.py
+++ b/skpro/datatypes/_table/_check.py
@@ -98,6 +98,8 @@ def check_pdseries_table(obj, return_metadata=False, var_name="obj"):
         metadata["is_univariate"] = True
     if _req("n_instances", return_metadata):
         metadata["n_instances"] = len(index)
+    if _req("n_features", return_metadata):
+        metadata["n_features"] = 1
     if _req("feature_names", return_metadata):
         if not hasattr(obj, "name") or obj.name is None:
             metadata["feature_names"] = [0]

--- a/skpro/datatypes/_table/_check.py
+++ b/skpro/datatypes/_table/_check.py
@@ -30,6 +30,8 @@ metadata: dict - metadata about obj if valid, otherwise None
         "is_empty": bool, True iff table has no variables or no instances
         "has_nans": bool, True iff the panel contains NaN values
         "n_instances": int, number of instances/rows in the table
+        "n_features": int, number of variables in series
+        "feature_names": list of int or object, names of variables in series
 """
 
 __author__ = ["fkiraly"]
@@ -65,6 +67,10 @@ def check_pddataframe_table(obj, return_metadata=False, var_name="obj"):
         metadata["n_instances"] = len(index)
     if _req("has_nans", return_metadata):
         metadata["has_nans"] = obj.isna().values.any()
+    if _req("n_features", return_metadata):
+        metadata["n_features"] = len(obj.columns)
+    if _req("feature_names", return_metadata):
+        metadata["feature_names"] = obj.columns.to_list()
 
     # check that no dtype is object
     if "object" in obj.dtypes.values:
@@ -92,6 +98,11 @@ def check_pdseries_table(obj, return_metadata=False, var_name="obj"):
         metadata["is_univariate"] = True
     if _req("n_instances", return_metadata):
         metadata["n_instances"] = len(index)
+    if _req("feature_names", return_metadata):
+        if not hasattr(obj, "name") or obj.name is None:
+            metadata["feature_names"] = [0]
+        else:
+            metadata["feature_names"] = [obj.name]
 
     # check that dtype is not object
     if "object" == obj.dtypes:
@@ -131,6 +142,11 @@ def check_numpy1d_table(obj, return_metadata=False, var_name="obj"):
     # check whether there any nans; compute only if requested
     if _req("has_nans", return_metadata):
         metadata["has_nans"] = pd.isnull(obj).any()
+    # 1D numpy arrays are considered univariate, with one feature named 0 (integer)
+    if _req("n_features", return_metadata):
+        metadata["n_features"] = 1
+    if _req("feature_names", return_metadata):
+        metadata["feature_names"] = [0]
 
     return _ret(True, None, metadata, return_metadata)
 
@@ -159,6 +175,11 @@ def check_numpy2d_table(obj, return_metadata=False, var_name="obj"):
     # check whether there any nans; compute only if requested
     if _req("has_nans", return_metadata):
         metadata["has_nans"] = pd.isnull(obj).any()
+    # 1D numpy arrays are considered univariate, with integer feature names
+    if _req("n_features", return_metadata):
+        metadata["n_features"] = obj.shape[1]
+    if _req("feature_names", return_metadata):
+        metadata["feature_names"] = list(range(obj.shape[1]))
 
     return _ret(True, None, metadata, return_metadata)
 
@@ -207,6 +228,16 @@ def check_list_of_dict_table(obj, return_metadata=False, var_name="obj"):
         metadata["is_empty"] = len(obj) < 1 or np.all([len(x) < 1 for x in obj])
     if _req("n_instances", return_metadata):
         metadata["n_instances"] = len(obj)
+
+    # this can be expensive, so compute only if requested
+    if _req("n_features", return_metadata) or _req("feature_names", return_metadata):
+        all_keys = np.unique([key for d in obj for key in d.keys()])
+        if _req("n_features", return_metadata):
+            metadata["n_features"] = len(all_keys)
+        if _req("feature_names", return_metadata):
+            metadata["feature_names"] = all_keys
+
+    if _req("feature_names", return_metadata):
 
     return _ret(True, None, metadata, return_metadata)
 

--- a/skpro/datatypes/_table/_check.py
+++ b/skpro/datatypes/_table/_check.py
@@ -30,8 +30,8 @@ metadata: dict - metadata about obj if valid, otherwise None
         "is_empty": bool, True iff table has no variables or no instances
         "has_nans": bool, True iff the panel contains NaN values
         "n_instances": int, number of instances/rows in the table
-        "n_features": int, number of variables in series
-        "feature_names": list of int or object, names of variables in series
+        "n_features": int, number of variables in table
+        "feature_names": list of int or object, names of variables in tab;e
 """
 
 __author__ = ["fkiraly"]

--- a/skpro/datatypes/_table/_check.py
+++ b/skpro/datatypes/_table/_check.py
@@ -235,9 +235,7 @@ def check_list_of_dict_table(obj, return_metadata=False, var_name="obj"):
         if _req("n_features", return_metadata):
             metadata["n_features"] = len(all_keys)
         if _req("feature_names", return_metadata):
-            metadata["feature_names"] = all_keys
-
-    if _req("feature_names", return_metadata):
+            metadata["feature_names"] = all_keys.tolist()
 
     return _ret(True, None, metadata, return_metadata)
 

--- a/skpro/datatypes/_table/_examples.py
+++ b/skpro/datatypes/_table/_examples.py
@@ -72,6 +72,8 @@ example_dict_metadata[("Table", 0)] = {
     "is_empty": False,
     "has_nans": False,
     "n_instances": 4,
+    "n_features": 1,
+    "feature_names": ["a"],
 }
 
 ###
@@ -117,4 +119,6 @@ example_dict_metadata[("Table", 1)] = {
     "is_empty": False,
     "has_nans": False,
     "n_instances": 4,
+    "n_features": 2,
+    "feature_names": ["a", "b"],
 }

--- a/skpro/datatypes/tests/test_check.py
+++ b/skpro/datatypes/tests/test_check.py
@@ -272,7 +272,7 @@ def test_check_metadata_inference(scitype, mtype, fixture_index):
     if fixture is not None and check_is_defined and metadata_provided:
         for metadata_key in subset_keys:
             check_result = check_is_mtype(
-                fixture, mtype, scitype, return_metadata=[metadata_key],
+                fixture, mtype, scitype, return_metadata=[metadata_key]
             )
             metadata = check_result[2]
 


### PR DESCRIPTION
This PR adds `n_features` and `feature_names` metadat field for data table mtypes - similar to the attributes of the same name in `sklearn`.

This will be useful for cleaner input/output queriability in a variety of places, and further `sklearn` compatibility.

Similar to https://github.com/sktime/sktime/pull/5596 (for time series)
