### PR TITLE
[ENH] `check_is_mtype` dict type return, improved input check error messages in `BaseRegressorProba`

### DIFF
--- a/skpro/datatypes/__init__.py
+++ b/skpro/datatypes/__init__.py
@@ -6,6 +6,7 @@
 __author__ = ["fkiraly"]
 
 from skpro.datatypes._check import (
+    check_is_error_msg,
     check_is_mtype,
     check_is_scitype,
     check_raise,
@@ -25,6 +26,7 @@ from skpro.datatypes._registry import (
 )
 
 __all__ = [
+    "check_is_error_msg",
     "check_is_mtype",
     "check_is_scitype",
     "check_raise",

--- a/skpro/datatypes/_check.py
+++ b/skpro/datatypes/_check.py
@@ -24,6 +24,7 @@ __all__ = [
 ]
 
 import numpy as np
+from warnings import warn
 
 from skpro.datatypes._common import _metadata_requested, _ret
 from skpro.datatypes._proba import check_dict_Proba

--- a/skpro/datatypes/_check.py
+++ b/skpro/datatypes/_check.py
@@ -76,12 +76,14 @@ def _coerce_list_of_str(obj, var_name="obj"):
     return obj
 
 
+# todo 2.3.0: change default for msg_return_dict to "dict", update docstring
 def check_is_mtype(
     obj,
     mtype,
     scitype: str = None,
     return_metadata=False,
     var_name="obj",
+    msg_return_dict=None,
 ):
     """Check object for compliance with mtype specification, return metadata.
 
@@ -97,14 +99,23 @@ def check_is_mtype(
         if False, returns only "valid" return
         if True, returns all three return objects
         if str, list of str, metadata return dict is subset to keys in return_metadata
-    var_name: str, optional, default="obj" - name of input in error messages
+    var_name: str, optional, default="obj"
+        name of input in error messages
+    msg_return_dict: str, "list" or "dict", optional, default="list"
+        whether returned msg, if returned is a str, dict or list
+        if "list", msg is str if mtype is str, list of str if mtype is list
+        if "dict", msg is dict if mtype is str, list of str if mtype is list,
+        if dict, has with mtype as key and error message for mtype as value
 
     Returns
     -------
     valid: bool - whether obj is a valid object of mtype/scitype
-    msg: str or list of str - error messages if object is not valid, otherwise None
-            str if mtype is str; list of len(mtype) with message per mtype if list
-            returned only if return_metadata is True or str, list of str
+    msg: str or list/dict of str - error messages if object is not valid, otherwise None
+        list or dict type is controlled via msg_return_dict
+        if str: error message for tested mtype
+        it list: list of len(mtype) with message per mtype if list, same order as mtype
+        if dict: dict with mtype as key and error message for mtype as value
+        returned only if return_metadata is True or str, list of str
     metadata: dict - metadata about obj if valid, otherwise None
             returned only if return_metadata is True or str, list of str
         Keys populated depend on (assumed, otherwise identified) scitype of obj.
@@ -143,7 +154,24 @@ def check_is_mtype(
 
     # we loop through individual mtypes in mtype and see whether they pass the check
     #  for each check we remember whether it passed and what it returned
-    msg = []
+
+    # initialize loop variables
+    if msg_return_dict is None:
+        # todo 2.3.0: remove this warning, and change default to "dict"
+        warn(
+            "From skpro 2.3.0 onwards, msg return of check_is_mtype "
+            "will default to dict if mtype is a list. "
+            "To retain the old behaviour, set msg_return_dict='list' explicitly. "
+            "To move to the new behaviour, set msg_return_dict='dict' explicitly. "
+            "Setting msg_return_dict explicitly will silence the warning."
+        )
+        msg = []
+        msg_return_dict = "list"
+    elif msg_return_dict == "list":
+        msg = []
+    elif msg_return_dict == "dict":
+        msg = dict()
+
     found_mtype = []
     found_scitype = []
 
@@ -169,7 +197,10 @@ def check_is_mtype(
             found_scitype.append(scitype_of_m)
             final_result = res
         elif _metadata_requested(return_metadata):
-            msg.append(res[1])
+            if msg_return_dict == "list":
+                msg.append(res[1])
+            else:
+                msg[m] = res[1]
 
     # there are three options on the result of check_is_mtype:
     # a. two or more mtypes are found - this is unexpected and an error with checks
@@ -227,6 +258,7 @@ def check_raise(obj, mtype: str, scitype: str = None, var_name: str = "input"):
         scitype=scitype,
         return_metadata=[],
         var_name=var_name,
+        msg_return_dict="list",
     )
 
     if valid:
@@ -287,6 +319,7 @@ def mtype(obj, as_scitype=None, exclude_mtypes=AMBIGUOUS_MTYPES):
             mtype=m_plus_scitype[0],
             scitype=m_plus_scitype[1],
             return_metadata=[],
+            msg_return_dict="list",
         )
         if valid:
             mtypes_positive += [m_plus_scitype[0]]
@@ -421,6 +454,45 @@ def check_is_scitype(
     # c. no mtype is found - then return False and all error messages if requested
     else:
         return _ret(False, msg, None, return_metadata)
+
+
+def check_is_error_msg(msg, var_name="obj", allowed_msg=None, raise_exception=False):
+    """Format and possibly raise error message from check_is_mtype or check_is_scitype.
+
+    Parameters
+    ----------
+    msg: dict[str, str]
+        error message from check_is_scitype, or from check_is_mtype with dict return
+    var_name: str, optional, default="obj"
+        name of input in error messages
+    allowed_msg: str, optional, default=None
+        message component detailing allowed mtypes or scitype combinations
+    raise_exception: bool or Exception, optional, default=False
+        whether to raise exception or return error message
+        if False, returns formatted error message
+        if True, raises TypeError with formatted error message
+        if Exception, raises that Exception with formatted error message
+
+    Returns
+    -------
+    str - formatted error message
+    """
+    msg_invalid_input = (
+        f"{var_name} must be in an skpro compatible format. {allowed_msg}"
+        f"If you think the data is already in an skpro supported input format, "
+        f"run skpro.datatypes.check_raise(data, mtype) to diagnose the error, "
+        f"where mtype is the string of the type specification you want. "
+        f"Error message for checked mtypes, in format [mtype: message], as follows:"
+    )
+    for mtype, err in msg.items():
+        msg_invalid_input += f" [{mtype}: {err}] "
+
+    if raise_exception is True:
+        raise TypeError(msg_invalid_input)
+    elif raise_exception is False:
+        return msg_invalid_input
+    else:
+        raise raise_exception(msg_invalid_input)
 
 
 def scitype(obj, candidate_scitypes=SCITYPE_LIST, exclude_mtypes=AMBIGUOUS_MTYPES):

--- a/skpro/datatypes/_check.py
+++ b/skpro/datatypes/_check.py
@@ -23,8 +23,9 @@ __all__ = [
     "mtype",
 ]
 
-import numpy as np
 from warnings import warn
+
+import numpy as np
 
 from skpro.datatypes._common import _metadata_requested, _ret
 from skpro.datatypes._proba import check_dict_Proba

--- a/skpro/datatypes/tests/test_check.py
+++ b/skpro/datatypes/tests/test_check.py
@@ -331,7 +331,10 @@ def test_check_negative(scitype, mtype):
             # check fixtures that exist against checks that exist
             if fixture_wrong_type is not None and check_is_defined:
                 assert not check_is_mtype(
-                    fixture_wrong_type, mtype, scitype, msg_return_dict="list",
+                    fixture_wrong_type,
+                    mtype,
+                    scitype,
+                    msg_return_dict="list",
                 ), (
                     f"check_is_mtype {mtype} returns True "
                     f"on {wrong_mtype} fixture {i}"

--- a/skpro/datatypes/tests/test_check.py
+++ b/skpro/datatypes/tests/test_check.py
@@ -127,7 +127,9 @@ def test_check_positive(scitype, mtype, fixture_index):
 
     # check fixtures that exist against checks that exist, when full metadata is queried
     if fixture is not None and check_is_defined:
-        check_result = check_is_mtype(fixture, mtype, scitype, return_metadata=True)
+        check_result = check_is_mtype(
+            fixture, mtype, scitype, return_metadata=True, msg_return_dict="list"
+        )
         if not check_result[0]:
             msg = (
                 f"check_is_mtype returns False on scitype {scitype}, mtype {mtype} "
@@ -138,7 +140,9 @@ def test_check_positive(scitype, mtype, fixture_index):
 
     # check fixtures that exist against checks that exist, when no metadata is queried
     if fixture is not None and check_is_defined:
-        check_result = check_is_mtype(fixture, mtype, scitype, return_metadata=[])
+        check_result = check_is_mtype(
+            fixture, mtype, scitype, return_metadata=[], msg_return_dict="list"
+        )
         if not check_result[0]:
             msg = (
                 f"check_is_mtype returns False on scitype {scitype}, mtype {mtype} "
@@ -233,7 +237,9 @@ def test_check_metadata_inference(scitype, mtype, fixture_index):
 
     # check fixtures that exist against checks that exist, full metadata query
     if fixture is not None and check_is_defined and metadata_provided:
-        check_result = check_is_mtype(fixture, mtype, scitype, return_metadata=True)
+        check_result = check_is_mtype(
+            fixture, mtype, scitype, return_metadata=True, msg_return_dict="list"
+        )
         metadata = check_result[2]
 
         # remove mtype & scitype key if exists, since comparison is on scitype level
@@ -258,7 +264,11 @@ def test_check_metadata_inference(scitype, mtype, fixture_index):
     if fixture is not None and check_is_defined and metadata_provided:
         for metadata_key in subset_keys:
             check_result = check_is_mtype(
-                fixture, mtype, scitype, return_metadata=[metadata_key]
+                fixture,
+                mtype,
+                scitype,
+                return_metadata=[metadata_key],
+                msg_return_dict="list",
             )
             metadata = check_result[2]
 
@@ -320,7 +330,9 @@ def test_check_negative(scitype, mtype):
 
             # check fixtures that exist against checks that exist
             if fixture_wrong_type is not None and check_is_defined:
-                assert not check_is_mtype(fixture_wrong_type, mtype, scitype), (
+                assert not check_is_mtype(
+                    fixture_wrong_type, mtype, scitype, msg_return_dict="list",
+                ), (
                     f"check_is_mtype {mtype} returns True "
                     f"on {wrong_mtype} fixture {i}"
                 )
@@ -328,7 +340,11 @@ def test_check_negative(scitype, mtype):
             # check fixtures that exist against checks that exist
             if fixture_wrong_type is not None and check_is_defined:
                 result = check_is_mtype(
-                    fixture_wrong_type, mtype, scitype, return_metadata=[]
+                    fixture_wrong_type,
+                    mtype,
+                    scitype,
+                    return_metadata=[],
+                    msg_return_dict="list",
                 )[0]
                 assert not result, (
                     f"check_is_mtype {mtype} returns True "

--- a/skpro/distributions/tests/test_all_distrs.py
+++ b/skpro/distributions/tests/test_all_distrs.py
@@ -139,7 +139,9 @@ class TestAllDistributions(PackageConfig, DistributionFixtureGenerator, QuickTes
         d = object_instance
 
         def _check_quantile_output(obj, q):
-            assert check_is_mtype(obj, "pred_quantiles", "Proba")
+            assert check_is_mtype(
+                obj, "pred_quantiles", "Proba", msg_return_dict="list"
+            )
             assert (obj.index == d.index).all()
 
             if not isinstance(q, list):

--- a/skpro/regression/base/_base.py
+++ b/skpro/regression/base/_base.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 
 from skpro.base import BaseEstimator
-from skpro.datatypes import check_is_mtype, convert
+from skpro.datatypes import check_is_error_msg, check_is_mtype, convert
 from skpro.utils.validation._dependencies import _check_estimator_deps
 
 # allowed input mtypes
@@ -575,12 +575,17 @@ class BaseProbaRegressor(BaseEstimator):
             req_metadata = []
         # input validity check for X
         valid, msg, metadata = check_is_mtype(
-            X, ALLOWED_MTYPES, "Table", return_metadata=req_metadata, var_name="X"
+            X,
+            ALLOWED_MTYPES,
+            "Table",
+            return_metadata=req_metadata,
+            var_name="X",
+            msg_return_dict="list",
         )
 
         # update with clearer message
         if not valid:
-            raise TypeError(msg)
+            check_is_error_msg(msg, var_name="X", raise_exception=True)
 
         # convert X to X_inner_mtype
         X_inner_mtype = self.get_tag("X_inner_mtype")
@@ -615,12 +620,17 @@ class BaseProbaRegressor(BaseEstimator):
     def _check_y(self, y):
         # input validity check for y
         valid, msg, metadata = check_is_mtype(
-            y, ALLOWED_MTYPES, "Table", return_metadata=["n_instances"], var_name="y"
+            y,
+            ALLOWED_MTYPES,
+            "Table",
+            return_metadata=["n_instances"],
+            var_name="y",
+            msg_return_dict="list",
         )
 
         # update with clearer message
         if not valid:
-            raise TypeError(msg)
+            check_is_error_msg(msg, var_name="y", raise_exception=True)
 
         # convert y to y_inner_mtype
         y_inner_mtype = self.get_tag("y_inner_mtype")

--- a/skpro/regression/tests/test_all_regressors.py
+++ b/skpro/regression/tests/test_all_regressors.py
@@ -89,6 +89,7 @@ class TestAllRegressors(PackageConfig, BaseFixtureGenerator, QuickTester):
             scitype="Proba",
             return_metadata=True,
             var_name="predict_quantiles return",
+            msg_return_dict="list",
         )  # type: ignore
         assert valid, msg
 
@@ -117,6 +118,7 @@ class TestAllRegressors(PackageConfig, BaseFixtureGenerator, QuickTester):
             scitype="Proba",
             return_metadata=True,
             var_name="predict_interval return",
+            msg_return_dict="list",
         )  # type: ignore
         assert valid, msg
 


### PR DESCRIPTION
This PR brings the datatypes checkers to the same input/output format as https://github.com/sktime/sktime/pull/5510.

Main changes:

* `check_is_mtype` gets an option to return multiple error messages in same format as `check_is_scitype`, with a deprecation for this as the default if multiple `mtypes` to check against are passed.
* added `check_is_error_msg` for streamlined generation of input check error messages
* placeholder error message in `BaseRegressorProba` is replaced by `check_is_error_msg` return

This also introduces deprecation warnings for 2.3.0.


