### PR TITLE
[ENH] adapter from `scipy` `rv_discrete` to `skpro` `Empirical`

### DIFF
--- a/skpro/distributions/adapters/__init__.py
+++ b/skpro/distributions/adapters/__init__.py
@@ -1,0 +1,2 @@
+"""Adapters for probability distribution objects."""
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)

--- a/skpro/distributions/adapters/scipy/__init__.py
+++ b/skpro/distributions/adapters/scipy/__init__.py
@@ -1,2 +1,6 @@
 """Adapters for probability distribution objects, scipy facing."""
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+
+from skpro.distributions.adapters.scipy._empirical import empirical_from_discrete
+
+__all__ = ["empirical_from_discrete"]

--- a/skpro/distributions/adapters/scipy/__init__.py
+++ b/skpro/distributions/adapters/scipy/__init__.py
@@ -1,0 +1,2 @@
+"""Adapters for probability distribution objects, scipy facing."""
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)

--- a/skpro/distributions/adapters/scipy/_empirical.py
+++ b/skpro/distributions/adapters/scipy/_empirical.py
@@ -1,0 +1,46 @@
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+"""Empirical distribution."""
+
+__author__ = ["fkiraly"]
+
+import numpy as np
+import pandas as pd
+
+
+def empirical_from_discrete(dist, index=None, columns=None):
+    """Converts a list of scipy discrete distributions to an skpro empirical.
+
+    Parameters
+    ----------
+    dist : list of rv_discrete
+        List of scipy discrete distributions, instances of rv_discrete.
+    index : pd.Index or coercible, optional
+        Index of the resulting empirical distribution.
+        Must be the same length as dist.
+    columns : pd.Index or coercible, optional
+        Columns of the resulting empirical distribution.
+        Must be of length 1.
+    """
+    from skpro.distributions.empirical import Empirical
+
+    if index is None:
+        index = pd.RangeIndex(len(dist))
+
+    xks = [d.xk for d in dist]
+    pks = [d.pk for d in dist]
+
+    lens = [len(xk) for xk in xks]
+    idxs_inst = [np.repeat(index[i], leni) for i, leni in enumerate(lens)]
+    idx_inst_flat = np.concatenate(idxs_inst)
+    idx_spl = [np.arange(leni) for leni in lens]
+    idx_spl_flat = np.concatenate(idx_spl)
+
+    idx_mult = pd.MultiIndex.from_arrays([idx_spl_flat, idx_inst_flat])
+
+    spl = pd.DataFrame(np.concatenate(xks), index=idx_mult, columns=columns)
+    weights = pd.Series(np.concatenate(pks), index=idx_mult)
+
+    emp = Empirical(
+        spl=spl, weights=weights, time_indep=True, index=index, columns=columns
+    )
+    return emp

--- a/skpro/distributions/adapters/scipy/_empirical.py
+++ b/skpro/distributions/adapters/scipy/_empirical.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 
 def empirical_from_discrete(dist, index=None, columns=None):
-    """Converts a list of scipy discrete distributions to an skpro empirical.
+    """Convert a list of scipy discrete distributions to an skpro Empirical object.
 
     Parameters
     ----------

--- a/skpro/distributions/adapters/scipy/tests/__init__.py
+++ b/skpro/distributions/adapters/scipy/tests/__init__.py
@@ -1,0 +1,2 @@
+"""Tests for adapters for probability distribution objects, scipy facing."""
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)

--- a/skpro/distributions/adapters/scipy/tests/test_scipy_adapters.py
+++ b/skpro/distributions/adapters/scipy/tests/test_scipy_adapters.py
@@ -1,0 +1,42 @@
+"""Tests for adapters for probability distribution objects, scipy facing."""
+
+import numpy as np
+import pandas as pd
+
+
+def test_empirical_from_discrete():
+    """Test empirical_from_discrete."""
+    from scipy.stats import rv_discrete
+
+    from skpro.distributions.adapters.scipy._empirical import empirical_from_discrete
+
+    xk = np.arange(7)
+    pk = (0.1, 0.2, 0.3, 0.1, 0.1, 0.0, 0.2)
+    pk2 = (0.1, 0.1, 0.4, 0.0, 0.1, 0.2, 0.1)
+
+    dist1 = rv_discrete(name='custm', values=(xk, pk))
+    dist2 = rv_discrete(name='custm', values=(xk, pk2))
+
+    emp = empirical_from_discrete([dist1, dist2])
+    assert isinstance(emp.spl, pd.DataFrame)
+    assert isinstance(emp.weights, pd.Series)
+    assert emp.spl.shape == (14, 1)
+    assert emp.weights.shape == (14,)
+    expected_idx = pd.MultiIndex.from_arrays(
+        [[0, 1, 2, 3, 4, 5, 6] * 2, [0] * 7 + [1] * 7]
+    )
+    assert np.all(emp.spl.index == expected_idx)
+    assert np.all(emp.spl.columns == [0])
+
+    emp2 = empirical_from_discrete(
+        [dist1, dist2], index=pd.Index(["foo", "bar"]), columns=["abc"]
+    )
+    assert isinstance(emp2.spl, pd.DataFrame)
+    assert isinstance(emp2.weights, pd.Series)
+    assert emp2.spl.shape == (14, 1)
+    assert emp2.weights.shape == (14,)
+    expected_idx = pd.MultiIndex.from_arrays(
+        [[0, 1, 2, 3, 4, 5, 6] * 2, ["foo"] * 7 + ["bar"] * 7]
+    )
+    assert np.all(emp2.spl.index == expected_idx)
+    assert np.all(emp2.spl.columns == ["abc"])

--- a/skpro/distributions/adapters/scipy/tests/test_scipy_adapters.py
+++ b/skpro/distributions/adapters/scipy/tests/test_scipy_adapters.py
@@ -14,8 +14,8 @@ def test_empirical_from_discrete():
     pk = (0.1, 0.2, 0.3, 0.1, 0.1, 0.0, 0.2)
     pk2 = (0.1, 0.1, 0.4, 0.0, 0.1, 0.2, 0.1)
 
-    dist1 = rv_discrete(name='custm', values=(xk, pk))
-    dist2 = rv_discrete(name='custm', values=(xk, pk2))
+    dist1 = rv_discrete(name="custm", values=(xk, pk))
+    dist2 = rv_discrete(name="custm", values=(xk, pk2))
 
     emp = empirical_from_discrete([dist1, dist2])
     assert isinstance(emp.spl, pd.DataFrame)

--- a/skpro/distributions/empirical.py
+++ b/skpro/distributions/empirical.py
@@ -16,12 +16,12 @@ class Empirical(BaseDistribution):
     ----------
     spl : pd.DataFrame with pd.MultiIndex
         empirical sample
-        last (highest) index is time, first (lowest) index is sample
+        last (highest) index is instance, first (lowest) index is sample
     weights : pd.Series, with same index and length as spl, optional, default=None
         if not passed, ``spl`` is assumed to be unweighted
     time_indep : bool, optional, default=True
-        if True, ``sample`` will sample individual time indices independently
-        if False, ``sample`` will sample etire instances from ``spl``
+        if True, ``sample`` will sample individual instance indices independently
+        if False, ``sample`` will sample entire instances from ``spl``
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
 
@@ -79,7 +79,6 @@ class Empirical(BaseDistribution):
 
         sorted = {}
         weights = {}
-        weights
         for t in times:
             sorted[t] = {}
             weights[t] = {}


### PR DESCRIPTION
This PR adds an adapter from lists of `scipy` `rv_discrete` to `skpro` `Empirical`.

This adapter will be useful in interfacing `statsmodels` models that return lists of discrete `rv_discrete` distributions to represent tabular distribution objects.

Also makes minor corrections to the `Empirical` docstring, and removes a stray line.