### PR TITLE
[ENH] clean up copy-paste leftovers in `BaseProbaRegressor`

### DIFF
--- a/skpro/regression/base/_base.py
+++ b/skpro/regression/base/_base.py
@@ -185,16 +185,6 @@ class BaseProbaRegressor(BaseEstimator):
         X = self._check_X(X)
 
         y_pred = self._predict_proba(X)
-
-        # output conversion
-        y_pred = convert(
-            y_pred,
-            from_type=self.get_tag("X_inner_mtype"),
-            to_type=self._X_input_mtype,
-            as_scitype="Table",
-            store=self._y_converter_store,
-        )
-
         return y_pred
 
     def _predict_proba(self, X):

--- a/skpro/regression/base/_base.py
+++ b/skpro/regression/base/_base.py
@@ -30,7 +30,6 @@ class BaseProbaRegressor(BaseEstimator):
     }
 
     def __init__(self):
-
         super().__init__()
         _check_estimator_deps(self)
 

--- a/skpro/regression/base/_base.py
+++ b/skpro/regression/base/_base.py
@@ -29,14 +29,13 @@ class BaseProbaRegressor(BaseEstimator):
         "y_inner_mtype": "pd_DataFrame_Table",
     }
 
-    def __init__(self, index=None, columns=None):
-        self.index = index
-        self.columns = columns
+    def __init__(self):
 
         super().__init__()
         _check_estimator_deps(self)
 
         self._X_converter_store = {}
+        self._y_converter_store = {}
 
     def __rmul__(self, other):
         """Magic * method, return (left) concatenated Pipeline.
@@ -193,7 +192,7 @@ class BaseProbaRegressor(BaseEstimator):
             from_type=self.get_tag("X_inner_mtype"),
             to_type=self._X_input_mtype,
             as_scitype="Table",
-            store=self._X_converter_store,
+            store=self._y_converter_store,
         )
 
         return y_pred
@@ -639,6 +638,7 @@ class BaseProbaRegressor(BaseEstimator):
             from_type=metadata["mtype"],
             to_type=y_inner_mtype,
             as_scitype="Table",
+            store=self._y_converter_store,
         )
 
         return y, metadata


### PR DESCRIPTION
This PR cleans up some copy-paste leftovers in `BaseProbaRegressor` that could have led to bugs:

* stray `index`, `columns` argument, these are not used and likely copy-paste artefacts from `BaseDistribution`
* there was a superfluous convert in `predict_proba` - this could have led to errors, but did not, as it defaulted to the identity transform
* minor refactor - made checker functions pure, `self` write moved to `fit`