### PR TITLE
[ENH] scitype inference utility, test class register, test class test condition

### DIFF
--- a/skpro/registry/__init__.py
+++ b/skpro/registry/__init__.py
@@ -1,6 +1,7 @@
 """Registry and lookup functionality."""
 
 from skpro.registry._lookup import all_objects, all_tags
+from skpro.registry._scitype import scitype
 from skpro.registry._tags import (
     OBJECT_TAG_LIST,
     OBJECT_TAG_REGISTER,
@@ -13,4 +14,5 @@ __all__ = [
     "all_objects",
     "all_tags",
     "check_tag_is_valid",
+    "scitype",
 ]

--- a/skpro/registry/_scitype.py
+++ b/skpro/registry/_scitype.py
@@ -1,0 +1,69 @@
+"""Utility to determine scitype of estimator, based on base class type."""
+
+__author__ = ["fkiraly"]
+
+from inspect import isclass
+
+from sktime.registry._base_classes import BASE_CLASS_REGISTER
+
+
+def scitype(obj, force_single_scitype=True, coerce_to_list=False):
+    """Determine scitype string of obj.
+
+    Parameters
+    ----------
+    obj : class or object inheriting from sktime BaseObject
+    force_single_scitype : bool, optional, default = True
+        whether only a single scitype is returned
+        if True, only the *first* scitype found will be returned
+        order is determined by the order in BASE_CLASS_REGISTER
+    coerce_to_list : bool, optional, default = False
+        whether return should be coerced to list, even if only one scitype is identified
+
+    Returns
+    -------
+    scitype : str, or list of str of sktime scitype strings from BASE_CLASS_REGISTER
+        str, sktime scitype string, if exactly one scitype can be determined for obj
+            or force_single_scitype is True, and if coerce_to_list is False
+        list of str, of scitype strings, if more than one scitype are determined,
+            or if coerce_to_list is True
+        obj has scitype if it inherits from class in same row of BASE_CLASS_REGISTER
+
+    Raises
+    ------
+    TypeError if no scitype can be determined for obj
+    """
+    # if object has tag, return tag
+    if hasattr(obj, "get_tag"):
+        if isclass(obj):
+            tag_type = obj.get_class_tag("object_type", None)
+        else:
+            tag_type = obj.get_tag("object_type", None, raise_error=False)
+        if tag_type is not None:
+            if coerce_to_list and not isinstance(tag_type, list):
+                return [tag_type]
+            else:
+                return tag_type
+
+    # if the tag is not present, determine scitype from legacy base class logic
+    if isclass(obj):
+        scitypes = [sci[0] for sci in BASE_CLASS_REGISTER if issubclass(obj, sci[1])]
+    else:
+        scitypes = [sci[0] for sci in BASE_CLASS_REGISTER if isinstance(obj, sci[1])]
+
+    if len(scitypes) == 0:
+        raise TypeError("Error, no scitype could be determined for obj")
+
+    if len(scitypes) > 1 and "object" in scitypes:
+        scitypes = list(set(scitypes).difference(["object"]))
+
+    if len(scitypes) > 1 and "estimator" in scitypes:
+        scitypes = list(set(scitypes).difference(["estimator"]))
+
+    if force_single_scitype:
+        scitypes = [scitypes[0]]
+
+    if len(scitypes) == 1 and not coerce_to_list:
+        return scitypes[0]
+
+    return scitypes

--- a/skpro/registry/_scitype.py
+++ b/skpro/registry/_scitype.py
@@ -4,8 +4,6 @@ __author__ = ["fkiraly"]
 
 from inspect import isclass
 
-from sktime.registry._base_classes import BASE_CLASS_REGISTER
-
 
 def scitype(obj, force_single_scitype=True, coerce_to_list=False):
     """Determine scitype string of obj.
@@ -41,29 +39,19 @@ def scitype(obj, force_single_scitype=True, coerce_to_list=False):
             tag_type = obj.get_tag("object_type", None, raise_error=False)
         if tag_type is not None:
             if coerce_to_list and not isinstance(tag_type, list):
-                return [tag_type]
+                scitypes = [tag_type]
             else:
-                return tag_type
-
-    # if the tag is not present, determine scitype from legacy base class logic
-    if isclass(obj):
-        scitypes = [sci[0] for sci in BASE_CLASS_REGISTER if issubclass(obj, sci[1])]
+                scitypes = tag_type
     else:
-        scitypes = [sci[0] for sci in BASE_CLASS_REGISTER if isinstance(obj, sci[1])]
+        scitypes = ["object"]
 
-    if len(scitypes) == 0:
+    if isinstance(scitypes, list) and len(scitypes) == 0:
         raise TypeError("Error, no scitype could be determined for obj")
 
-    if len(scitypes) > 1 and "object" in scitypes:
-        scitypes = list(set(scitypes).difference(["object"]))
-
-    if len(scitypes) > 1 and "estimator" in scitypes:
-        scitypes = list(set(scitypes).difference(["estimator"]))
-
-    if force_single_scitype:
+    if isinstance(scitypes, list) and force_single_scitype:
         scitypes = [scitypes[0]]
 
-    if len(scitypes) == 1 and not coerce_to_list:
+    if isinstance(scitypes, list) and len(scitypes) == 1 and not coerce_to_list:
         return scitypes[0]
 
     return scitypes

--- a/skpro/registry/tests/test_scitype.py
+++ b/skpro/registry/tests/test_scitype.py
@@ -1,0 +1,38 @@
+"""Tests for scitype typing function."""
+
+import pytest
+
+from skpro.registry._scitype import scitype
+
+
+@pytest.mark.parametrize("coerce_to_list", [True, False])
+def test_scitype(coerce_to_list):
+    """Test that the scitype function recovers the correct scitype(s)."""
+    from skpro.distributions.laplace import Laplace
+    from skpro.regression.mapie import MapieRegressor
+    from skpro.regression.residual import ResidualDouble
+
+    # test that scitype works for classes with soft dependencies
+    result_mapie = scitype(MapieRegressor, coerce_to_list=coerce_to_list)
+    if coerce_to_list:
+        assert isinstance(result_mapie, list)
+        assert "regressor_proba" == result_mapie[0]
+    else:
+        assert "regressor_proba" == result_mapie
+
+    # test that scitype works for instances
+    inst = ResidualDouble.create_test_instance()
+    result_naive = scitype(inst, coerce_to_list=coerce_to_list)
+    if coerce_to_list:
+        assert isinstance(result_naive, list)
+        assert "regressor_proba" == result_naive[0]
+    else:
+        assert "regressor_proba" == result_naive
+
+    # test distribution object
+    result_transformer = scitype(Laplace, coerce_to_list=coerce_to_list)
+    if coerce_to_list:
+        assert isinstance(result_transformer, list)
+        assert "distribution" == result_transformer[0]
+    else:
+        assert "distribution" == result_transformer

--- a/skpro/tests/test_class_register.py
+++ b/skpro/tests/test_class_register.py
@@ -1,0 +1,96 @@
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+"""Registry and dispatcher for test classes.
+
+Module does not contain tests, only test utilities.
+"""
+
+__author__ = ["fkiraly"]
+
+from inspect import isclass
+
+
+def get_test_class_registry():
+    """Return test class registry.
+
+    Wrapped in a function to avoid circular imports.
+
+    Returns
+    -------
+    testclass_dict : dict
+        test class registry
+        keys are scitypes, values are test classes TestAll[Scitype]
+    """
+    from skpro.distributions.tests.test_all_distrs import TestAllDistributions
+    from skpro.regression.tests.test_all_regressors import TestAllRegressors
+    from skpro.tests.test_all_estimators import TestAllEstimators, TestAllObjects
+
+    testclass_dict = dict()
+    # every object in sktime inherits from BaseObject
+    # "object" tests are run for all objects
+    testclass_dict["object"] = TestAllObjects
+    # fittable objects inherit from BaseEstimator
+    # "estimator" tests are run for all estimators
+    # estimators are also objects
+    testclass_dict["estimator"] = TestAllEstimators
+    # more specific base classes
+    # these inherit either from BaseEstimator or BaseObject,
+    # so also imply estimator and object tests, or only object tests
+    testclass_dict["distribution"] = TestAllDistributions
+    testclass_dict["regressor_proba"] = TestAllRegressors
+
+    return testclass_dict
+
+
+def get_test_classes_for_obj(obj):
+    """Get all test classes relevant for an object or estimator.
+
+    Parameters
+    ----------
+    obj : object or estimator, descendant of sktime BaseObject or BaseEstimator
+        object or estimator for which to get test classes
+
+    Returns
+    -------
+    test_classes : list of test classes
+        list of test classes relevant for obj
+        these are references to the actual classes, not strings
+        if obj was not a descendant of BaseObject or BaseEstimator, returns empty list
+    """
+    from skpro.base import BaseEstimator, BaseObject
+    from skpro.registry import scitype
+
+    def is_object(obj):
+        """Return whether obj is an estimator class or estimator object."""
+        if isclass(obj):
+            return issubclass(obj, BaseObject)
+        else:
+            return isinstance(obj, BaseObject)
+
+    def is_estimator(obj):
+        """Return whether obj is an estimator class or estimator object."""
+        if isclass(obj):
+            return issubclass(obj, BaseEstimator)
+        else:
+            return isinstance(obj, BaseEstimator)
+
+    if not is_object(obj):
+        return []
+
+    testclass_dict = get_test_class_registry()
+
+    # we always need to run "object" tests
+    test_clss = [testclass_dict["object"]]
+
+    if is_estimator(obj):
+        test_clss += [testclass_dict["estimator"]]
+
+    try:
+        obj_scitypes = scitype(obj, force_single_scitype=False, coerce_to_list=True)
+    except Exception:
+        obj_scitypes = []
+
+    for obj_scitype in obj_scitypes:
+        if obj_scitype in testclass_dict:
+            test_clss += [testclass_dict[obj_scitype]]
+
+    return test_clss

--- a/skpro/tests/test_class_register.py
+++ b/skpro/tests/test_class_register.py
@@ -73,7 +73,9 @@ def get_test_classes_for_obj(obj):
         else:
             return isinstance(obj, BaseEstimator)
 
-    if not is_object(obj):
+    # warning: BaseEstimator does not inherit from BaseObject,
+    # therefore we need to check both
+    if not is_object(obj) and not is_estimator(obj):
         return []
 
     testclass_dict = get_test_class_registry()

--- a/skpro/tests/test_switch.py
+++ b/skpro/tests/test_switch.py
@@ -59,7 +59,7 @@ def run_test_for_class(cls):
         else:
             return True
 
-    def _is_class_changed_or_sktime_parents(cls):
+    def _is_class_changed_or_parents(cls):
         """Check if class or any of its sktime parents have changed, return bool."""
         # if cls is a function, not a class, default to is_class_changed
         if not isclass(cls):
@@ -67,14 +67,14 @@ def run_test_for_class(cls):
 
         # now we know cls is a class, so has an mro
         cls_and_parents = getmro(cls)
-        cls_and_sktime_parents = [
+        cls_and_parents = [
             x for x in cls_and_parents if x.__module__.startswith("sktime")
         ]
-        return any(is_class_changed(x) for x in cls_and_sktime_parents)
+        return any(is_class_changed(x) for x in cls_and_parents)
 
     def _tests_covering_class_changed(cls):
         """Check if any of the tests covering cls have changed, return bool."""
-        from sktime.tests.test_class_register import get_test_classes_for_obj
+        from skpro.tests.test_class_register import get_test_classes_for_obj
 
         test_classes = get_test_classes_for_obj(cls)
         return any(is_class_changed(x) for x in test_classes)
@@ -89,7 +89,7 @@ def run_test_for_class(cls):
     # if ONLY_CHANGED_MODULES is on, run the test if and only if
     # any of the modules containing any of the classes in the list have changed
     if ONLY_CHANGED_MODULES:
-        cond2 = any(_is_class_changed_or_sktime_parents(x) for x in cls)
+        cond2 = any(_is_class_changed_or_parents(x) for x in cls)
     else:
         cond2 = True
 

--- a/skpro/tests/test_switch.py
+++ b/skpro/tests/test_switch.py
@@ -14,17 +14,26 @@ def run_test_for_class(cls):
 
     1. whether all required soft dependencies are present.
        If not, does not run the test.
-    2. If yes:
-      * if ONLY_CHANGED_MODULES setting is on, runs the test if and only
+       If yes, runs the test if and only if
+       at least one of conditions 2, 3 below are met.
+
+    2. Condition 2:
+
+      * if ONLY_CHANGED_MODULES setting is on, condition 2 is met if and only
       if the module containing the class/func has changed according to is_class_changed
-      * if ONLY_CHANGED_MODULES if off, always runs the test if all soft dependencies
-      are present.
+      * if ONLY_CHANGED_MODULES if off, condition 2 is always met.
+
+    3. Condition 3:
+
+      If the object is an sktime BaseObject, and one of the test classes
+      covering the class have changed, then condition 3 is met.
 
     cls can also be a list of classes or functions,
     in this case the test is run if and only if:
 
     * all required soft dependencies are present
-    * if yes, if any of the estimators in the list should be tested by criterion 2 above
+    * if yes, if any of the estimators in the list should be tested by
+      criterion 2 or 3 above
 
     Parameters
     ----------
@@ -50,28 +59,44 @@ def run_test_for_class(cls):
         else:
             return True
 
-    def _is_class_changed_or_parents(cls):
-        """Check if class or any of its parents have changed, return bool."""
+    def _is_class_changed_or_sktime_parents(cls):
+        """Check if class or any of its sktime parents have changed, return bool."""
         # if cls is a function, not a class, default to is_class_changed
         if not isclass(cls):
             return is_class_changed(cls)
 
         # now we know cls is a class, so has an mro
         cls_and_parents = getmro(cls)
-        cls_and_parents = [
-            x for x in cls_and_parents if x.__module__.startswith("skpro")
+        cls_and_sktime_parents = [
+            x for x in cls_and_parents if x.__module__.startswith("sktime")
         ]
-        return any(is_class_changed(x) for x in cls_and_parents)
+        return any(is_class_changed(x) for x in cls_and_sktime_parents)
 
+    def _tests_covering_class_changed(cls):
+        """Check if any of the tests covering cls have changed, return bool."""
+        from sktime.tests.test_class_register import get_test_classes_for_obj
+
+        test_classes = get_test_classes_for_obj(cls)
+        return any(is_class_changed(x) for x in test_classes)
+
+    # Condition 1:
     # if any of the required soft dependencies are not present, do not run the test
     if not all(_required_deps_present(x) for x in cls):
         return False
+    # otherwise, continue
 
+    # Condition 2:
     # if ONLY_CHANGED_MODULES is on, run the test if and only if
     # any of the modules containing any of the classes in the list have changed
     if ONLY_CHANGED_MODULES:
-        return any(_is_class_changed_or_parents(x) for x in cls)
+        cond2 = any(_is_class_changed_or_sktime_parents(x) for x in cls)
+    else:
+        cond2 = True
 
-    # otherwise
-    # i.e., dependencies are present, and differential testing is disabled
-    return True
+    # Condition 3:
+    # if the object is an sktime BaseObject, and one of the test classes
+    # covering the class have changed, then run the test
+    cond3 = any(_tests_covering_class_changed(x) for x in cls)
+
+    # run the test if and only if at least one of the conditions 2, 3 are met
+    return cond2 or cond3

--- a/skpro/utils/estimator_checks.py
+++ b/skpro/utils/estimator_checks.py
@@ -3,8 +3,6 @@
 __author__ = ["fkiraly"]
 __all__ = ["check_estimator"]
 
-from inspect import isclass
-
 from skpro.utils.validation._dependencies import _check_soft_dependencies
 
 
@@ -109,60 +107,22 @@ def check_estimator(
     )
     _check_soft_dependencies("pytest", msg=msg)
 
-    from skpro.base import BaseEstimator
-    from skpro.distributions.tests.test_all_distrs import TestAllDistributions
-    from skpro.regression.tests.test_all_regressors import TestAllRegressors
-    from skpro.tests.test_all_estimators import TestAllEstimators, TestAllObjects
+    from skpro.tests.test_class_register import get_test_classes_for_obj
 
-    testclass_dict = dict()
+    test_clss_for_est = get_test_classes_for_obj(estimator)
 
-    testclass_dict["regressor_proba"] = TestAllRegressors
-    testclass_dict["distribution"] = TestAllDistributions
+    results = {}
 
-    results = TestAllObjects().run_tests(
-        obj=estimator,
-        raise_exceptions=raise_exceptions,
-        tests_to_run=tests_to_run,
-        fixtures_to_run=fixtures_to_run,
-        tests_to_exclude=tests_to_exclude,
-        fixtures_to_exclude=fixtures_to_exclude,
-    )
-
-    def is_estimator(obj):
-        """Return whether obj is an estimator class or estimator object."""
-        if isclass(obj):
-            return issubclass(obj, BaseEstimator)
-        else:
-            return isinstance(obj, BaseEstimator)
-
-    if is_estimator(estimator):
-        results_estimator = TestAllEstimators().run_tests(
-            obj=estimator,
+    for test_cls in test_clss_for_est:
+        test_cls_results = test_cls().run_tests(
+            estimator=estimator,
             raise_exceptions=raise_exceptions,
             tests_to_run=tests_to_run,
             fixtures_to_run=fixtures_to_run,
             tests_to_exclude=tests_to_exclude,
             fixtures_to_exclude=fixtures_to_exclude,
         )
-        results.update(results_estimator)
-
-    if isclass(estimator) and hasattr(estimator, "get_class_tag"):
-        scitype_of_estimator = estimator.get_class_tag("object_type", "object")
-    elif hasattr(estimator, "get_tag"):
-        scitype_of_estimator = estimator.get_tag("object_type", "object")
-    else:
-        scitype_of_estimator = ""
-
-    if scitype_of_estimator in testclass_dict.keys():
-        results_scitype = testclass_dict[scitype_of_estimator]().run_tests(
-            obj=estimator,
-            raise_exceptions=raise_exceptions,
-            tests_to_run=tests_to_run,
-            fixtures_to_run=fixtures_to_run,
-            tests_to_exclude=tests_to_exclude,
-            fixtures_to_exclude=fixtures_to_exclude,
-        )
-        results.update(results_scitype)
+        results.update(test_cls_results)
 
     failed_tests = [key for key in results.keys() if results[key] != "PASSED"]
     if len(failed_tests) > 0:

--- a/skpro/utils/estimator_checks.py
+++ b/skpro/utils/estimator_checks.py
@@ -115,7 +115,7 @@ def check_estimator(
 
     for test_cls in test_clss_for_est:
         test_cls_results = test_cls().run_tests(
-            estimator=estimator,
+            obj=estimator,
             raise_exceptions=raise_exceptions,
             tests_to_run=tests_to_run,
             fixtures_to_run=fixtures_to_run,


### PR DESCRIPTION
This PR brings registries and test logic on par with `sktime` state:

* `scitype` inference utility, can be used to coerce tag to single string
* test class registry, accessible via `get_test_classes_for_obj`
* `check_estimator` is refactored using the above
* `run_test_for_class` is updated with a condition that estimators are always tested if any covering test class changes