### PR TITLE
[ENH] adding `codecov.yml` and turning coverage reports informational

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,0 +1,29 @@
+# paths to ignore
+ignore:
+  - "docs/**/*"
+  - "build_tools/**/*"
+  - "examples/*"
+  - ".github/*"
+  - ".binder/*"
+  - "extension_templates/*"
+  - "*.md"
+  - "*.yml"
+  - "*.yaml"
+
+# PR status check
+coverage:
+  status:
+    project:
+      default:
+        # threshold: 1%
+        informational: true
+    patch:
+      default:
+        informational: true
+
+# post coverage report as comment on PR
+comment: false
+
+# enable codecov to report to GitHub status checks
+github_checks:
+  annotations: false


### PR DESCRIPTION
Partially addresses https://github.com/sktime/skpro/issues/164 by adding a `codecov.yml` that ensures CI does not fail on low CI.

This is not fully satisfactory, but takes into account that repoted coverage underestimates actual, due to incremental testing.