### PR TITLE
[ENH] allow `scikit-base` 0.7.X

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "numpy>=1.21.0,<1.27",
     "pandas>=1.1.0,<2.2.0",
     "packaging",
-    "scikit-base>=0.6.1,<0.7.0",
+    "scikit-base>=0.6.1,<0.8.0",
     "scikit-learn>=0.24.0,<1.4.0",
     "scipy<2.0.0,>=1.2.0",
 ]


### PR DESCRIPTION
This allows `scikit-base` 0.7.X in `pyproject`, and therefore fixes issues with `deep_equals` or `set_config`.