### PR TITLE
[ENH] add tags to `SklearnProbaReg`

### DIFF
--- a/skpro/regression/adapters/sklearn/_sklearn_proba.py
+++ b/skpro/regression/adapters/sklearn/_sklearn_proba.py
@@ -25,7 +25,10 @@ class SklearnProbaReg(BaseProbaRegressor):
         Estimator to wrap, must have ``predict`` with ``return_std`` argument.
     """
 
-    _tags = {}
+    _tags = {
+        "capability:multioutput": False,
+        "capability:missing": True,
+    }
 
     def __init__(self, estimator):
         self.estimator = estimator


### PR DESCRIPTION
This PR adds tags in `SklearnProbaReg`, otherwise one of the tests complains.

Should not matter due to inheritance, and odd that it did not complain when merged.