### PR TITLE
[MNT] handle deprecation of `pandas.DataFrame.applymap`

### DIFF
--- a/skpro/distributions/base.py
+++ b/skpro/distributions/base.py
@@ -271,8 +271,6 @@ class BaseDistribution(BaseObject):
             )
             warn(self._method_error_msg("log_pdf", fill_in=approx_method))
 
-            pdf_res = self.pdf(x=x)
-
             return df_map(self.pdf(x=x))(np.log)
 
         raise NotImplementedError(self._method_error_msg("log_pdf", "error"))

--- a/skpro/distributions/base.py
+++ b/skpro/distributions/base.py
@@ -11,6 +11,7 @@ import numpy as np
 import pandas as pd
 
 from skpro.base import BaseObject
+from skpro.utils.pandas import df_map
 from skpro.utils.validation._dependencies import _check_estimator_deps
 
 
@@ -229,7 +230,8 @@ class BaseDistribution(BaseObject):
                 "this may be numerically unstable"
             )
             warn(self._method_error_msg("pdf", fill_in=approx_method))
-            return self.log_pdf(x=x).applymap(np.exp)
+
+            return df_map(self.log_pdf(x=x))(np.exp)
 
         raise NotImplementedError(self._method_error_msg("pdf", "error"))
 
@@ -270,12 +272,8 @@ class BaseDistribution(BaseObject):
             warn(self._method_error_msg("log_pdf", fill_in=approx_method))
 
             pdf_res = self.pdf(x=x)
-            # safe deprecation of applymap, renamed to map in pandas 2 versions
-            # this if/else ensures compatibility with a wider range of pandas versions
-            if hasattr(pdf_res, "map"):
-                return pdf_res.map(np.log)
-            else:
-                return pdf_res.applymap(np.log)
+
+            return df_map(self.pdf(x=x))(np.log)
 
         raise NotImplementedError(self._method_error_msg("log_pdf", "error"))
 

--- a/skpro/distributions/normal.py
+++ b/skpro/distributions/normal.py
@@ -15,9 +15,9 @@ class Normal(BaseDistribution):
 
     Parameters
     ----------
-    mean : float or array of float (1D or 2D)
+    mu : float or array of float (1D or 2D)
         mean of the normal distribution
-    sd : float or array of float (1D or 2D), must be positive
+    sigma : float or array of float (1D or 2D), must be positive
         standard deviation of the normal distribution
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex

--- a/skpro/utils/pandas.py
+++ b/skpro/utils/pandas.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3 -u
+"""Utilities for pandas adapbation."""
+
+__author__ = ["fkiraly"]
+
+
+def df_map(x):
+    """Access map or applymap, of DataFrame.
+
+    In pandas 2.1.0, applymap was deprecated in favor of the newly introduced map.
+    To ensure compatibility with older versions, we use map if available,
+    otherwise applymap.
+
+    Parameters
+    ----------
+    x : assumed pd.DataFrame
+
+    Returns
+    -------
+    x.map, if available, otherwise x.applymap
+        Note: returns method itself, not result of method call
+    """
+    if hasattr(x, "map"):
+        return x.map
+    else:
+        return x.applymap


### PR DESCRIPTION
This PR handles deprecation of `DataFrame.applymap`, by replacing instances with a version-conditional call.

Additionally, also fixes a minor, unrelated docstring typo.