### PR TITLE
[MNT] handle `polars` deprecations

### DIFF
--- a/skpro/datatypes/_adapter/polars.py
+++ b/skpro/datatypes/_adapter/polars.py
@@ -42,7 +42,7 @@ def check_polars_frame(obj, return_metadata=False, var_name="obj", lazy=False):
         if isinstance(obj, pl.LazyFrame):
             metadata["has_nans"] = "NA"
         else:
-            hasnan = obj.null_count().sum(axis=1).to_numpy()[0] > 0
+            hasnan = obj.null_count().sum_horizontal().to_numpy()[0] > 0
             metadata["has_nans"] = hasnan
 
     return ret(True, None, metadata, return_metadata)

--- a/skpro/utils/deep_equals/_deep_equals.py
+++ b/skpro/utils/deep_equals/_deep_equals.py
@@ -58,7 +58,7 @@ def deep_equals(x, y, return_msg=False, plugins=None):
             [key] - if dict: value at key is not equal
             [colname] - if pandas.DataFrame: column with name colname is not equal
             != - call to generic != returns False
-            .polars_equals - .frame_equal of polars returns False
+            .polars_equals - .equals of polars returns False
     """
     # call deep_equals_custom with default plugins
     plugins_default = [
@@ -89,10 +89,10 @@ def _polars_equals_plugin(x, y, return_msg=False):
 
     # compare pl.DataFrame
     if isinstance(x, pl.DataFrame):
-        return ret(x.frame_equal(y), ".polars_equals")
+        return ret(x.equals(y), ".polars_equals")
 
     # compare pl.LazyFrame
     if isinstance(x, pl.LazyFrame):
-        return ret(x.collect().frame_equal(y.collect()), ".polars_equals")
+        return ret(x.collect().equals(y.collect()), ".polars_equals")
 
     return None


### PR DESCRIPTION
Handles deprecations from `polars`:

* `sum(axis=1)` being replaced by `sum_horizontal`
* `frame_equal` being renamed to `equals`