### PR TITLE
[ENH] in `BaseRegressorProba`, use `"feature_names"` metadata field to store feature names

### DIFF
--- a/skpro/regression/base/_base.py
+++ b/skpro/regression/base/_base.py
@@ -611,6 +611,8 @@ class BaseProbaRegressor(BaseEstimator):
         )
         # shorthands for metadata used below
         X_feature_names = X_metadata["feature_names"]
+        if not isinstance(X_feature_names, np.ndarray):
+            X_feature_names = np.array(X_feature_names)
 
         # update with clearer message
         if not valid:

--- a/skpro/regression/base/_base.py
+++ b/skpro/regression/base/_base.py
@@ -575,9 +575,9 @@ class BaseProbaRegressor(BaseEstimator):
 
     def _check_X(self, X, return_metadata=False):
         if return_metadata:
-            req_metadata = ["n_instances"]
+            req_metadata = ["n_instances", "feature_names"]
         else:
-            req_metadata = []
+            req_metadata = ["feature_names"]
         # input validity check for X
         valid, msg, metadata = check_is_mtype(
             X,
@@ -612,7 +612,7 @@ class BaseProbaRegressor(BaseEstimator):
                 )
         # if not, remember columns
         else:
-            self._X_columns = X.columns
+            self._X_columns = metadata["feature_names"]
 
         if return_metadata:
             return X, metadata


### PR DESCRIPTION
This switches explicit inspection of columns to use the `"feature_names"` metadata field from `datatypes` checks.