### PR TITLE
[ENH] author and maintainer tags, tags documented in regressor extension template

### DIFF
--- a/extension_templates/regression.py
+++ b/extension_templates/regression.py
@@ -40,7 +40,28 @@ class ClassName(BaseProbaRegressor):
     # todo: fill out estimator tags here
     #  tags are inherited from parent class if they are not set
     # tags inherited from base are "safe defaults" which can usually be left as-is
-    _tags = {}
+    _tags = {
+        # packaging info
+        # --------------
+        "authors": ["author1", "author2"],  # authors, GitHub handles
+        "maintainers": ["maintainer1", "maintainer2"],  # maintainers, GitHub handles
+        # author = significant contribution to code at some point
+        # maintainer = algorithm maintainer role, "owner"
+        # specify one or multiple authors and maintainers, only for skpro contribution
+        # remove maintainer tag if maintained by skpro/sktim core team
+        #
+        "python_version": None,  # PEP 440 python version specifier to limit versions
+        "python_dependencies": None,  # PEP 440 python dependencies specifier,
+        # e.g., "numba>0.53", or a list, e.g., ["numba>0.53", "numpy>=1.19.0"]
+        # delete if no python dependencies or version limitations
+        #
+        # estimator tags
+        # --------------
+        "capability:multioutput": False,  # can the estimator handle multi-output data?
+        "capability:missing": True,  # can the estimator handle missing data?
+        "X_inner_mtype": "pd_DataFrame_Table",  # type seen in internal _fit, _predict
+        "y_inner_mtype": "pd_DataFrame_Table",  # type seen in internal _fit
+    }
 
     # todo: fill init
     # params should be written to self and never changed

--- a/skpro/base/_base.py
+++ b/skpro/base/_base.py
@@ -10,7 +10,11 @@ class _CommonTags:
     # config common to all estimators
     _config = {}
 
-    _tags = {"estimator_type": "estimator"}
+    _tags = {
+        "estimator_type": "estimator",
+        "authors": "skpro developers",
+        "maintainers": "skpro developers",
+    }
 
     @property
     def name(self):

--- a/skpro/distributions/qpd.py
+++ b/skpro/distributions/qpd.py
@@ -61,10 +61,16 @@ class QPD_S(BaseDistribution):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["setoguchi-naoki", "felix-wick"],
+        "maintainers": ["setoguchi-naoki"],
+        "python_dependencies": "cyclic_boosting>=1.2.5",
+        # estimator tags
+        # --------------
         "capabilities:approx": [],
         "capabilities:exact": ["mean", "var", "cdf", "ppf"],
         "distr:measuretype": "continuous",
-        "python_dependencies": "cyclic_boosting>=1.2.5",
     }
 
     def __init__(
@@ -289,10 +295,16 @@ class QPD_B(BaseDistribution):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["setoguchi-naoki", "felix-wick"],
+        "maintainers": ["setoguchi-naoki"],
+        "python_dependencies": "cyclic_boosting>=1.2.5",
+        # estimator tags
+        # --------------
         "capabilities:approx": [],
         "capabilities:exact": ["mean", "var", "cdf", "ppf"],
         "distr:measuretype": "continuous",
-        "python_dependencies": "cyclic_boosting>=1.2.5",
     }
 
     def __init__(
@@ -518,10 +530,16 @@ class QPD_U(BaseDistribution):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["setoguchi-naoki", "felix-wick"],
+        "maintainers": ["setoguchi-naoki"],
+        "python_dependencies": "cyclic_boosting>=1.2.5",
+        # estimator tags
+        # --------------
         "capabilities:approx": [],
         "capabilities:exact": ["mean", "var", "cdf", "ppf"],
         "distr:measuretype": "continuous",
-        "python_dependencies": "cyclic_boosting>=1.2.5",
     }
 
     def __init__(

--- a/skpro/registry/_tags.py
+++ b/skpro/registry/_tags.py
@@ -61,6 +61,20 @@ OBJECT_TAG_REGISTER = [
         "str",
         "type of estimator, e.g., 'regressor', 'transformer'",
     ),
+    # packaging information
+    # ---------------------
+    (
+        "maintainers",
+        "object",
+        ("list", "str"),
+        "list of current maintainers of the object, each maintainer a GitHub handle",
+    ),
+    (
+        "authors",
+        "object",
+        ("list", "str"),
+        "list of authors of the object, each author a GitHub handle",
+    ),
     (
         "python_version",
         "object",

--- a/skpro/regression/bootstrap.py
+++ b/skpro/regression/bootstrap.py
@@ -67,7 +67,7 @@ class BootstrapRegressor(BaseProbaRegressor):
     >>> y_pred = reg_proba.predict_proba(X_test)
     """
 
-    _tags = {"capability:missing": True}
+    _tags = {"authors": "fkiraly", "capability:missing": True}
 
     def __init__(
         self,

--- a/skpro/regression/cyclic_boosting.py
+++ b/skpro/regression/cyclic_boosting.py
@@ -85,12 +85,18 @@ class CyclicBoosting(BaseProbaRegressor):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["setoguchi-naoki", "felix-wick"],
+        "maintainers": ["setoguchi-naoki"],
         "estimator_type": "regressor_proba",
+        "python_dependencies": "cyclic_boosting>=1.2.5",
+        # estimator tags
+        # --------------
         "capability:multioutput": False,
         "capability:missing": True,
         "X_inner_mtype": "pd_DataFrame_Table",
         "y_inner_mtype": "pd_DataFrame_Table",
-        "python_dependencies": "cyclic_boosting>=1.2.5",
     }
 
     def __init__(

--- a/skpro/regression/mapie.py
+++ b/skpro/regression/mapie.py
@@ -164,8 +164,13 @@ class MapieRegressor(BaseProbaRegressor):
     """
 
     _tags = {
-        "capability:missing": True,
+        # packaging info
+        # --------------
+        "authors": ["fkiraly"],
         "python_dependencies": ["mapie"],
+        # estimator tags
+        # --------------
+        "capability:missing": True,
     }
 
     def __init__(

--- a/skpro/regression/multiquantile.py
+++ b/skpro/regression/multiquantile.py
@@ -96,6 +96,11 @@ class MultipleQuantileRegressor(BaseProbaRegressor):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["ram0nb"],
+        # estimator tags
+        # --------------
         "capability:missing": False,
         "capability:multioutput": False,
     }


### PR DESCRIPTION
This PR:

* adds authors and maintainers tags, bringing the packaging tags on par with `sktime`
    * the tags are also filled for contributed estimators
* documents probabilistic regressor tags in the extension template from regressors. These were missing previously.