### PR TITLE
[MNT] skip `CyclicBoosting` and QPD tests until #189 failures are resolved

### DIFF
--- a/skpro/distributions/tests/test_all_distrs.py
+++ b/skpro/distributions/tests/test_all_distrs.py
@@ -29,11 +29,6 @@ class DistributionFixtureGenerator(BaseFixtureGenerator):
 
     object_type_filter = BaseDistribution
 
-    # TEMPORARY skip for CyclicBoosting and QPD classes
-    # due to silent failures on main, se #190
-    exclude_objects = ["QPD_S", "QPD_B", "QPD_U"]
-    # remove this when fixing failures to re-enable testing
-
 
 def _has_capability(distr, method):
     """Check whether distr has capability of method.
@@ -64,6 +59,11 @@ METHODS_ROWWISE = ["energy"]  # results in one column
 
 class TestAllDistributions(PackageConfig, DistributionFixtureGenerator, QuickTester):
     """Module level tests for all skpro parameter fitters."""
+
+    # TEMPORARY skip for CyclicBoosting and QPD classes
+    # due to silent failures on main, se #190
+    exclude_objects = ["QPD_S", "QPD_B", "QPD_U"]
+    # remove this when fixing failures to re-enable testing
 
     @pytest.mark.parametrize("shuffled", [False, True])
     def test_sample(self, object_instance, shuffled):

--- a/skpro/distributions/tests/test_all_distrs.py
+++ b/skpro/distributions/tests/test_all_distrs.py
@@ -29,6 +29,11 @@ class DistributionFixtureGenerator(BaseFixtureGenerator):
 
     object_type_filter = BaseDistribution
 
+    # TEMPORARY skip for CyclicBoosting and QPD classes
+    # due to silent failures on main, se #190
+    exclude_objects = ["QPD_S", "QPD_B", "QPD_U"]
+    # remove this when fixing failures to re-enable testing
+
 
 def _has_capability(distr, method):
     """Check whether distr has capability of method.

--- a/skpro/regression/tests/test_all_regressors.py
+++ b/skpro/regression/tests/test_all_regressors.py
@@ -22,7 +22,7 @@ class TestAllRegressors(PackageConfig, BaseFixtureGenerator, QuickTester):
 
     # TEMPORARY skip for CyclicBoosting and QPD classes
     # due to silent failures on main, se #190
-    exclude_objects = ["QPD_S", "QPD_B", "QPD_U", "CyclicBoosting"]
+    exclude_objects = ["CyclicBoosting"]
     # remove this when fixing failures to re-enable testing
 
     def test_input_output_contract(self, object_instance):

--- a/skpro/regression/tests/test_all_regressors.py
+++ b/skpro/regression/tests/test_all_regressors.py
@@ -20,6 +20,11 @@ class TestAllRegressors(PackageConfig, BaseFixtureGenerator, QuickTester):
     # which object types are generated; None=all, or class (passed to all_objects)
     object_type_filter = BaseProbaRegressor
 
+    # TEMPORARY skip for CyclicBoosting and QPD classes
+    # due to silent failures on main, se #190
+    exclude_objects = ["QPD_S", "QPD_B", "QPD_U", "CyclicBoosting"]
+    # remove this when fixing failures to re-enable testing
+
     def test_input_output_contract(self, object_instance):
         """Tests that output of predict methods is as specified."""
         import pandas as pd


### PR DESCRIPTION
This PR adds a skip for failures of `CyclicBoosting` and QPD objects on main, until failures in #189 are resolved.

The PR resolving the failures should remove the skips again.