### PR TITLE
[ENH] survival prediction metrics - framework support and tests, SPLL, Harrell C

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -7,7 +7,7 @@ API Reference
 Welcome to the API reference for ``skpro``.
 
 The API reference provides a technical manual.
-It describes the classes and functions included in ``sktime``.
+It describes the classes and functions included in ``skpro``.
 
 .. include:: includes/api_css.rst
 
@@ -17,5 +17,6 @@ It describes the classes and functions included in ``sktime``.
     api_reference/regression
     api_reference/survival
     api_reference/distributions
+    api_reference/metrics
     api_reference/base
     api_reference/utils

--- a/docs/source/api_reference/metrics.rst
+++ b/docs/source/api_reference/metrics.rst
@@ -57,9 +57,6 @@ Survival or time-to-event predictions are a variant of distribution predictions,
 where the ground truth may be censored.
 These metrics take the censoring information into account.
 
-Distribution predictions are also known as conditional distribution predictions.
-(or conditional density predictions, if continuous).
-
 .. currentmodule:: skpro.metrics.survival
 
 .. autosummary::

--- a/docs/source/api_reference/metrics.rst
+++ b/docs/source/api_reference/metrics.rst
@@ -1,11 +1,11 @@
 
-.. _performance_metric_ref:
+.. _metrics_ref:
 
 Performance metrics
 ===================
 
 The :mod:`skpro.metrics` module contains metrics for evaluating
-probabilistic predictions, including survival and time-to-event prediction.s.
+probabilistic predictions, including survival and time-to-event predictions.
 
 All metrics in ``skpro`` can be listed using the ``skpro.registry.all_objects`` utility,
 using ``object_types="metric"``, optionally filtered by tags.

--- a/docs/source/api_reference/metrics.rst
+++ b/docs/source/api_reference/metrics.rst
@@ -1,0 +1,70 @@
+
+.. _performance_metric_ref:
+
+Performance metrics
+===================
+
+The :mod:`skpro.metrics` module contains metrics for evaluating
+probabilistic predictions, including survival and time-to-event prediction.s.
+
+All metrics in ``skpro`` can be listed using the ``skpro.registry.all_objects`` utility,
+using ``object_types="metric"``, optionally filtered by tags.
+Valid tags can be listed using ``sktime.registry.all_tags``.
+
+Survival/time-to-event specific metrics in ``skpro`` can be listed
+by filtering by ``capability:survival`` being ``True``.
+
+All probabilistic metrics can be used for survival
+prediction, by default they will ignore the censoring information.
+Note: this is different from subsetting to uncensored observations.
+
+
+Quantile and interval prediction metrics
+----------------------------------------
+
+.. currentmodule:: skpro.metrics
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class_with_call.rst
+
+    PinballLoss
+    EmpiricalCoverage
+    ConstraintViolation
+
+Distribution prediction metrics
+-------------------------------
+
+Distribution predictions are also known as conditional distribution predictions.
+(or conditional density predictions, if continuous).
+
+.. currentmodule:: skpro.metrics
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class_with_call.rst
+
+    CRPS
+    LogLoss
+    SquaredDistrLoss
+    LinearizedLogLoss
+    SquaredDistrLoss
+
+Survival prediction metrics
+---------------------------
+
+Survival or time-to-event predictions are a variant of distribution predictions,
+where the ground truth may be censored.
+These metrics take the censoring information into account.
+
+Distribution predictions are also known as conditional distribution predictions.
+(or conditional density predictions, if continuous).
+
+.. currentmodule:: skpro.metrics.survival
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class_with_call.rst
+
+    ConcordanceHarrell
+    SPLL

--- a/skpro/distributions/base.py
+++ b/skpro/distributions/base.py
@@ -447,7 +447,8 @@ class BaseDistribution(BaseObject):
 
         # uses formula int p(x)^a dx = E[p(X)^{a-1}], and MC approximates the RHS
         spl = [self.pdf(self.sample()) ** (a - 1) for _ in range(approx_spl_size)]
-        return pd.concat(spl, axis=0).groupby(level=1, sort=False).mean()
+        spl_df = pd.concat(spl, keys=range(approx_spl_size))
+        return spl_df.groupby(level=1, sort=False).mean()
 
     def _coerce_to_self_index_df(self, x):
         x = np.array(x)

--- a/skpro/metrics/__init__.py
+++ b/skpro/metrics/__init__.py
@@ -12,6 +12,7 @@ __all__ = [
     "LogLoss",
     "LinearizedLogLoss",
     "SquaredDistrLoss",
+    "ConcordanceHarrell",
     "SPLL",
 ]
 
@@ -24,4 +25,4 @@ from skpro.metrics._classes import (
     PinballLoss,
     SquaredDistrLoss,
 )
-from skpro.metrics.survival import SPLL
+from skpro.metrics.survival import ConcordanceHarrell, SPLL

--- a/skpro/metrics/__init__.py
+++ b/skpro/metrics/__init__.py
@@ -25,4 +25,4 @@ from skpro.metrics._classes import (
     PinballLoss,
     SquaredDistrLoss,
 )
-from skpro.metrics.survival import ConcordanceHarrell, SPLL
+from skpro.metrics.survival import SPLL, ConcordanceHarrell

--- a/skpro/metrics/__init__.py
+++ b/skpro/metrics/__init__.py
@@ -12,6 +12,7 @@ __all__ = [
     "LogLoss",
     "LinearizedLogLoss",
     "SquaredDistrLoss",
+    "SPLL",
 ]
 
 from skpro.metrics._classes import (
@@ -23,3 +24,4 @@ from skpro.metrics._classes import (
     PinballLoss,
     SquaredDistrLoss,
 )
+from skpro.metrics.survival import SPLL

--- a/skpro/metrics/survival/__init__.py
+++ b/skpro/metrics/survival/__init__.py
@@ -1,0 +1,10 @@
+"""Metrics for time-to-event or survival prediction."""
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+
+__author__ = ["fkiraly"]
+
+__all__ = [
+    "SPLL",
+]
+
+from skpro.metrics.survival._spll import SPLL

--- a/skpro/metrics/survival/__init__.py
+++ b/skpro/metrics/survival/__init__.py
@@ -4,7 +4,9 @@
 __author__ = ["fkiraly"]
 
 __all__ = [
+    "ConcordanceHarrell",
     "SPLL",
 ]
 
+from skpro.metrics.survival._c_harrell import ConcordanceHarrell
 from skpro.metrics.survival._spll import SPLL

--- a/skpro/metrics/survival/_c_harrell.py
+++ b/skpro/metrics/survival/_c_harrell.py
@@ -142,7 +142,7 @@ class ConcordanceHarrell(BaseDistrMetric):
                 comp2 = nCj & (yj < yij)  # comparable, < type
                 conc2 = comp2 & (rj < rij)
 
-                # mark concordnt pairs, handling ties
+                # mark concordant pairs, handling ties
                 conc3 = nCij & nCj & ((yj == yij) & (rj == rij))
                 conc = conc1 | conc2 | conc3
 

--- a/skpro/metrics/survival/_c_harrell.py
+++ b/skpro/metrics/survival/_c_harrell.py
@@ -126,15 +126,15 @@ class ConcordanceHarrell(BaseDistrMetric):
 
         for j in range(y_true.shape[1]):
             yj = y_true[:, j]
-            Cj = C_true[:, j]
-            nCj = 1 - Cj
+            Cj = C_true[:, j] == 1
+            nCj = ~Cj
             rj = risk_scores[:, j]
             for i in range(y_true.shape[0]):
                 yij = yj[i]
                 rij = rj[i]
                 Cij = Cj[i]
-                nCij = 1 - Cij
-                one_unc = 1 - Cj * Cij
+                nCij = ~Cij
+                one_unc = ~(Cj & Cij)
 
                 # mark concordant pairs (no ties)
                 comp1 = nCij & (yj > yij)  # comparable, > type

--- a/skpro/metrics/survival/_c_harrell.py
+++ b/skpro/metrics/survival/_c_harrell.py
@@ -137,23 +137,23 @@ class ConcordanceHarrell(BaseDistrMetric):
                 one_unc = 1 - Cj * Cij
 
                 # mark concordant pairs (no ties)
-                comp1 = nCij * (yj > yij)  # comparable, > type
+                comp1 = nCij & (yj > yij)  # comparable, > type
                 conc1 = comp1 & (rj > rij)
-                comp2 = nCj * (yj < yij)  # comparable, < type
+                comp2 = nCj & (yj < yij)  # comparable, < type
                 conc2 = comp2 & (rj < rij)
 
                 # mark concordnt pairs, handling ties
-                conc3 = nCij * nCj * ((yj == yij) & (rj == rij))
+                conc3 = nCij & nCj &     ((yj == yij) & (rj == rij))
                 conc = conc1 | conc2 | conc3
 
                 # count concordant pairs
                 nconc = conc.sum() - nCij * nCj  # subtract i=j
                 if tie_score != 0:
                     nconc += np.sum((yj != yij) & (rj == rij)) * tie_score
-                    nconc += np.sum(one_unc * (yj == yij) & (rj == rij)) * tie_score
+                    nconc += np.sum(one_unc & (yj == yij) & (rj == rij)) * tie_score
 
                 # count comparable pairs
-                comp3 = one_unc * (yj == yij)
+                comp3 = one_unc & (yj == yij)
                 comp = comp1 | comp2 | comp3
                 ncomp = comp.sum() - nCij  # subtract i=j, but only if counted above
 

--- a/skpro/metrics/survival/_c_harrell.py
+++ b/skpro/metrics/survival/_c_harrell.py
@@ -68,7 +68,7 @@ class ConcordanceHarrell(BaseDistrMetric):
         fractions of concordant pairs are averaged primarily overall,
         or primarily per index. In both cases, ``evaluate`` returns the
         arithmetic mean of ``evaluate_by_index``.
-        
+
         * If ``'overall'``, ``evaluate``
         returns the fraction of concordant among all comparable pairs.
         This is as in [1]_.

--- a/skpro/metrics/survival/_c_harrell.py
+++ b/skpro/metrics/survival/_c_harrell.py
@@ -181,7 +181,10 @@ class ConcordanceHarrell(BaseDistrMetric):
                 conc = conc1 | conc2 | conc3
 
                 # count concordant pairs
-                nconc = conc.sum() - nCij * nCj  # subtract i=j
+                nconc = conc.sum() - nCij  # sum, subtract i=j if counted above
+                # i=j was counted iff it was not censored
+
+                # handle ties in total of concordant pairs
                 if tie_score != 0:
                     nconc = nconc.astype(float)
                     nconc += np.sum((yj != yij) & (rj == rij)) * tie_score

--- a/skpro/metrics/survival/_c_harrell.py
+++ b/skpro/metrics/survival/_c_harrell.py
@@ -72,9 +72,9 @@ class ConcordanceHarrell(BaseDistrMetric):
         * If ``'overall'``, ``evaluate``
         returns the fraction of concordant among all comparable pairs.
         This is as in [1]_.
-        In ``evaluate_by_index``, fractions are multiplied by the
-        number of comparable pairs overall, divided by the number of comparable pairs
-        for the index, times the number of non-equal indices.
+        In ``evaluate_by_index``, fraction denominators are the
+        number of comparable pairs overall, divided by the number of samples,
+        instead of the number of comparable pairs in which the index is the first index.
 
         * If ``'index'``, ``evaluate`` returns the average, over indices,
         of the fraction of concordant pairs among

--- a/skpro/metrics/survival/_c_harrell.py
+++ b/skpro/metrics/survival/_c_harrell.py
@@ -203,7 +203,7 @@ class ConcordanceHarrell(BaseDistrMetric):
             # weighting is such that average over rows
             # results in the overall C-index
             ncomp_total = ncomp_mat.sum(axis=0)
-            nspl = len(ncomp)
+            nspl = len(ncomp_mat)
             result = (nspl / ncomp_total) * nconc_mat
         else:  # normalization == "index"
             # weighting is such that rows contain simple fractions

--- a/skpro/metrics/survival/_c_harrell.py
+++ b/skpro/metrics/survival/_c_harrell.py
@@ -195,11 +195,17 @@ class ConcordanceHarrell(BaseDistrMetric):
                 nconc_mat[i, j] = nconc
                 ncomp_mat[i, j] = ncomp
 
+        # normalization
         if normalization == "overall":
+            # weighting is such that average over rows
+            # results in the overall C-index
             ncomp_total = ncomp_mat.sum(axis=0)
             nspl = len(ncomp)
             result = (nspl / ncomp_total) * nconc_mat
         else:  # normalization == "index"
+            # weighting is such that rows contain simple fractions
+            # but the average over rows is not the overall C-index,
+            # as number of comparable pairs is in general not the same for each index
             result = nconc_mat / ncomp_mat
 
         res_df = pd.DataFrame(result, index=ix, columns=cols)

--- a/skpro/metrics/survival/_c_harrell.py
+++ b/skpro/metrics/survival/_c_harrell.py
@@ -143,7 +143,7 @@ class ConcordanceHarrell(BaseDistrMetric):
                 conc2 = comp2 & (rj < rij)
 
                 # mark concordnt pairs, handling ties
-                conc3 = nCij & nCj &     ((yj == yij) & (rj == rij))
+                conc3 = nCij & nCj & ((yj == yij) & (rj == rij))
                 conc = conc1 | conc2 | conc3
 
                 # count concordant pairs

--- a/skpro/metrics/survival/_c_harrell.py
+++ b/skpro/metrics/survival/_c_harrell.py
@@ -183,6 +183,7 @@ class ConcordanceHarrell(BaseDistrMetric):
                 # count concordant pairs
                 nconc = conc.sum() - nCij * nCj  # subtract i=j
                 if tie_score != 0:
+                    nconc = nconc.astype(float)
                     nconc += np.sum((yj != yij) & (rj == rij)) * tie_score
                     nconc += np.sum(one_unc & (yj == yij) & (rj == rij)) * tie_score
 

--- a/skpro/metrics/survival/_c_harrell.py
+++ b/skpro/metrics/survival/_c_harrell.py
@@ -1,0 +1,157 @@
+"""Concrete performance metrics for probabilistic supervised regression."""
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+# adapted from sktime
+
+import numpy as np
+import pandas as pd
+
+from skpro.metrics.base import BaseDistrMetric
+
+
+class ConcordanceHarrell(BaseDistrMetric):
+    r"""Concordance index (Harrell).
+
+    Fraction of concordant test index pairs among all such pairs,
+    as proposed in [1]_, commonly known as Harrell's C-index, Harrell's C,
+    or simply concordance index,
+    if not in delination of other C-indices (e.g., Uno's C-index).
+
+    For ground truth samples :math:`y_i, c_i, i = 1 \dots N`,
+    and predicted inverse risk scores :math:`s_i, i = 1 \dots N`,
+    a pair of test non-equal test indices :math:`i \lneq j` is concordant if
+    :math:`(y_i > y_j) \land (s_i > s_j)` or :math:`(y_i < y_j) \land (s_i < s_j)`.
+    If :math:`(s_i = s_j)`, the pair is counted as concordant if :math:`y_i = y_j`,
+    otherwise it is considered a tie,
+    counted as half concordant, half discordant by default.
+
+    This metric supports multiple options for inverse risk scores,
+    including any method evaluates of predictive distributions.
+
+    The default is the predictive mean survival time.
+
+    `evaluate` computes the concordance index.
+    `evaluate_by_index` produces, for one test sample,
+    the fraction of concordant pairs among all pairs with this sample as first index.
+    `multivariate` controls averaging over variables.
+
+    Parameters
+    ----------
+    score : str, optional, default='mean'
+        The type of inverse risk score to use.
+        Calls predict_proba, then the method of the same name as `score`.
+        Examples include 'mean', 'median', 'quantile', 'cdf'.
+    score_args : dict, optional, default=None
+        Additional arguments to pass to the score method, e.g., quantiles.
+    higher_score_is_lower_risk : bool, optional, default=True
+        If True, higher score is considered lower risk, and vice versa,
+        that is, the score is assumed to be an inverse risk score.
+        If False, the score is assumed to be a risk score, and a
+        negative sign is applied to the score.
+    tie_score : float, optional, default=0.5
+        The value to use for ties in the risk scores,
+        as a relative value to counting as concordant.
+        1 is counting as concordant, 0 is counting as discordant.
+    multioutput : {'raw_values', 'uniform_average'} or array-like of shape
+        (n_outputs,), default='uniform_average'
+        Defines whether and how to aggregate metric for across variables.
+        If 'uniform_average' (default), errors are mean-averaged across variables.
+        If array-like, errors are weighted averaged across variables, values as weights.
+        If 'raw_values', does not average errors across variables, columns are retained.
+    multivariate : bool, optional, default=False
+        if True, behaves as multivariate log-loss
+        C-index is computed for entire row, results one score per row
+        if False, is univariate log-loss
+        C-index is computed per variable marginal, results in many scores per row
+
+    References
+    ----------
+    .. [1] Harrell FE, Califf R.M., Pryor DB, Lee KL, Rosati RA.
+      Multivariable prognostic models: issues in developing models,
+      evaluating assumptions and adequacy, and measuring and reducing errors.
+      Statistics in Medicine, 15(4), 361-87, 1996.
+    """
+
+    _tags = {
+        "authors": "fkiraly",
+        "capability:survival": True,
+        "scitype:y_pred": "pred_proba",
+        "lower_is_better": False,
+    }
+
+    def __init__(
+        self,
+        score="mean",
+        score_args=None,
+        higher_score_is_lower_risk=True,
+        tie_score=0.5,
+        multioutput="uniform_average",
+        multivariate=False,
+    ):
+        self.score = score
+        self.score_args = score_args
+        self.higher_score_is_lower_risk = higher_score_is_lower_risk
+        self.tie_score = tie_score
+        self.multivariate = multivariate
+        super().__init__(multioutput=multioutput)
+
+    def _evaluate_by_index(self, y_true, y_pred, **kwargs):
+        C_true = kwargs.get("C_true", None)
+        tie_score = self.tie_score
+
+        ix = y_true.index
+        cols = y_true.columns
+
+        y_true = y_true.to_numpy()
+        if C_true is not None:
+            C_true = C_true.to_numpy()
+        else:
+            C_true = np.zeros_like_like(y_true)
+
+        risk_scores = getattr(y_pred, self.score)(**self.score_args)
+        if self.higher_score_is_lower_risk:
+            risk_scores = -risk_scores
+        risk_scores = risk_scores.to_numpy()
+
+        result = np.zeros_like(y_true)
+
+        for j in range(y_true.shape[1]):
+            yj = y_true[:, j]
+            Cj = C_true[:, j]
+            nCj = 1 - Cj
+            rj = risk_scores[:, j]
+            for i in range(y_true.shape[0]):
+                yij = yj[i]
+                rij = rj[i]
+                Cij = Cj[i]
+                nCij = 1 - Cij
+                one_unc = (1 - Cj * Cij)
+
+                # mark concordant pairs (no ties)
+                comp1 = nCij * (yj > yij)  # comparable, > type
+                conc1 = comp1 & (rj > rij)
+                comp2 = nCj * (yj < yij)  # comparable, < type
+                conc2 = comp2 & (rj < rij)
+
+                # mark concordnt pairs, handling ties
+                conc3 = nCij * nCj * ((yj == yij) & (rj == rij))
+                conc = conc1 | conc2 | conc3
+
+                # count concordant pairs
+                nconc = conc.sum() - nCij * nCj  # subtract i=j
+                if tie_score != 0:
+                    nconc += np.sum((yj != yij) & (rj == rij)) * tie_score
+                    nconc += np.sum(one_unc * (yj == yij) & (rj == rij)) * tie_score
+
+                # count comparable pairs
+                comp3 = one_unc * (yj == yij)
+                comp = comp1 | comp2 | comp3
+                ncomp = comp.sum() - nCij  # subtract i=j, but only if counted above
+
+                result[i, j] = nconc / ncomp
+
+        res_df = pd.DataFrame(result, index=ix, columns=cols)
+
+        if self.multivariate:
+            return pd.DataFrame(res_df.mean(axis=1), columns=["C_Harrell"])
+        else:
+            return res_df

--- a/skpro/metrics/survival/_c_harrell.py
+++ b/skpro/metrics/survival/_c_harrell.py
@@ -1,6 +1,5 @@
-"""Concrete performance metrics for probabilistic supervised regression."""
+"""Concordance index, Harrell's."""
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
-# adapted from sktime
 
 import numpy as np
 import pandas as pd
@@ -149,7 +148,7 @@ class ConcordanceHarrell(BaseDistrMetric):
             C_true = np.zeros_like(y_true)
 
         risk_scores = getattr(y_pred, self.score)(**score_args)
-        if self.higher_score_is_lower_risk:
+        if not self.higher_score_is_lower_risk:
             risk_scores = -risk_scores
         risk_scores = risk_scores.to_numpy()
 

--- a/skpro/metrics/survival/_c_harrell.py
+++ b/skpro/metrics/survival/_c_harrell.py
@@ -131,7 +131,7 @@ class ConcordanceHarrell(BaseDistrMetric):
                 rij = rj[i]
                 Cij = Cj[i]
                 nCij = 1 - Cij
-                one_unc = (1 - Cj * Cij)
+                one_unc = 1 - Cj * Cij
 
                 # mark concordant pairs (no ties)
                 comp1 = nCij * (yj > yij)  # comparable, > type

--- a/skpro/metrics/survival/_c_harrell.py
+++ b/skpro/metrics/survival/_c_harrell.py
@@ -104,6 +104,9 @@ class ConcordanceHarrell(BaseDistrMetric):
     def _evaluate_by_index(self, y_true, y_pred, **kwargs):
         C_true = kwargs.get("C_true", None)
         tie_score = self.tie_score
+        score_args = self.score_args
+        if score_args is None:
+            score_args = {}
 
         ix = y_true.index
         cols = y_true.columns
@@ -114,7 +117,7 @@ class ConcordanceHarrell(BaseDistrMetric):
         else:
             C_true = np.zeros_like(y_true)
 
-        risk_scores = getattr(y_pred, self.score)(**self.score_args)
+        risk_scores = getattr(y_pred, self.score)(**score_args)
         if self.higher_score_is_lower_risk:
             risk_scores = -risk_scores
         risk_scores = risk_scores.to_numpy()

--- a/skpro/metrics/survival/_c_harrell.py
+++ b/skpro/metrics/survival/_c_harrell.py
@@ -112,7 +112,7 @@ class ConcordanceHarrell(BaseDistrMetric):
         if C_true is not None:
             C_true = C_true.to_numpy()
         else:
-            C_true = np.zeros_like_like(y_true)
+            C_true = np.zeros_like(y_true)
 
         risk_scores = getattr(y_pred, self.score)(**self.score_args)
         if self.higher_score_is_lower_risk:

--- a/skpro/metrics/survival/_c_harrell.py
+++ b/skpro/metrics/survival/_c_harrell.py
@@ -11,7 +11,7 @@ from skpro.metrics.base import BaseDistrMetric
 class ConcordanceHarrell(BaseDistrMetric):
     r"""Concordance index (Harrell).
 
-    Fraction of concordant test index pairs among all such pairs,
+    Fraction of concordant test index pairs among all comparale pairs,
     as proposed in [1]_, commonly known as Harrell's C-index, Harrell's C,
     or simply concordance index,
     if not in delination of other C-indices (e.g., Uno's C-index).
@@ -21,8 +21,15 @@ class ConcordanceHarrell(BaseDistrMetric):
     a pair of test non-equal test indices :math:`i \lneq j` is concordant if
     :math:`(y_i > y_j) \land (s_i > s_j)` or :math:`(y_i < y_j) \land (s_i < s_j)`.
     If :math:`(s_i = s_j)`, the pair is counted as concordant if :math:`y_i = y_j`,
-    otherwise it is considered a tie,
+    and :math:`c_i = c_j = 0`, otherwise it is considered a tie,
     counted as half concordant, half discordant by default.
+
+    A pair of test indices :math:`i \lneq j` is said to be comparable
+    if one of the following conditions holds:
+
+    * :math:`y_i > y_j` and :math:`c_j = 0`
+    * :math:`y_i < y_j` and :math:`c_i = 0`
+    * :math:`y_i = y_j` and :math:`c_i c_j = 0`
 
     This metric supports multiple options for inverse risk scores,
     including any method evaluates of predictive distributions.

--- a/skpro/metrics/survival/_spll.py
+++ b/skpro/metrics/survival/_spll.py
@@ -1,0 +1,77 @@
+"""Concrete performance metrics for probabilistic supervised regression."""
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+# adapted from sktime
+
+import numpy as np
+import pandas as pd
+
+from skpro.metrics.base import BaseDistrMetric
+
+
+class SPLL(BaseDistrMetric):
+    r"""Survival Process Logarithmic Loss for distributional predictions.
+
+    Same as the negative log-likelihood of the survival process (see [1]_),
+    and therefore a proper scoring rule for survival predictions.
+
+    For a predictive distribution :math:`d` with hazard function :math:`d.\lambda`,
+    survival function :math:`d.S`, a ground truth value :math:`y`
+    and censoring indicator :math:`\Delta`, taking values 1 (censored) and
+    0 (uncensored), the survival process logarithmic loss is defined as
+    :math:`L(y, d) := (\Delta - 1) (\log d.\lambda(y)) - \Delta \log d.S(y)`.
+    Logarithms are natural logarithms.
+
+    The above can be expressed in terms of pdf :math:`d.p` and cdf :math:`d.F`
+    by substituting :math:`d.\lambda = -d.p / d.S` and :math:`d.S = 1 - d.F`.
+
+    To obtain the loss from formula 7.1.2 in [1]_, condition on
+    :math:`N(A) \le 1` (i.e., no more than one event in the interval :math:`A`),
+    use that :math:`\Delta = 1` iff :math:`N(A) = 0`,
+    and :math:`-\log d.S(y) = \int_A d.\lambda(t) \; dt`.
+
+    `evaluate` computes the average test sample loss.
+    `evaluate_by_index` produces the loss sample by test data point.
+    `multivariate` controls averaging over variables.
+
+    Parameters
+    ----------
+    multioutput : {'raw_values', 'uniform_average'} or array-like of shape \
+            (n_outputs,), default='uniform_average'
+        Defines whether and how to aggregate metric for across variables.
+        If 'uniform_average' (default), errors are mean-averaged across variables.
+        If array-like, errors are weighted averaged across variables, values as weights.
+        If 'raw_values', does not average errors across variables, columns are retained.
+    multivariate : bool, optional, default=False
+        if True, behaves as multivariate log-loss
+        log-loss is computed for entire row, results one score per row
+        if False, is univariate log-loss
+        log-loss is computed per variable marginal, results in many scores per row
+
+    References
+    ----------
+    .. [1] Daley DJ, Vere-Jones. An Introduction to the Theory of Point Processes,
+        2nd Edition, 2003, Springer, New York. Formula 7.1.2.
+    """
+
+    def __init__(self, multioutput="uniform_average", multivariate=False):
+        self.multivariate = multivariate
+        super().__init__(multioutput=multioutput)
+
+    def _evaluate_by_index(self, y_true, y_pred, **kwargs):
+
+        C = kwargs.get("C", None)
+
+        if C is None:
+            # then all uncensored, Delta = 0
+            res = -y_pred.log_pdf(y_true)
+        else:
+            cont_term = -y_pred.log_pdf(y_true) * (1 - C.to_numpy())
+            disc_term = np.log(1 - y_pred.cdf(y_true)) * C.to_numpy()
+            res = cont_term + disc_term
+
+        # replace this by multivariate log_pdf once distr implements
+        # i.e., pass multivariate on to log_pdf
+        if self.multivariate:
+            return pd.DataFrame(res.mean(axis=1), columns=["SPLL"])
+        else:
+            return res

--- a/skpro/metrics/survival/_spll.py
+++ b/skpro/metrics/survival/_spll.py
@@ -1,6 +1,5 @@
-"""Concrete performance metrics for probabilistic supervised regression."""
+"""Survival Process Logarithmic Loss for distributional predictions."""
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
-# adapted from sktime
 
 import numpy as np
 import pandas as pd

--- a/skpro/metrics/survival/_spll.py
+++ b/skpro/metrics/survival/_spll.py
@@ -14,7 +14,7 @@ class SPLL(BaseDistrMetric):
     Same as the negative log-likelihood of the survival process (see [1]_),
     and therefore a proper scoring rule for survival predictions.
 
-    For a predictive distribution :math:`d` with hazard function :math:`d.\lambda`,
+    For a predictive distribution :math:`d` with pdf :math:`d.p`,
     survival function :math:`d.S`, a ground truth value :math:`y`
     and censoring indicator :math:`\Delta`, taking values 1 (censored) and
     0 (uncensored), the survival process logarithmic loss is defined as

--- a/skpro/metrics/survival/_spll.py
+++ b/skpro/metrics/survival/_spll.py
@@ -66,14 +66,14 @@ class SPLL(BaseDistrMetric):
 
     def _evaluate_by_index(self, y_true, y_pred, **kwargs):
 
-        C = kwargs.get("C", None)
+        C_true = kwargs.get("C_true", None)
 
-        if C is None:
+        if C_true is None:
             # then all uncensored, Delta = 0
             res = -y_pred.log_pdf(y_true)
         else:
-            cont_term = -y_pred.log_pdf(y_true) * (1 - C.to_numpy())
-            disc_term = np.log(1 - y_pred.cdf(y_true)) * C.to_numpy()
+            cont_term = -y_pred.log_pdf(y_true) * (1 - C_true.to_numpy())
+            disc_term = np.log(1 - y_pred.cdf(y_true)) * C_true.to_numpy()
             res = cont_term + disc_term
 
         if self.multivariate:

--- a/skpro/metrics/survival/_spll.py
+++ b/skpro/metrics/survival/_spll.py
@@ -76,8 +76,6 @@ class SPLL(BaseDistrMetric):
             disc_term = np.log(1 - y_pred.cdf(y_true)) * C.to_numpy()
             res = cont_term + disc_term
 
-        # replace this by multivariate log_pdf once distr implements
-        # i.e., pass multivariate on to log_pdf
         if self.multivariate:
             return pd.DataFrame(res.mean(axis=1), columns=["SPLL"])
         else:

--- a/skpro/metrics/survival/_spll.py
+++ b/skpro/metrics/survival/_spll.py
@@ -53,6 +53,13 @@ class SPLL(BaseDistrMetric):
         2nd Edition, 2003, Springer, New York. Formula 7.1.2.
     """
 
+    _tags = {
+        "authors": "fkiraly",
+        "capability:survival": True,
+        "scitype:y_pred": "pred_proba",
+        "lower_is_better": True,
+    }
+
     def __init__(self, multioutput="uniform_average", multivariate=False):
         self.multivariate = multivariate
         super().__init__(multioutput=multioutput)

--- a/skpro/metrics/survival/_spll.py
+++ b/skpro/metrics/survival/_spll.py
@@ -18,16 +18,16 @@ class SPLL(BaseDistrMetric):
     survival function :math:`d.S`, a ground truth value :math:`y`
     and censoring indicator :math:`\Delta`, taking values 1 (censored) and
     0 (uncensored), the survival process logarithmic loss is defined as
-    :math:`L((y, \Delta), d) := (\Delta - 1) (\log d.\lambda(y)) - \Delta \log d.S(y)`.
+    :math:`L((y, \Delta), d) := (\Delta - 1) (\log d.p(y)) - \Delta \log d.S(y)`.
     Logarithms are natural logarithms.
 
-    The above can be expressed in terms of pdf :math:`d.p` and cdf :math:`d.F`
-    by substituting :math:`d.\lambda = -d.p / d.S` and :math:`d.S = 1 - d.F`.
+    Where :math:`d.S = 1 - d.F` for the cdf :math:`d.F` of :math:`d`.
 
     To obtain the loss from formula 7.1.2 in [1]_, condition on
     :math:`N(A) \le 1` (i.e., no more than one event in the interval :math:`A`),
     use that :math:`\Delta = 1` iff :math:`N(A) = 0`,
-    and :math:`-\log d.S(y) = \int_A d.\lambda(t) \; dt`.
+    and :math:`-\log d.S(y) = \int_A d.\lambda(t) \; dt`, with
+    :math:`d.\lambda = -d.p / d.S`.
 
     `evaluate` computes the average test sample loss.
     `evaluate_by_index` produces the loss sample by test data point.

--- a/skpro/metrics/survival/_spll.py
+++ b/skpro/metrics/survival/_spll.py
@@ -65,7 +65,6 @@ class SPLL(BaseDistrMetric):
         super().__init__(multioutput=multioutput)
 
     def _evaluate_by_index(self, y_true, y_pred, **kwargs):
-
         C_true = kwargs.get("C_true", None)
 
         if C_true is None:

--- a/skpro/metrics/survival/_spll.py
+++ b/skpro/metrics/survival/_spll.py
@@ -18,7 +18,7 @@ class SPLL(BaseDistrMetric):
     survival function :math:`d.S`, a ground truth value :math:`y`
     and censoring indicator :math:`\Delta`, taking values 1 (censored) and
     0 (uncensored), the survival process logarithmic loss is defined as
-    :math:`L(y, d) := (\Delta - 1) (\log d.\lambda(y)) - \Delta \log d.S(y)`.
+    :math:`L((y, \Delta), d) := (\Delta - 1) (\log d.\lambda(y)) - \Delta \log d.S(y)`.
     Logarithms are natural logarithms.
 
     The above can be expressed in terms of pdf :math:`d.p` and cdf :math:`d.F`

--- a/skpro/metrics/survival/tests/__init__.py
+++ b/skpro/metrics/survival/tests/__init__.py
@@ -1,0 +1,2 @@
+"""Tests for metrics for time-to-event or survival prediction."""
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)

--- a/skpro/metrics/survival/tests/test_c_harrell.py
+++ b/skpro/metrics/survival/tests/test_c_harrell.py
@@ -1,0 +1,52 @@
+"""Tests for Harell's C-index."""
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+
+import pandas as pd
+import pytest
+
+
+@pytest.mark.parametrize("concordant", [True, False])
+@pytest.mark.parametrize("pass_c", [True, False])
+@pytest.mark.parametrize("normalization", ["overall", "index"])
+def test_charrell_logic(concordant=True, pass_c=True, normalization="overall"):
+    """Test the logic of the Harrell's C-index metric.
+
+    Parameters
+    ----------
+    concordant : bool, optional, default=True
+        If True, the test examples are fully concordant.
+        If False, the test examples are fully discordant.
+    pass_c : bool, optional, default=True
+        If True, the `c_true` argument is passed to the metric.
+        If False, the `c_true` argument is not passed to the metric.
+    normalization : str, optional, default="overall"
+        The normalization method for the metric.
+    """
+    from skpro.distributions import Normal
+    from skpro.metrics.survival._c_harrell import ConcordanceHarrell
+
+    # examples are constructed to be fully concordant or discordant,
+    # depending on the value of `concordant`
+    y_true = pd.DataFrame({"a": [1, 2, 3, 4], "b": [5, 4, 3, 2]})
+    c_true = pd.DataFrame({"a": [1, 0, 1, 0], "b": [0, 1, 0, 1]})
+    y_pred_mean = pd.DataFrame({"a": [2, 3, 4, 5], "b": [6, 5, 4, 3]})
+
+    if not concordant:
+        y_pred_mean = -y_pred_mean
+    y_pred = Normal(y_pred_mean, sigma=1, columns=pd.Index(["a", "b"]))
+
+    # evaluate the metric
+    metric = ConcordanceHarrell(normalization=normalization)
+    metric_args = {"y_true": y_true, "y_pred": y_pred}
+    if pass_c:
+        metric_args["c_true"] = c_true
+
+    res = metric(**metric_args)
+    res_by_index = metric.evaluate_by_index(**metric_args)
+
+    # test assumptions
+    # if concordant, the result should be 1
+    # if discordant, the result should be 0
+    assert res == concordant
+    assert res_by_index.shape == y_true.shape
+    assert (res_by_index == concordant).all().all()

--- a/skpro/metrics/survival/tests/test_c_harrell.py
+++ b/skpro/metrics/survival/tests/test_c_harrell.py
@@ -8,7 +8,7 @@ import pytest
 @pytest.mark.parametrize("concordant", [True, False])
 @pytest.mark.parametrize("pass_c", [True, False])
 @pytest.mark.parametrize("normalization", ["overall", "index"])
-def test_charrell_logic(concordant=True, pass_c=True, normalization="overall"):
+def test_charrell_logic(concordant, pass_c, normalization):
     """Test the logic of the Harrell's C-index metric.
 
     Parameters

--- a/skpro/metrics/tests/test_distr_metrics.py
+++ b/skpro/metrics/tests/test_distr_metrics.py
@@ -10,7 +10,7 @@ from skpro.metrics import (
     SPLL,
     ConcordanceHarrell,
     LinearizedLogLoss,
-    LogLoss, 
+    LogLoss,
     SquaredDistrLoss,
 )
 
@@ -21,7 +21,7 @@ DISTR_METRICS = [
     SPLL,
     ConcordanceHarrell,
     LinearizedLogLoss,
-    LogLoss, 
+    LogLoss,
     SquaredDistrLoss,
 ]
 

--- a/skpro/metrics/tests/test_distr_metrics.py
+++ b/skpro/metrics/tests/test_distr_metrics.py
@@ -5,11 +5,25 @@ import pandas as pd
 import pytest
 
 from skpro.distributions import Normal
-from skpro.metrics._classes import CRPS, LogLoss
+from skpro.metrics import (
+    CRPS,
+    SPLL,
+    ConcordanceHarrell,
+    LinearizedLogLoss,
+    LogLoss, 
+    SquaredDistrLoss,
+)
 
 warnings.filterwarnings("ignore", category=FutureWarning)
 
-DISTR_METRICS = [CRPS, LogLoss]
+DISTR_METRICS = [
+    CRPS,
+    SPLL,
+    ConcordanceHarrell,
+    LinearizedLogLoss,
+    LogLoss, 
+    SquaredDistrLoss,
+]
 
 normal_dists = [Normal]
 

--- a/skpro/registry/_tags.py
+++ b/skpro/registry/_tags.py
@@ -99,7 +99,7 @@ OBJECT_TAG_REGISTER = [
     # ------------------
     (
         "capability:survival",
-        "regressor_proba",
+        ["regressor_proba", "metric"],
         "bool",
         "whether estimator can use censoring information, for survival analysis",
     ),

--- a/skpro/registry/_tags.py
+++ b/skpro/registry/_tags.py
@@ -99,7 +99,7 @@ OBJECT_TAG_REGISTER = [
     # ------------------
     (
         "capability:survival",
-        ["regressor_proba", "metric"],
+        "regressor_proba",
         "bool",
         "whether estimator can use censoring information, for survival analysis",
     ),
@@ -198,6 +198,12 @@ OBJECT_TAG_REGISTER = [
         "metric",
         "bool",
         "whether lower (True) or higher (False) is better",
+    ),
+    (
+        "capability:survival",
+        "metric",
+        "bool",
+        "whether metric uses censoring information, for survival analysis",
     ),
     # ----------------------------
     # BaseMetaObject reserved tags


### PR DESCRIPTION
This PR adds framework support for survival prediction metrics, and test coverage.

It also adds two metrics for survival predictions, as proof-of-concept, and for testing the framework.
* the survival process log-loss - a proper scoring rule for survival predictions
* Harrell's C-index


### Design

Survival prediction metrics use the `BaseProbaMetric` or `BaseDistrMetric` as base class, and differ only in that they may optionally take a `pd.DataFrame` of censoring indicators as argument `C_true` in `evaluate` or `evaluate_by_index`.

An implementer of `_evaluate_by_index` of a survival metric will have to cope with the cases of `C_true=None` and `C_true: pd.DataFrame`.

Metrics that make use of `C_true` are labelled with the `capability_survival` tag.

The above design ensures that:

* non-survival metrics can take the `C_true` argument, they simply ignore censoring information
* survival metrics can be invoked without `C_true` argument, in which case they become supervised regression metrics (assuming no censoring)

In particular, all metrics (survival or not) can be used with all data settings (survival or not), which ensures maximal composability and interoperability through unified API.


### Implementation

* no major changes to `BaseDistrMetric` ar necssary, only conversion handling for the optional `C_true` argument.
* the tag `capability:survival` already exists, for regressors - its scope is extended to metrics
* a survival metric, the survival process log loss, is implemented
* tests are added to test all probabilistic metrics with and without `C_true` argument
* regressor `evaluate` for benchmarking alredy passes `C_test` as `C_true`, so requires no change