### PR TITLE
[BUG] fix fallback for `pdfnorm` method, add metrics to tests

### DIFF
--- a/skpro/distributions/base.py
+++ b/skpro/distributions/base.py
@@ -447,7 +447,8 @@ class BaseDistribution(BaseObject):
 
         # uses formula int p(x)^a dx = E[p(X)^{a-1}], and MC approximates the RHS
         spl = [self.pdf(self.sample()) ** (a - 1) for _ in range(approx_spl_size)]
-        return pd.concat(spl, axis=0).groupby(level=1, sort=False).mean()
+        spl_df = pd.concat(spl, keys=range(approx_spl_size))
+        return spl_df.groupby(level=1, sort=False).mean()
 
     def _coerce_to_self_index_df(self, x):
         x = np.array(x)

--- a/skpro/metrics/tests/test_distr_metrics.py
+++ b/skpro/metrics/tests/test_distr_metrics.py
@@ -5,11 +5,21 @@ import pandas as pd
 import pytest
 
 from skpro.distributions import Normal
-from skpro.metrics._classes import CRPS, LogLoss
+from skpro.metrics import (
+    CRPS,
+    LinearizedLogLoss,
+    LogLoss,
+    SquaredDistrLoss,
+)
 
 warnings.filterwarnings("ignore", category=FutureWarning)
 
-DISTR_METRICS = [CRPS, LogLoss]
+DISTR_METRICS = [
+    CRPS,
+    LinearizedLogLoss,
+    LogLoss,
+    SquaredDistrLoss,
+]
 
 normal_dists = [Normal]
 

--- a/skpro/metrics/tests/test_distr_metrics.py
+++ b/skpro/metrics/tests/test_distr_metrics.py
@@ -5,12 +5,7 @@ import pandas as pd
 import pytest
 
 from skpro.distributions import Normal
-from skpro.metrics import (
-    CRPS,
-    LinearizedLogLoss,
-    LogLoss,
-    SquaredDistrLoss,
-)
+from skpro.metrics import CRPS, LinearizedLogLoss, LogLoss, SquaredDistrLoss
 
 warnings.filterwarnings("ignore", category=FutureWarning)
 


### PR DESCRIPTION
This PR fixes an unreported bug where the fallback Monte Carlo approximation for `pdfnorm` was not working, and adds semi-direct tests through the sqared norm metric.