### PR TITLE
[DOC] README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 It provides `scikit-learn`-like, `scikit-base` compatible interfaces to:
 
 * tabular **supervised regressors for probabilistic prediction** - interval, quantile and distribution predictions
-* **metrics to evaluate probabilistic predictions**, e.g., pinball loss, empirical coverage, CRPS
+* tabular **probabilistic time-to-event and survival prediction** - instance-individual survival distributions
+* **metrics to evaluate probabilistic predictions**, e.g., pinball loss, empirical coverage, CRPS, survival losses
 * **reductions** to turn `scikit-learn` regressors into probabilistic `skpro` regressors, such as bootstrap or conformal
 * building **pipelines and composite models**, including tuning via probabilistic performance metrics
 * symbolic **probability distributions** with value domain of `pandas.DataFrame`-s and `pandas`-like interface
@@ -63,6 +64,39 @@ We strongly believe in the value of sharing help publicly, as it allows a wider 
 [github discussions]: https://github.com/sktime/skpro/discussions
 [stack overflow]: https://stackoverflow.com/questions/tagged/sktime
 [discord]: https://discord.com/invite/54ACzaFsn7
+
+
+## :dizzy: Features
+
+Our objective is to enhance the interoperability and usability of the AI model ecosystem:
+
+* ``skpro`` is compatible with [scikit-learn] and [sktime], and composites can be built across
+libraries, e.g., an ``sktime`` probabiistic forecaster via reduction to an ``skpro`` probabilistic regressor
+which in turn is an ``sklearn`` regressor with added probabilistic prediction mode by a ``skpro`` compositor.
+
+* ``skpro`` provides de-novo implementations of algorithms or composition meta-algorithms, but aso
+a mini-package management framework interfacing popular second- and third-party components, such as
+[cyclic-boosting] or [MAPIE] packages.
+
+[scikit-learn]: https://scikit-learn.org/stable/
+[sktime]: https://www.sktime.net
+[MAPIE]: https://mapie.readthedocs.io/en/latest/
+[cyclic-boosting]:  https://cyclic-boosting.readthedocs.io/en/latest/
+
+``skpro`` curates libraries of components of the following types:
+
+| Module | Status | Links |
+|---|---|---|
+| **[Probabilistic tabular regression]** | maturing | [Tutorial](https://github.com/sktime/skpro/blob/main/examples/01_skpro_intro.ipynb) · [API Reference](https://skpro.readthedocs.io/en/latest/api_reference/regression.html) · [Extension Template](https://github.com/sktime/skpro/blob/main/extension_templates/regression.py) |
+| **[Time-to-event (survival) prediction]** | experimental | [API Reference](https://skpro.readthedocs.io/en/latest/api_reference/survival.html) · [Extension Template](https://github.com/sktime/skpro/blob/main/extension_templates/survival.py) |
+| **[Performance metrics]** | maturing | [API Reference](https://skpro.readthedocs.io/en/latest/api_reference/metrics.html) |
+| **[Probability distributions]** | maturing | [API Reference](https://skpro.readthedocs.io/en/latest/api_reference/distributions.html) |
+
+[Probabilistic tabular regression]: https://github.com/sktime/skpro/tree/main/skpro/regression
+[Time-to-event (survival) prediction]: https://github.com/sktime/skpro/tree/main/skpro/survival
+[Performance metrics]: https://github.com/sktime/skpro/tree/main/skpro/metrics
+[Probability distributions]: https://github.com/sktime/skpro/tree/main/skpro/distributions
+
 
 ## :hourglass_flowing_sand: Installing `skpro`
 

--- a/docs/source/api_reference/regression.rst
+++ b/docs/source/api_reference/regression.rst
@@ -1,10 +1,13 @@
 .. _regression_ref:
 
-Time series regression
-======================
+Probabilistic supervised regression
+===================================
 
 The :mod:`skpro.regression` module contains algorithms and composition tools for probabilistic supervised regression,
 i.e., tabular regression estimation with a probabilistic prediction mode.
+
+This learning task is sometimes also known as conditional distribution predictions,
+or conditional density estimation, if predictive distributions are continuous.
 
 All regressors in ``skpro`` can be listed using the ``skpro.registry.all_objects`` utility,
 using ``object_types="regressor_proba"``, optionally filtered by tags.


### PR DESCRIPTION
This PR updates the README to projected 2.2.0 state:

* "features" section with reference to popuar third party packages such as `cyclic_boosting`
* estimator/object type table in features section
* reference to time-to-event/survival task

Minor fixes:

* regression API page had an incorrect header, fixed