### PR TITLE
[ENH] migrate tests of distribution prediction metrics to `skbase` class

### DIFF
--- a/skpro/metrics/base.py
+++ b/skpro/metrics/base.py
@@ -34,7 +34,7 @@ class BaseProbaMetric(BaseObject):
     """
 
     _tags = {
-        "object_type": "metric",  # type of object
+        "object_type": ["metric", "metric_distr"],  # type of object
         "reserved_params": ["multioutput", "score_average"],
         "scitype:y_pred": "pred_proba",
         "lower_is_better": True,

--- a/skpro/metrics/base.py
+++ b/skpro/metrics/base.py
@@ -34,7 +34,7 @@ class BaseProbaMetric(BaseObject):
     """
 
     _tags = {
-        "object_type": ["metric", "metric_distr"],  # type of object
+        "object_type": "metric",  # type of object
         "reserved_params": ["multioutput", "score_average"],
         "scitype:y_pred": "pred_proba",
         "lower_is_better": True,
@@ -376,6 +376,7 @@ class BaseDistrMetric(BaseProbaMetric):
     """
 
     _tags = {
+        "object_type": ["metric", "metric_distr"],  # type of object
         "scitype:y_pred": "pred_proba",
         "lower_is_better": True,
     }
@@ -402,7 +403,7 @@ class BaseDistrMetric(BaseProbaMetric):
         multioutput = self.multioutput
         multivariate = self.multivariate
 
-        index_df = self.evaluate_by_index(y_true, y_pred)
+        index_df = self.evaluate_by_index(y_true, y_pred, **kwargs)
         out_df = pd.DataFrame(index_df.mean(axis=0)).T
         out_df.columns = index_df.columns
 

--- a/skpro/metrics/tests/test_distr_metrics.py
+++ b/skpro/metrics/tests/test_distr_metrics.py
@@ -33,7 +33,7 @@ class TestAllDistrMetrics(PackageConfig, BaseFixtureGenerator, QuickTester):
         y_pred = dist.create_test_instance()
         y_true = y_pred.sample()
 
-        m = metric(multivariate=multivariate, multioutput=multioutput)
+        m = metric.set_params(multivariate=multivariate, multioutput=multioutput)
 
         if not multivariate:
             expected_cols = y_true.columns
@@ -51,7 +51,7 @@ class TestAllDistrMetrics(PackageConfig, BaseFixtureGenerator, QuickTester):
         assert (res.columns == expected_cols).all()
         assert res.shape == (y_true.shape[0], len(expected_cols))
 
-        res = m.evaluate(y_true, y_pred)
+        res = m.evaluate(**metric_args)
 
         expect_df = not multivariate and multioutput == "raw_values"
         if expect_df:

--- a/skpro/metrics/tests/test_distr_metrics.py
+++ b/skpro/metrics/tests/test_distr_metrics.py
@@ -24,7 +24,9 @@ class TestAllDistrMetrics(PackageConfig, BaseFixtureGenerator, QuickTester):
     @pytest.mark.parametrize("pass_c", [True, False])
     @pytest.mark.parametrize("multivariate", [True, False])
     @pytest.mark.parametrize("multioutput", ["raw_values", "uniform_average"])
-    def test_distr_evaluate(object_instance, dist, pass_c, multivariate, multioutput):
+    def test_distr_evaluate(
+        self, object_instance, dist, pass_c, multivariate, multioutput
+    ):
         """Test expected output of evaluate functions."""
         metric = object_instance
 

--- a/skpro/metrics/tests/test_distr_metrics.py
+++ b/skpro/metrics/tests/test_distr_metrics.py
@@ -7,7 +7,6 @@ from skbase.testing import QuickTester
 from skpro.distributions import Normal
 from skpro.tests.test_all_estimators import BaseFixtureGenerator, PackageConfig
 
-
 TEST_DISTS = [Normal]
 
 

--- a/skpro/metrics/tests/test_distr_metrics.py
+++ b/skpro/metrics/tests/test_distr_metrics.py
@@ -33,7 +33,9 @@ class TestAllDistrMetrics(PackageConfig, BaseFixtureGenerator, QuickTester):
         y_pred = dist.create_test_instance()
         y_true = y_pred.sample()
 
-        m = metric.set_params(multivariate=multivariate, multioutput=multioutput)
+        m = metric.set_params(multioutput=multioutput)
+        if "multivariate" in metric.get_params():
+            m = m.set_params(multivariate=multivariate)
 
         if not multivariate:
             expected_cols = y_true.columns

--- a/skpro/metrics/tests/test_distr_metrics.py
+++ b/skpro/metrics/tests/test_distr_metrics.py
@@ -3,58 +3,53 @@ import warnings
 
 import pandas as pd
 import pytest
+from skbase.testing import QuickTester
 
 from skpro.distributions import Normal
-from skpro.metrics import (
-    CRPS,
-    SPLL,
-    ConcordanceHarrell,
-    LinearizedLogLoss,
-    LogLoss,
-    SquaredDistrLoss,
-)
-
-warnings.filterwarnings("ignore", category=FutureWarning)
-
-DISTR_METRICS = [
-    CRPS,
-    SPLL,
-    ConcordanceHarrell,
-    LinearizedLogLoss,
-    LogLoss,
-    SquaredDistrLoss,
-]
-
-normal_dists = [Normal]
+from skpro.tests.test_all_estimators import BaseFixtureGenerator, PackageConfig
 
 
-@pytest.mark.parametrize("normal", normal_dists)
-@pytest.mark.parametrize("metric", DISTR_METRICS)
-@pytest.mark.parametrize("multivariate", [True, False])
-@pytest.mark.parametrize("multioutput", ["raw_values", "uniform_average"])
-def test_distr_evaluate(normal, metric, multivariate, multioutput):
-    """Test expected output of evaluate functions."""
-    y_pred = normal.create_test_instance()
-    y_true = y_pred.sample()
+TEST_DISTS = [Normal]
 
-    m = metric(multivariate=multivariate, multioutput=multioutput)
 
-    if not multivariate:
-        expected_cols = y_true.columns
-    else:
-        expected_cols = ["score"]
+class TestAllDistrMetrics(PackageConfig, BaseFixtureGenerator, QuickTester):
+    """Generic tests for all regressors in the mini package."""
 
-    res = m.evaluate_by_index(y_true, y_pred)
-    assert isinstance(res, pd.DataFrame)
-    assert (res.columns == expected_cols).all()
-    assert res.shape == (y_true.shape[0], len(expected_cols))
+    # class variables which can be overridden by descendants
+    # ------------------------------------------------------
 
-    res = m.evaluate(y_true, y_pred)
+    # which object types are generated; None=all, or scitype string
+    # passed to skpro.registry.all_objects as object_type
+    object_type_filter = "metric_distr"
 
-    expect_df = not multivariate and multioutput == "raw_values"
-    if expect_df:
+    @pytest.mark.parametrize("normal", TEST_DISTS)
+    @pytest.mark.parametrize("multivariate", [True, False])
+    @pytest.mark.parametrize("multioutput", ["raw_values", "uniform_average"])
+    def test_distr_evaluate(object_instance, dist, multivariate, multioutput):
+        """Test expected output of evaluate functions."""
+        metric = object_instance
+
+        y_pred = dist.create_test_instance()
+        y_true = y_pred.sample()
+
+        m = metric(multivariate=multivariate, multioutput=multioutput)
+
+        if not multivariate:
+            expected_cols = y_true.columns
+        else:
+            expected_cols = ["score"]
+
+        res = m.evaluate_by_index(y_true, y_pred)
         assert isinstance(res, pd.DataFrame)
         assert (res.columns == expected_cols).all()
-        assert res.shape == (1, len(expected_cols))
-    else:
-        assert isinstance(res, float)
+        assert res.shape == (y_true.shape[0], len(expected_cols))
+
+        res = m.evaluate(y_true, y_pred)
+
+        expect_df = not multivariate and multioutput == "raw_values"
+        if expect_df:
+            assert isinstance(res, pd.DataFrame)
+            assert (res.columns == expected_cols).all()
+            assert res.shape == (1, len(expected_cols))
+        else:
+            assert isinstance(res, float)

--- a/skpro/tests/test_class_register.py
+++ b/skpro/tests/test_class_register.py
@@ -21,6 +21,7 @@ def get_test_class_registry():
         keys are scitypes, values are test classes TestAll[Scitype]
     """
     from skpro.distributions.tests.test_all_distrs import TestAllDistributions
+    from skpro.metrics.tests.test_distr_metrics import TestAllDistrMetrics
     from skpro.regression.tests.test_all_regressors import TestAllRegressors
     from skpro.tests.test_all_estimators import TestAllEstimators, TestAllObjects
 
@@ -37,6 +38,7 @@ def get_test_class_registry():
     # so also imply estimator and object tests, or only object tests
     testclass_dict["distribution"] = TestAllDistributions
     testclass_dict["regressor_proba"] = TestAllRegressors
+    testclass_dict["metric_proba"] = TestAllDistrMetrics
 
     return testclass_dict
 


### PR DESCRIPTION
This PR migrates tests of distribution prediction metrics to an `skbase` class.

Also generalizes the test for censored ground truth.