### PR TITLE
[ENH] add `len` of `BaseDistribution`, test `shape`, `len`, indices

### DIFF
--- a/skpro/distributions/base.py
+++ b/skpro/distributions/base.py
@@ -76,6 +76,10 @@ class BaseDistribution(BaseObject):
         """Shape of self, a pair (2-tuple)."""
         return (len(self.index), len(self.columns))
 
+    def __len__(self):
+        """Length of self, number of rows."""
+        return len(self.index)
+
     def _loc(self, rowidx=None, colidx=None):
         if rowidx is not None:
             row_iloc = self.index.get_indexer_for(rowidx)

--- a/skpro/distributions/tests/test_all_distrs.py
+++ b/skpro/distributions/tests/test_all_distrs.py
@@ -65,7 +65,7 @@ class TestAllDistributions(PackageConfig, DistributionFixtureGenerator, QuickTes
     # remove this when fixing failures to re-enable testing
 
     def test_shape(self, object_instance):
-        """Test index and shape of distribution."""
+        """Test index, columns, len and shape of distribution."""
         d = object_instance
 
         assert isinstance(d.index, pd.Index)

--- a/skpro/distributions/tests/test_all_distrs.py
+++ b/skpro/distributions/tests/test_all_distrs.py
@@ -64,6 +64,22 @@ class TestAllDistributions(PackageConfig, DistributionFixtureGenerator, QuickTes
     exclude_objects = ["QPD_S", "QPD_B", "QPD_U"]
     # remove this when fixing failures to re-enable testing
 
+    def test_shape(self, object_instance):
+        """Test index and shape of distribution."""
+        d = object_instance
+
+        assert isinstance(d.index, pd.Index)
+        assert isinstance(d.columns, pd.Index)
+
+        assert isinstance(d.shape, tuple)
+        assert len(d.shape) == 2
+
+        assert d.shape[0] == len(d.index)
+        assert d.shape[1] == len(d.columns)
+
+        assert isinstance(len(d), int)
+        assert len(d) == d.shape[0]
+
     @pytest.mark.parametrize("shuffled", [False, True])
     def test_sample(self, object_instance, shuffled):
         """Test sample expected return."""


### PR DESCRIPTION
This PR adds a `__len__` dunder to `BaseDistribution`, and a test for `len` and `shape`.