### PR TITLE
[ENH] Logistic distribution

### DIFF
--- a/skpro/distributions/__init__.py
+++ b/skpro/distributions/__init__.py
@@ -12,6 +12,7 @@ __all__ = [
     "QPD_B",
     "QPD_U",
     "TDistribution",
+    "Logistic",
 ]
 
 from skpro.distributions.empirical import Empirical
@@ -21,3 +22,4 @@ from skpro.distributions.normal import Normal
 from skpro.distributions.poisson import Poisson
 from skpro.distributions.qpd import QPD_B, QPD_S, QPD_U
 from skpro.distributions.t import TDistribution
+from skpro.distributions.logistic import Logistic

--- a/skpro/distributions/logistic.py
+++ b/skpro/distributions/logistic.py
@@ -1,0 +1,124 @@
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+"""Logistic probability distribution."""
+
+__author__ = ["malikrafsan"]
+
+import numpy as np
+import pandas as pd
+
+from skpro.distributions.base import BaseDistribution
+
+class Logistic(BaseDistribution):
+    """Logistic distribution.
+
+    Parameters
+    ----------
+    mu : float or array of float (1D or 2D)
+        mean of the logistic distribution
+    scale : float or array of float (1D or 2D), must be positive
+        scale parameter of the distribution
+    index : pd.Index, optional, default = RangeIndex
+    columns : pd.Index, optional, default = RangeIndex
+
+    Example
+    -------
+    >>> from skpro.distributions.logistic import Logistic
+
+    >>> l = Logistic(mu=[[0, 1], [2, 3], [4, 5]], scale=1)
+    """
+
+    _tags = {
+        "capabilities:approx": ["pdfnorm"],
+        "capabilities:exact": ["mean", "var", "energy", "pdf", "log_pdf", "cdf", "ppf"],
+        "distr:measuretype": "continuous",
+    }
+
+    def __init__(self, mu, scale, index=None, columns=None):
+        self.mu = mu
+        self.scale = scale
+        self.index = index
+        self.columns = columns
+
+        # todo: untangle index handling
+        # and broadcast of parameters.
+        # move this functionality to the base class
+        self._mu, self._scale = self._get_bc_params(self.mu, self.scale)
+        shape = self._mu.shape
+
+        if index is None:
+            index = pd.RangeIndex(shape[0])
+        
+        if columns is None:
+            columns = pd.RangeIndex(shape[1])
+        
+        super().__init__(index=index, columns=columns)
+
+    def energy(self, x=None):
+        raise NotImplementedError
+    
+    def mean(self):
+        r"""Return expected value of the distribution.
+
+        Let :math:`X` be a random variable with the distribution of `self`.
+        Returns the expectation :math:`\mathbb{E}[X]`
+
+        Returns
+        -------
+        pd.DataFrame with same rows, columns as `self`
+        expected value of distribution (entry-wise)
+        """
+        mean_arr = self._mu
+        return pd.DataFrame(mean_arr, index=self.index, columns=self.columns)
+
+    def var(self):
+        r"""Return variance of the distribution.
+
+        Let :math:`X` be a random variable with the distribution of `self`.
+        Returns the variance :math:`\mathbb{V}[X] = \frac{\mathbb{S}^2 \times \pi^3}{3}`
+
+        Returns
+        -------
+        pd.DataFrame with same rows, columns as `self`
+        variance of distribution (entry-wise)
+        """
+        var_arr = (self._scale**2 * np.pi**2) / 3
+        return pd.DataFrame(var_arr, index=self.index, columns=self.columns)
+    
+    def pdf(self, x):
+        """Probability density function."""
+        d = self.loc[x.index, x.columns]
+        numerator = np.exp(-(x.values - d.mu) / d.scale)
+        denumerator = d.scale * ((1 + np.exp(-(x.values - d.mu) / d.scale))**2)
+        pdf_arr = numerator / denumerator
+        return pd.DataFrame(pdf_arr, index=x.index, columns=x.columns)
+
+    def log_pdf(self, x):
+        """Logarithmic probability density function."""
+        d = self.loc[x.index, x.columns]
+        lpdf_arr = np.log(1/(2 * d.scale * (np.cosh((x.values - d.mu)/d.scale) + 1)))
+        return pd.DataFrame(lpdf_arr, index=x.index, columns=x.columns)
+
+    def cdf(self, x):
+        """Cumulative distribution function."""
+        d = self.loc[x.index, x.columns]
+        cdf_arr = (1 + np.tanh((x.values - d.mu) / (2 * d.scale))) / 2
+        return pd.DataFrame(cdf_arr, index=x.index, columns=x.columns)
+
+    def ppf(self, p):
+        """Quantile function = percent point function = inverse cdf."""
+        d = self.loc[p.index, p.columns]
+        ppf_arr = d.mu + d.scale * np.log(p.values / (1 - p.values))
+        return pd.DataFrame(ppf_arr, index=p.index, columns=p.columns)
+    
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator."""
+        params1 = {"mu": [[0, 1], [2, 3], [4, 5]], "scale": 1}
+        params2 = {
+            "mu": 0,
+            "scale": 1,
+            "index": pd.Index([1, 2, 5]),
+            "columns": pd.Index(["a", "b"]),
+        }
+        return [params1, params2]
+


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skpro.readthedocs.io/en/latest/contribute.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
https://github.com/sktime/skpro/issues/22

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
Logistic probability distribution

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new core dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core skpro package to a minimum.
-->
no

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [ ] Energy formula for logistic distribution

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->
- Yes, I try to install this library locally using `pip install --editable .[dev,test]` and create simple driver program to use this new distribution

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

* I use the formula from Wikipedia, which can be accessed [here](https://en.wikipedia.org/wiki/Logistic_distribution)
* For log_pdf, I use wolfram alpha to derive the formula, here is the screenshot
![Screenshot from 2024-04-07 01-05-52](https://github.com/sktime/skpro/assets/77711133/03f5b10d-956d-492f-8125-2d17f43f77cc)


#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
