### PR TITLE
[MNT] Fix broken api source links in latest docs version

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -134,7 +134,11 @@ def linkcode_resolve(domain, info):
         filename = "skpro/%s#L%d-L%d" % find_source()
     except Exception:
         filename = info["module"].replace(".", "/") + ".py"
-    return f"https://github.com/sktime/skpro/blob/{version_match}/{filename}"
+    if version_match == "latest":
+        version = "main"
+    else:
+        version = version_match
+    return f"https://github.com/sktime/skpro/blob/{version}/{filename}"
 
 
 # -- Options for HTML output -------------------------------------------------


### PR DESCRIPTION

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

A docs bug discussed on Discord. The source link is pointing to the non-existent latest branch instead of main. I think this would be the simplest solution, though you would have to merge to see if it works. A relevant part in sktime docs for more clarification  https://github.com/sktime/sktime/blob/9838adfed3ebd5fcf42805ddd6448606c2743585/docs/source/conf.py#L33
