### PR TITLE
[ENH] refactor test scenario creation to be lazy rather than on module load

### DIFF
--- a/skpro/tests/scenarios/scenarios_regressor_proba.py
+++ b/skpro/tests/scenarios/scenarios_regressor_proba.py
@@ -110,14 +110,6 @@ def _get_Xy_traintest():
     return X_train, X_test, y_train, y_test
 
 
-X_train, X_test, y_train, y_test = _get_Xy_traintest()
-C_train = pd.DataFrame(
-    np.random.choice([0, 1], size=len(y_train)),
-    index=y_train.index,
-    columns=y_train.columns,
-)
-
-
 class ProbaRegressorBasic(_ProbaRegressorTestScenario):
     """Fit/predict with multivariate pandas mtype (same dtype), and labels y."""
 
@@ -128,10 +120,14 @@ class ProbaRegressorBasic(_ProbaRegressorTestScenario):
         "is_enabled": True,
     }
 
-    args = {
-        "fit": {"X": X_train, "y": y_train},
-        "predict": {"X": X_test},
-    }
+    @property
+    def args(self):
+        X_train, X_test, y_train, _ = _get_Xy_traintest()
+        return {
+            "fit": {"X": X_train, "y": y_train},
+            "predict": {"X": X_test},
+        }
+
     default_method_sequence = ["fit", "predict", "predict_proba"]
     default_arg_sequence = ["fit", "predict", "predict"]
 
@@ -146,10 +142,19 @@ class ProbaRegressorSurvival(_ProbaRegressorTestScenario):
         "is_enabled": True,
     }
 
-    args = {
-        "fit": {"X": X_train, "y": y_train, "C": C_train},
-        "predict": {"X": X_test},
-    }
+    @property
+    def args(self):
+        X_train, X_test, y_train, _ = _get_Xy_traintest()
+        C_train = pd.DataFrame(
+            np.random.choice([0, 1], size=len(y_train)),
+            index=y_train.index,
+            columns=y_train.columns,
+        )
+        return {
+            "fit": {"X": X_train, "y": y_train, "C": C_train},
+            "predict": {"X": X_test},
+        }
+
     default_method_sequence = ["fit", "predict", "predict_proba"]
     default_arg_sequence = ["fit", "predict", "predict"]
 
@@ -182,9 +187,6 @@ def _get_Xy_traintest_X_mixix_ynp():
     return X_train, X_test, y_train, y_test
 
 
-X_train_mc, X_test_mc, y_train_mc, y_test_mc = _get_Xy_traintest_X_mixix_ynp()
-
-
 class ProbaRegressorXcolMixIxYnp(_ProbaRegressorTestScenario):
     """Fit/predict with multivariate pandas mtype, mixed col idx type."""
 
@@ -195,10 +197,14 @@ class ProbaRegressorXcolMixIxYnp(_ProbaRegressorTestScenario):
         "is_enabled": True,
     }
 
-    args = {
-        "fit": {"X": X_train_mc, "y": y_train_mc},
-        "predict": {"X": X_test_mc},
-    }
+    @property
+    def args(self):
+        X_train_mc, X_test_mc, y_train_mc, _ = _get_Xy_traintest_X_mixix_ynp()
+        return {
+            "fit": {"X": X_train_mc, "y": y_train_mc},
+            "predict": {"X": X_test_mc},
+        }
+
     default_method_sequence = ["fit", "predict", "predict_proba"]
     default_arg_sequence = ["fit", "predict", "predict"]
 


### PR DESCRIPTION
This PR refactors test scenario creation to be lazy rather than on module load.

Currently, the data for test scenarios is created on module load and is persisted as module variables, which may increase test collection time and memory usage. The status quo also creates a risk for side effects to which `pandas` objects are prone.

This PR migrates the architecture to the same pattern that `pytest` fixtures use, where concrete objects are only created when the scenario is loaded. The change also ensures that a new object is created each time the fixture is requested, avoiding side effects from mutating the single reference.

Same as https://github.com/sktime/sktime/pull/6278, for `skpro`.