### PR TITLE
[ENH] adapter to `lifelines`, most distributional survival regressors interfaced

### DIFF
--- a/docs/source/api_reference/survival.rst
+++ b/docs/source/api_reference/survival.rst
@@ -90,6 +90,17 @@ Proportional hazards models
     CoxPHSkSurv
     CoxNet
 
+Accelerated failure time models
+-------------------------------
+
+.. currentmodule:: skpro.survival.aft
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    AFTWeibull
+
 Generalized additive survival models
 ------------------------------------
 

--- a/docs/source/api_reference/survival.rst
+++ b/docs/source/api_reference/survival.rst
@@ -86,6 +86,7 @@ Proportional hazards models
     :template: class.rst
 
     CoxPH
+    CoxPHlifelines
     CoxPHSkSurv
     CoxNet
 

--- a/docs/source/api_reference/survival.rst
+++ b/docs/source/api_reference/survival.rst
@@ -89,6 +89,17 @@ Proportional hazards models
     CoxPHSkSurv
     CoxNet
 
+Generalized additive survival models
+------------------------------------
+
+.. currentmodule:: skpro.survival.additive
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    AalenAdditiveLifelines
+
 Tree models
 -----------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dependencies = [
 all_extras = [
     "attrs",
     "distfit",
+    "lifelines<0.29.0",
     "mapie",
     "matplotlib>=3.3.2",
     "ngboost",

--- a/skpro/survival/adapters/_common.py
+++ b/skpro/survival/adapters/_common.py
@@ -77,3 +77,44 @@ def _surv_diff(surv_arr):
     surv_arr_diff = surv_arr_diff[:, :-1]
 
     return surv_arr_diff
+
+
+def _get_fitted_params_default_safe(obj=None):
+    """Obtain fitted params of object, per sklearn convention.
+
+    Same as _get_fitted_params_default, but with exception handling.
+
+    This is since in sksurv, feature_importances_ is a property
+    and may raise an exception if the estimator does not have it.
+
+    Parameters
+    ----------
+    obj : any object
+
+    Returns
+    -------
+    fitted_params : dict with str keys
+        fitted parameters, keyed by names of fitted parameter
+    """
+    # default retrieves all self attributes ending in "_"
+    # and returns them with keys that have the "_" removed
+    #
+    # get all attributes ending in "_", exclude any that start with "_" (private)
+    fitted_params = [
+        attr for attr in dir(obj) if attr.endswith("_") and not attr.startswith("_")
+    ]
+
+    def hasattr_safe(obj, attr):
+        try:
+            if hasattr(obj, attr):
+                getattr(obj, attr)
+                return True
+        except Exception:
+            return False
+
+    # remove the "_" at the end
+    fitted_param_dict = {
+        p[:-1]: getattr(obj, p) for p in fitted_params if hasattr_safe(obj, p)
+    }
+
+    return fitted_param_dict

--- a/skpro/survival/adapters/_common.py
+++ b/skpro/survival/adapters/_common.py
@@ -1,0 +1,78 @@
+"""Common utilities for adapters."""
+
+import numpy as np
+
+
+def _clip_surv(surv_arr):
+    """Clips improper survival function values to proper range.
+
+    Enforces: values are in [0, 1] and are monotonically decreasing.
+
+    First clips to [0, 1], then enforces monotonicity, by replacing
+    any value with minimum of itself and any previous values.
+
+    Parameters
+    ----------
+    surv_arr : 2D np.ndarray
+        Survival function values.
+        index 0 is instance index.
+        index 1 is time index, increasing.
+
+    Returns
+    -------
+    surv_arr_clipped : 2D np.ndarray
+        Clipped survival function values.
+    surv_arr_diff : 2D np.ndarray
+        Difference of clipped survival function values.
+        Same as np.diff(surv_arr_clipped, axis=1, prepend=1).
+        Returned to avoid recomputation, if needed later in context.
+    clipped : boolean
+        Whether clipping was needed.
+    """
+    too_large = surv_arr > 1
+    too_small = surv_arr < 0
+
+    surv_arr[too_large] = 1
+    surv_arr[too_small] = 0
+
+    surv_arr_diff = _surv_diff(surv_arr)
+
+    # avoid iterative minimization if no further clipping is needed
+    if not (surv_arr_diff > 0).any():
+        clipped = too_large.any() or too_small.any()
+        return surv_arr, surv_arr_diff, clipped
+
+    # enforce monotonicity
+    # iterating from left to right ensures values are replaced
+    # with minimum of itself and all values to the left
+    for i in range(1, surv_arr.shape[1]):
+        surv_arr[:, i] = np.minimum(surv_arr[:, i], surv_arr[:, i - 1])
+
+    surv_arr_diff = _surv_diff(surv_arr)
+
+    return surv_arr, surv_arr_diff, True
+
+
+def _surv_diff(surv_arr):
+    """Compute difference of survival function values.
+
+    Parameters
+    ----------
+    surv_arr : 2D np.ndarray
+        Survival function values.
+        index 0 is instance index.
+        index 1 is time index, increasing.
+
+    Returns
+    -------
+    surv_arr_diff : 2D np.ndarray, same shape as surv_arr
+        Difference of survival function values.
+        Same as np.diff(surv_arr, axis=1, prepend=1, append=0),
+        then summing the last two columns to become one column
+    """
+    surv_arr_diff = np.diff(surv_arr, axis=1, prepend=1, append=0)
+
+    surv_arr_diff[:, -2] = surv_arr_diff[:, -2] + surv_arr_diff[:, -1]
+    surv_arr_diff = surv_arr_diff[:, :-1]
+
+    return surv_arr_diff

--- a/skpro/survival/adapters/_common.py
+++ b/skpro/survival/adapters/_common.py
@@ -22,7 +22,7 @@ def _clip_surv(surv_arr):
     -------
     surv_arr_clipped : 2D np.ndarray
         Clipped survival function values.
-    surv_arr_diff : 2D np.ndarray
+    surv_arr_diff : 2D np.ndarray, same shape as surv_arr_clipped.
         Difference of clipped survival function values.
         Same as np.diff(surv_arr, axis=1, prepend=1, append=0),
         then summing the last two columns to become one column.

--- a/skpro/survival/adapters/_common.py
+++ b/skpro/survival/adapters/_common.py
@@ -24,7 +24,8 @@ def _clip_surv(surv_arr):
         Clipped survival function values.
     surv_arr_diff : 2D np.ndarray
         Difference of clipped survival function values.
-        Same as np.diff(surv_arr_clipped, axis=1, prepend=1).
+        Same as np.diff(surv_arr, axis=1, prepend=1, append=0),
+        then summing the last two columns to become one column.
         Returned to avoid recomputation, if needed later in context.
     clipped : boolean
         Whether clipping was needed.

--- a/skpro/survival/adapters/lifelines.py
+++ b/skpro/survival/adapters/lifelines.py
@@ -4,6 +4,8 @@
 __all__ = ["_LifelinesAdapter"]
 __author__ = ["fkiraly"]
 
+from warnings import warn
+
 import numpy as np
 import pandas as pd
 
@@ -142,7 +144,20 @@ class _LifelinesAdapter:
         times_df = pd.DataFrame(times_val, index=mi, columns=self._y_cols)
 
         lifelines_survf_t = np.transpose(lifelines_survf.values)
-        weights = -np.diff(lifelines_survf_t, axis=1).flatten()
+        _, lifelines_survf_t_diff, clipped = _clip_surv(lifelines_survf_t)
+
+        if clipped:
+            warn(
+                f"Warning from {self.__class__.__name__}: "
+                f"Interfaced lifelines class {lifelines_est.__class__.__name__} "
+                "produced improper survival function predictions, i.e., "
+                "not monotonically decreasing or not in [0, 1]. "
+                "skpro has clipped the predictions to enforce proper range and "
+                "valid predictive distributions. "
+                "However, predictions may still be unreliable."
+            )
+
+        weights = -lifelines_survf_t_diff.flatten()
         weights_df = pd.Series(weights, index=mi)
 
         dist = Empirical(
@@ -150,3 +165,53 @@ class _LifelinesAdapter:
         )
 
         return dist
+
+
+def _clip_surv(surv_arr):
+    """Clips improper survival function values to proper range.
+
+    Enforces: values are in [0, 1] and are monotonically decreasing.
+
+    First clips to [0, 1], then enforces monotonicity, by replacing
+    any value with minimum of itself and any previous values.
+
+    Parameters
+    ----------
+    surv_arr : 2D np.ndarray
+        Survival function values.
+        index 0 is instance index.
+        index 1 is time index, increasing.
+
+    Returns
+    -------
+    surv_arr_clipped : 2D np.ndarray
+        Clipped survival function values.
+    surv_arr_diff : 2D np.ndarray
+        Difference of clipped survival function values.
+        Same as np.diff(surv_arr_clipped, axis=1).
+        Returned to avoid recomputation, if needed later in context.
+    clipped : boolean
+        Whether clipping was needed.
+    """
+    too_large = surv_arr > 1
+    too_small = surv_arr < 0
+
+    surv_arr[too_large] = 1
+    surv_arr[too_small] = 0
+
+    surv_arr_diff = np.diff(surv_arr, axis=1)
+
+    # avoid iterative minimization if no further clipping is needed
+    if np.sum(surv_arr_diff == 0):
+        clipped = too_large.any() or too_small.any()
+        return surv_arr, surv_arr_diff, clipped
+
+    # enforce monotonicity
+    # iterating from left to right ensures values are replaced
+    # with minimum of itself and all values to the left
+    for i in range(1, surv_arr.shape[1]):
+        surv_arr[:, i] = np.minimum(surv_arr[:, i], surv_arr[:, i - 1])
+
+    surv_arr_diff = np.diff(surv_arr, axis=1)
+
+    return surv_arr, surv_arr_diff, True

--- a/skpro/survival/adapters/lifelines.py
+++ b/skpro/survival/adapters/lifelines.py
@@ -155,7 +155,8 @@ class _LifelinesAdapter:
                 "not monotonically decreasing or not in [0, 1]. "
                 "skpro has clipped the predictions to enforce proper range and "
                 "valid predictive distributions. "
-                "However, predictions may still be unreliable."
+                "However, predictions may still be unreliable.",
+                stacklevel=2,
             )
 
         weights = -lifelines_survf_t_diff.flatten()

--- a/skpro/survival/adapters/lifelines.py
+++ b/skpro/survival/adapters/lifelines.py
@@ -110,7 +110,7 @@ class _LifelinesAdapter:
 
         # write fitted params to self
         # some fitted parameters are properties and may raise exceptions
-        # for example, AIC_ of CoxPHFitter
+        # for example, AIC_ and AIC_partial_ of CoxPHFitter
         # to avoid this, we use a safe getter
         lifelines_fitted_params = _get_fitted_params_default_safe(lifelines_est)
         for k, v in lifelines_fitted_params.items():

--- a/skpro/survival/adapters/lifelines.py
+++ b/skpro/survival/adapters/lifelines.py
@@ -109,6 +109,9 @@ class _LifelinesAdapter:
         lifelines_est.fit(**fit_args)
 
         # write fitted params to self
+        # some fitted parameters are properties and may raise exceptions
+        # for example, AIC_ of CoxPHFitter
+        # to avoid this, we use a safe getter
         lifelines_fitted_params = _get_fitted_params_default_safe(lifelines_est)
         for k, v in lifelines_fitted_params.items():
             setattr(self, f"{k}_", v)

--- a/skpro/survival/adapters/lifelines.py
+++ b/skpro/survival/adapters/lifelines.py
@@ -143,7 +143,7 @@ class _LifelinesAdapter:
         times_df = pd.DataFrame(times_val, index=mi, columns=self._y_cols)
 
         lifelines_survf_t = np.transpose(lifelines_survf.values)
-        weights = -np.diff(lifelines_survf, axis=1).flatten()
+        weights = -np.diff(lifelines_survf_t, axis=1).flatten()
         weights_df = pd.Series(weights, index=mi)
 
         dist = Empirical(

--- a/skpro/survival/adapters/lifelines.py
+++ b/skpro/survival/adapters/lifelines.py
@@ -95,7 +95,6 @@ class _LifelinesAdapter:
         self._y_cols = y.columns  # remember column names for later
         y_name = y.columns[0]
 
-
         fit_args = {
             "df": df,
             "duration_col": y_name,

--- a/skpro/survival/adapters/lifelines.py
+++ b/skpro/survival/adapters/lifelines.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 
 from skpro.distributions.empirical import Empirical
+from skpro.survival.adapters._common import _clip_surv
 from skpro.utils.sklearn import prep_skl_df
 
 
@@ -165,53 +166,3 @@ class _LifelinesAdapter:
         )
 
         return dist
-
-
-def _clip_surv(surv_arr):
-    """Clips improper survival function values to proper range.
-
-    Enforces: values are in [0, 1] and are monotonically decreasing.
-
-    First clips to [0, 1], then enforces monotonicity, by replacing
-    any value with minimum of itself and any previous values.
-
-    Parameters
-    ----------
-    surv_arr : 2D np.ndarray
-        Survival function values.
-        index 0 is instance index.
-        index 1 is time index, increasing.
-
-    Returns
-    -------
-    surv_arr_clipped : 2D np.ndarray
-        Clipped survival function values.
-    surv_arr_diff : 2D np.ndarray
-        Difference of clipped survival function values.
-        Same as np.diff(surv_arr_clipped, axis=1, prepend=1).
-        Returned to avoid recomputation, if needed later in context.
-    clipped : boolean
-        Whether clipping was needed.
-    """
-    too_large = surv_arr > 1
-    too_small = surv_arr < 0
-
-    surv_arr[too_large] = 1
-    surv_arr[too_small] = 0
-
-    surv_arr_diff = np.diff(surv_arr, axis=1, prepend=1)
-
-    # avoid iterative minimization if no further clipping is needed
-    if not (surv_arr_diff > 0).any():
-        clipped = too_large.any() or too_small.any()
-        return surv_arr, surv_arr_diff, clipped
-
-    # enforce monotonicity
-    # iterating from left to right ensures values are replaced
-    # with minimum of itself and all values to the left
-    for i in range(1, surv_arr.shape[1]):
-        surv_arr[:, i] = np.minimum(surv_arr[:, i], surv_arr[:, i - 1])
-
-    surv_arr_diff = np.diff(surv_arr, axis=1, prepend=1)
-
-    return surv_arr, surv_arr_diff, True

--- a/skpro/survival/adapters/lifelines.py
+++ b/skpro/survival/adapters/lifelines.py
@@ -202,7 +202,7 @@ def _clip_surv(surv_arr):
     surv_arr_diff = np.diff(surv_arr, axis=1)
 
     # avoid iterative minimization if no further clipping is needed
-    if np.sum(surv_arr_diff > 0) == 0:
+    if not (surv_arr_diff > 0).any():
         clipped = too_large.any() or too_small.any()
         return surv_arr, surv_arr_diff, clipped
 

--- a/skpro/survival/adapters/lifelines.py
+++ b/skpro/survival/adapters/lifelines.py
@@ -36,9 +36,9 @@ class _LifelinesAdapter:
 
         should import and return lifelines class
         """
-        # from lifelines import lifelinesClass
+        # from lifelines import LifelinesClass
         #
-        # return lifelines
+        # return LifelinesClass
         raise NotImplementedError("abstract method")
 
     def _get_lifelines_object(self):

--- a/skpro/survival/adapters/lifelines.py
+++ b/skpro/survival/adapters/lifelines.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 
 from skpro.distributions.empirical import Empirical
-from skpro.survival.adapters._common import _clip_surv
+from skpro.survival.adapters._common import _clip_surv, _get_fitted_params_default_safe
 from skpro.utils.sklearn import prep_skl_df
 
 
@@ -109,7 +109,7 @@ class _LifelinesAdapter:
         lifelines_est.fit(**fit_args)
 
         # write fitted params to self
-        lifelines_fitted_params = self._get_fitted_params_default(lifelines_est)
+        lifelines_fitted_params = _get_fitted_params_default_safe(lifelines_est)
         for k, v in lifelines_fitted_params.items():
             setattr(self, f"{k}_", v)
 

--- a/skpro/survival/adapters/lifelines.py
+++ b/skpro/survival/adapters/lifelines.py
@@ -202,7 +202,7 @@ def _clip_surv(surv_arr):
     surv_arr_diff = np.diff(surv_arr, axis=1)
 
     # avoid iterative minimization if no further clipping is needed
-    if np.sum(surv_arr_diff == 0):
+    if np.sum(surv_arr_diff > 0) == 0:
         clipped = too_large.any() or too_small.any()
         return surv_arr, surv_arr_diff, clipped
 

--- a/skpro/survival/adapters/lifelines.py
+++ b/skpro/survival/adapters/lifelines.py
@@ -1,0 +1,153 @@
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""Implements adapter for lifelines models."""
+
+__all__ = ["_LifelinesAdapter"]
+__author__ = ["fkiraly"]
+
+import numpy as np
+import pandas as pd
+
+from skpro.distributions.empirical import Empirical
+from skpro.utils.sklearn import prep_skl_df
+
+
+class _LifelinesAdapter:
+    """Mixin adapter class for lifelines models."""
+
+    _tags = {
+        # packaging info
+        # --------------
+        "authors": ["fkiraly"],
+        "python_dependencies": ["lifelines"],
+        "license_type": "permissive",
+        # capability tags
+        # ---------------
+        "X_inner_mtype": "pd_DataFrame_Table",
+        "y_inner_mtype": "pd_DataFrame_Table",
+        "C_inner_mtype": "pd_DataFrame_Table",
+        "capability:multioutput": False,
+    }
+
+    # defines the name of the attribute containing the lifelines estimator
+    _estimator_attr = "_estimator"
+
+    def _get_lifelines_class(self):
+        """Abstract method to get lifelines class.
+
+        should import and return lifelines class
+        """
+        # from lifelines import lifelinesClass
+        #
+        # return lifelines
+        raise NotImplementedError("abstract method")
+
+    def _get_lifelines_object(self):
+        """Abstract method to initialize lifelines object.
+
+        The default initializes result of _get_lifelines_class
+        with self.get_params.
+        """
+        cls = self._get_lifelines_class()
+        return cls(**self.get_params())
+
+    def _init_lifelines_object(self):
+        """Abstract method to initialize lifelines object and set to _estimator_attr.
+
+        The default writes the return of _get_lifelines_object to
+        the attribute of self with name _estimator_attr
+        """
+        cls = self._get_lifelines_object()
+        setattr(self, self._estimator_attr, cls)
+        return getattr(self, self._estimator_attr)
+
+    def _fit(self, X, y, C=None):
+        """Fit estimator training data.
+
+        Parameters
+        ----------
+        X : pd.DataFrame
+            Training features
+        y: pd.Series
+            Training labels
+        C: pd.Series, optional (default=None)
+            Censoring information for survival analysis.
+
+        Returns
+        -------
+        self: reference to self
+            Fitted estimator.
+        """
+        lifelines_est = self._init_lifelines_object()
+
+        # input conversion
+        X = X.astype("float")  # lifelines insists on float dtype
+        X = prep_skl_df(X)
+
+        to_concat = [X, y]
+
+        if C is not None:
+            C_col = 1 - C.copy()  # lifelines uses 1 for uncensored, 0 for censored
+            C_col.columns = ["__C"]
+            to_concat.append(C_col)
+
+        df = pd.concat(to_concat, axis=1)
+
+        self._y_cols = y.columns  # remember column names for later
+        y_name = y.columns[0]
+
+
+        fit_args = {
+            "df": df,
+            "duration_col": y_name,
+        }
+        if C is not None:
+            fit_args["event_col"] = "__C"
+
+        # fit lifelines estimator
+        lifelines_est.fit(**fit_args)
+
+        # write fitted params to self
+        lifelines_fitted_params = self._get_fitted_params_default(lifelines_est)
+        for k, v in lifelines_fitted_params.items():
+            setattr(self, f"{k}_", v)
+
+        return self
+
+    def _predict_proba(self, X):
+        """Predict_proba method adapter.
+
+        Parameters
+        ----------
+        X : pd.DataFrame
+            Features to predict on.
+
+        Returns
+        -------
+        skpro Empirical distribution
+        """
+        lifelines_est = getattr(self, self._estimator_attr)
+
+        # input conversion
+        X = X.astype("float")  # lifelines insists on float dtype
+        X = prep_skl_df(X)
+
+        # predict on X
+        lifelines_survf = lifelines_est.predict_survival_function(X)
+
+        times = lifelines_survf.index[:-1]
+
+        nt = len(times)
+        mi = pd.MultiIndex.from_product([X.index, range(nt)]).swaplevel()
+
+        times_val = np.repeat(times, repeats=len(X))
+        times_df = pd.DataFrame(times_val, index=mi, columns=self._y_cols)
+
+        lifelines_survf_t = np.transpose(lifelines_survf.values)
+        weights = -np.diff(lifelines_survf, axis=1).flatten()
+        weights_df = pd.Series(weights, index=mi)
+
+        dist = Empirical(
+            spl=times_df, weights=weights_df, index=X.index, columns=self._y_cols
+        )
+
+        return dist

--- a/skpro/survival/adapters/lifelines.py
+++ b/skpro/survival/adapters/lifelines.py
@@ -63,6 +63,25 @@ class _LifelinesAdapter:
         setattr(self, self._estimator_attr, cls)
         return getattr(self, self._estimator_attr)
 
+    def _get_extra_fit_args(self, X, y, C=None):
+        """Get extra arguments for the fit method.
+
+        Parameters
+        ----------
+        X : pd.DataFrame
+            Training features
+        y: pd.DataFrame
+            Training labels
+        C: pd.DataFrame, optional (default=None)
+            Censoring information for survival analysis.
+
+        Returns
+        -------
+        dict
+            Extra arguments for the fit method.
+        """
+        return {}
+
     def _fit(self, X, y, C=None):
         """Fit estimator training data.
 
@@ -70,9 +89,9 @@ class _LifelinesAdapter:
         ----------
         X : pd.DataFrame
             Training features
-        y: pd.Series
+        y: pd.DataFrame
             Training labels
-        C: pd.Series, optional (default=None)
+        C: pd.DataFrame, optional (default=None)
             Censoring information for survival analysis.
 
         Returns
@@ -85,6 +104,9 @@ class _LifelinesAdapter:
         # input conversion
         X = X.astype("float")  # lifelines insists on float dtype
         X = prep_skl_df(X)
+
+        if hasattr(self, "X_col_subset"):
+            X = X[self.X_col_subset]
 
         to_concat = [X, y]
 
@@ -104,6 +126,8 @@ class _LifelinesAdapter:
         }
         if C is not None:
             fit_args["event_col"] = "__C"
+
+        fit_args.update(self._get_extra_fit_args(X, y, C))
 
         # fit lifelines estimator
         lifelines_est.fit(**fit_args)

--- a/skpro/survival/adapters/lifelines.py
+++ b/skpro/survival/adapters/lifelines.py
@@ -135,7 +135,7 @@ class _LifelinesAdapter:
         # predict on X
         lifelines_survf = lifelines_est.predict_survival_function(X)
 
-        times = lifelines_survf.index[:-1]
+        times = lifelines_survf.index
 
         nt = len(times)
         mi = pd.MultiIndex.from_product([X.index, range(nt)]).swaplevel()
@@ -188,7 +188,7 @@ def _clip_surv(surv_arr):
         Clipped survival function values.
     surv_arr_diff : 2D np.ndarray
         Difference of clipped survival function values.
-        Same as np.diff(surv_arr_clipped, axis=1).
+        Same as np.diff(surv_arr_clipped, axis=1, prepend=1).
         Returned to avoid recomputation, if needed later in context.
     clipped : boolean
         Whether clipping was needed.
@@ -199,7 +199,7 @@ def _clip_surv(surv_arr):
     surv_arr[too_large] = 1
     surv_arr[too_small] = 0
 
-    surv_arr_diff = np.diff(surv_arr, axis=1)
+    surv_arr_diff = np.diff(surv_arr, axis=1, prepend=1)
 
     # avoid iterative minimization if no further clipping is needed
     if not (surv_arr_diff > 0).any():
@@ -212,6 +212,6 @@ def _clip_surv(surv_arr):
     for i in range(1, surv_arr.shape[1]):
         surv_arr[:, i] = np.minimum(surv_arr[:, i], surv_arr[:, i - 1])
 
-    surv_arr_diff = np.diff(surv_arr, axis=1)
+    surv_arr_diff = np.diff(surv_arr, axis=1, prepend=1)
 
     return surv_arr, surv_arr_diff, True

--- a/skpro/survival/adapters/sksurv.py
+++ b/skpro/survival/adapters/sksurv.py
@@ -102,7 +102,7 @@ class _SksurvAdapter:
 
         # write fitted params to self
         # some fitted parameters are properties and may raise exceptions
-        # for example, AIC_ of CoxPHFitter
+        # for example, AIC_ and AIC_partial_ of CoxPHFitter
         # to avoid this, we use a safe getter
         EXCEPTED_FITTED_PARAMS = ["n_features_in", "feature_names_in"]
         sksurv_fitted_params = _get_fitted_params_default_safe(sksurv_est)

--- a/skpro/survival/adapters/sksurv.py
+++ b/skpro/survival/adapters/sksurv.py
@@ -160,8 +160,7 @@ class _SksurvAdapter:
 
         Returns
         -------
-        np.ndarray (1d array of shape (n_instances,))
-            Index of the cluster each time series in X belongs to.
+        skpro Empirical distribution
         """
         sksurv_est = getattr(self, self._estimator_attr)
 

--- a/skpro/survival/adapters/sksurv.py
+++ b/skpro/survival/adapters/sksurv.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 
 from skpro.distributions.empirical import Empirical
+from skpro.survival.adapters._common import _get_fitted_params_default_safe
 from skpro.utils.sklearn import prep_skl_df
 
 
@@ -101,54 +102,12 @@ class _SksurvAdapter:
 
         # write fitted params to self
         EXCEPTED_FITTED_PARAMS = ["n_features_in", "feature_names_in"]
-        sksurv_fitted_params = self._get_fitted_params_default_safe(sksurv_est)
+        sksurv_fitted_params = _get_fitted_params_default_safe(sksurv_est)
         for k, v in sksurv_fitted_params.items():
             if k not in EXCEPTED_FITTED_PARAMS:
                 setattr(self, f"{k}_", v)
 
         return self
-
-    def _get_fitted_params_default_safe(self, obj=None):
-        """Obtain fitted params of object, per sklearn convention.
-
-        Same as _get_fitted_params_default, but with exception handling.
-
-        This is since in sksurv, feature_importances_ is a property
-        and may raise an exception if the estimator does not have it.
-
-        Parameters
-        ----------
-        obj : any object, optional, default=self
-
-        Returns
-        -------
-        fitted_params : dict with str keys
-            fitted parameters, keyed by names of fitted parameter
-        """
-        obj = obj if obj else self
-
-        # default retrieves all self attributes ending in "_"
-        # and returns them with keys that have the "_" removed
-        #
-        # get all attributes ending in "_", exclude any that start with "_" (private)
-        fitted_params = [
-            attr for attr in dir(obj) if attr.endswith("_") and not attr.startswith("_")
-        ]
-
-        def hasattr_safe(obj, attr):
-            try:
-                if hasattr(obj, attr):
-                    getattr(obj, attr)
-                    return True
-            except Exception:
-                return False
-
-        # remove the "_" at the end
-        fitted_param_dict = {
-            p[:-1]: getattr(obj, p) for p in fitted_params if hasattr_safe(obj, p)
-        }
-
-        return fitted_param_dict
 
     def _predict_proba(self, X):
         """Predict_proba method adapter.

--- a/skpro/survival/adapters/sksurv.py
+++ b/skpro/survival/adapters/sksurv.py
@@ -37,9 +37,9 @@ class _SksurvAdapter:
 
         should import and return sksurv class
         """
-        # from sksurv import sksurvClass
+        # from sksurv import SksurvClass
         #
-        # return sksurv
+        # return SksurvClass
         raise NotImplementedError("abstract method")
 
     def _get_sksurv_object(self):

--- a/skpro/survival/adapters/sksurv.py
+++ b/skpro/survival/adapters/sksurv.py
@@ -101,6 +101,9 @@ class _SksurvAdapter:
         sksurv_est.fit(X, y_sksurv)
 
         # write fitted params to self
+        # some fitted parameters are properties and may raise exceptions
+        # for example, AIC_ of CoxPHFitter
+        # to avoid this, we use a safe getter
         EXCEPTED_FITTED_PARAMS = ["n_features_in", "feature_names_in"]
         sksurv_fitted_params = _get_fitted_params_default_safe(sksurv_est)
         for k, v in sksurv_fitted_params.items():

--- a/skpro/survival/additive/__init__.py
+++ b/skpro/survival/additive/__init__.py
@@ -1,0 +1,3 @@
+"""Generalized additive survival models."""
+
+from skpro.additive._aalen_lifelines import AalenAdditiveLifelines

--- a/skpro/survival/additive/__init__.py
+++ b/skpro/survival/additive/__init__.py
@@ -1,3 +1,5 @@
 """Generalized additive survival models."""
 
+__all__ = ["AalenAdditiveLifelines"]
+
 from skpro.additive._aalen_lifelines import AalenAdditiveLifelines

--- a/skpro/survival/additive/__init__.py
+++ b/skpro/survival/additive/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["AalenAdditiveLifelines"]
 
-from skpro.additive._aalen_lifelines import AalenAdditiveLifelines
+from skpro.survival.additive._aalen_lifelines import AalenAdditiveLifelines

--- a/skpro/survival/additive/__init__.py
+++ b/skpro/survival/additive/__init__.py
@@ -1,5 +1,5 @@
 """Generalized additive survival models."""
 
-__all__ = ["AalenAdditiveLifelines"]
+__all__ = ["AalenAdditive"]
 
-from skpro.survival.additive._aalen_lifelines import AalenAdditiveLifelines
+from skpro.survival.additive._aalen_lifelines import AalenAdditive

--- a/skpro/survival/additive/_aalen_lifelines.py
+++ b/skpro/survival/additive/_aalen_lifelines.py
@@ -12,7 +12,7 @@ class AalenAdditive(_LifelinesAdapter, BaseSurvReg):
 
     Direct interface to ``lifelines.fitters.AalenAdditiveFitter``,
     by ``CamDavidsonPilon``.
-    
+
     This class fits the regression model:
 
     .. math::  h(t|x)  = b_0(t) + b_1(t) x_1 + ... + b_N(t) x_N
@@ -22,7 +22,7 @@ class AalenAdditive(_LifelinesAdapter, BaseSurvReg):
     This implementation assumes non-time-varying covariates.
 
     Parameters
-    -----------
+    ----------
     fit_intercept: bool, optional (default: True)
       If False, do not attach an intercept (column of ones) to the covariate matrix.
       The intercept, :math:`b_0(t)` acts as a baseline hazard.

--- a/skpro/survival/additive/_aalen_lifelines.py
+++ b/skpro/survival/additive/_aalen_lifelines.py
@@ -51,7 +51,7 @@ class AalenAdditive(_LifelinesAdapter, BaseSurvReg):
     """
 
     _tags = {"authors": ["CamDavidsonPilon", "rocreguant", "fkiraly"]}
-    # CamDavidsonPilon credit for interfaced estimator
+    # CamDavidsonPilon, rocreguant credit for interfaced estimator
 
     def __init__(
         self,

--- a/skpro/survival/additive/_aalen_lifelines.py
+++ b/skpro/survival/additive/_aalen_lifelines.py
@@ -1,0 +1,103 @@
+"""Interface adapter to lifelines Aalen additive surival model."""
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+
+__author__ = ["fkiraly"]
+
+from skpro.survival.adapters.lifelines import _LifelinesAdapter
+from skpro.survival.base import BaseSurvReg
+
+
+class AalenAdditive(_LifelinesAdapter, BaseSurvReg):
+    r"""Aalen additive hazards model, from lifelines.
+
+    Direct interface to ``lifelines.fitters.AalenAdditiveFitter``,
+    by ``CamDavidsonPilon``.
+    
+    This class fits the regression model:
+
+    .. math::  h(t|x)  = b_0(t) + b_1(t) x_1 + ... + b_N(t) x_N
+
+    that is, the hazard rate is a linear function of the covariates
+    with time-varying coefficients.
+    This implementation assumes non-time-varying covariates.
+
+    Parameters
+    -----------
+    fit_intercept: bool, optional (default: True)
+      If False, do not attach an intercept (column of ones) to the covariate matrix.
+      The intercept, :math:`b_0(t)` acts as a baseline hazard.
+    alpha: float, optional (default=0.05)
+      the level in the confidence intervals around the estimated survival function,
+      for computation of ``confidence_intervals_`` fitted parameter.
+    coef_penalizer: float, optional (default: 0)
+      Attach a L2 penalizer to the size of the coefficients during regression.
+      This improves
+      stability of the estimates and controls for high correlation between covariates.
+      For example, this shrinks the magnitude of :math:`c_{i,t}`.
+    smoothing_penalizer: float, optional (default: 0)
+      Attach a L2 penalizer to difference between adjacent (over time) coefficients.
+      For example, this shrinks the magnitude of :math:`c_{i,t} - c_{i,t+1}`.
+
+    Attributes
+    ----------
+    cumulative_hazards_ : DataFrame
+        The estimated cumulative hazard
+    hazards_ : DataFrame
+        The estimated hazards
+    confidence_intervals_ : DataFrame
+        The lower and upper confidence intervals for the cumulative hazard
+    durations: array
+        The durations provided
+    """
+
+    _tags = {"authors": ["CamDavidsonPilon", "rocreguant", "fkiraly"]}
+    # CamDavidsonPilon credit for interfaced estimator
+
+    def __init__(
+        self,
+        fit_intercept=True,
+        alpha=0.05,
+        coef_penalizer=0.0,
+        smoothing_penalizer=0.0,
+    ):
+        self.fit_intercept = fit_intercept
+        self.alpha = alpha
+        self.coef_penalizer = coef_penalizer
+        self.smoothing_penalizer = smoothing_penalizer
+
+        super().__init__()
+
+    def _get_lifelines_class(self):
+        """Getter of the lifelines class to be used for the adapter."""
+        from lifelines.fitters.aalen_additive_fitter import AalenAdditiveFitter
+
+        return AalenAdditiveFitter
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+        params1 = {}
+
+        params2 = {
+            "fit_intercept": False,
+            "alpha": 0.1,
+            "coef_penalizer": 0.1,
+            "smoothing_penalizer": 0.1,
+        }
+
+        return [params1, params2]

--- a/skpro/survival/aft/__init__.py
+++ b/skpro/survival/aft/__init__.py
@@ -1,6 +1,6 @@
 """Module containing accelerated failure time models."""
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 
-__all__ = ["_SksurvAdapter"]
+__all__ = ["AFTWeibull"]
 
-from skpro.survival.adapters.sksurv import _SksurvAdapter
+from skpro.survival.aft._aft_lifelines_weibull import AFTWeibull

--- a/skpro/survival/aft/__init__.py
+++ b/skpro/survival/aft/__init__.py
@@ -1,0 +1,6 @@
+"""Module containing accelerated failure time models."""
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+
+__all__ = ["_SksurvAdapter"]
+
+from skpro.survival.adapters.sksurv import _SksurvAdapter

--- a/skpro/survival/aft/_aft_lifelines_weibull.py
+++ b/skpro/survival/aft/_aft_lifelines_weibull.py
@@ -180,9 +180,9 @@ class AFTWeibull(_LifelinesAdapter, BaseSurvReg):
         lifelines_est = getattr(self, self._estimator_attr)
         ll_pred_proba = lifelines_est._prep_inputs_for_prediction_and_return_scores
 
-        scale, shape = ll_pred_proba(df, ancillary)
+        scale, k = ll_pred_proba(df, ancillary)
 
-        dist = Weibull(scale=scale, shape=shape, index=X.index, columns=self._y_cols)
+        dist = Weibull(scale=scale, k=k, index=X.index, columns=self._y_cols)
         return dist
 
     @classmethod

--- a/skpro/survival/aft/_aft_lifelines_weibull.py
+++ b/skpro/survival/aft/_aft_lifelines_weibull.py
@@ -1,0 +1,126 @@
+"""Interface adapter to lifelines Weibull AFT model."""
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+
+__author__ = ["fkiraly"]
+
+from skpro.survival.adapters.lifelines import _LifelinesAdapter
+from skpro.survival.base import BaseSurvReg
+
+
+class AFTWeibullLifelines(_LifelinesAdapter, BaseSurvReg):
+    r"""Weibull AFT model, from lifelines.
+
+    Direct interface to ``lifelines.fitters.WeibullAFTFitter``,
+    by ``CamDavidsonPilon``.
+
+    This class implements a Weibull AFT model. The model has parametric form, with
+    :math:`\lambda(x) = \exp\left(\beta_0 + \beta_1x_1 + ... + \beta_n x_n \right)`,
+    and optionally,
+    :math:`\rho(y) = \exp\left(\alpha_0 + \alpha_1 y_1 + ... + \alpha_m y_m \right)`,
+
+    with predictive distribution being Weibull, with
+    scale parameter :math:`\lambda(x)` and shape parameter (exponent) :math:`\rho(y)`.
+
+    The :math:`\lambda` (scale) parameter is a decay or half-like like parameter,
+    more specifically, the time by which the survival probability is 37%.
+    The :math:`\rho` (shape) parameter controls curvature of the the cumulative hazard,
+    e.g., whether it is convex or concave, representing accelerating or decelerating
+    hazards.
+
+    The cumulative hazard rate is
+
+    .. math:: H(t; x, y) = \left(\frac{t}{\lambda(x)} \right)^{\rho(y)},
+
+    Parameters
+    ----------
+    alpha: float, optional (default=0.05)
+      the level in the confidence intervals around the estimated survival function,
+      for computation of ``confidence_intervals_`` fitted parameter.
+
+    fit_intercept: boolean, optional (default=True)
+        Whether to fit an intercept term in the model.
+
+    penalizer: float or array, optional (default=0.0)
+        the penalizer coefficient to the size of the coefficients.
+        See ``l1_ratio``. Must be equal to or greater than 0.
+        Alternatively, penalizer is an array equal in size to the number of parameters,
+        with penalty coefficients for specific variables. For
+        example, ``penalizer=0.01 * np.ones(p)`` is the same as ``penalizer=0.01``
+
+    l1_ratio: float, optional (default=0.0)
+        how much of the penalizer should be attributed to an l1 penalty
+        (otherwise an l2 penalty). The penalty function looks like
+        ``penalizer * l1_ratio * ||w||_1 + 0.5 * penalizer * (1 - l1_ratio) * ||w||^2_2``  # noqa E501
+
+    Attributes
+    ----------
+    params_ : DataFrame
+        The estimated coefficients
+    confidence_intervals_ : DataFrame
+        The lower and upper confidence intervals for the coefficients
+    durations: Series
+        The event_observed variable provided
+    event_observed: Series
+        The event_observed variable provided
+    weights: Series
+        The event_observed variable provided
+    variance_matrix_ : DataFrame
+        The variance matrix of the coefficients
+    standard_errors_: Series
+        the standard errors of the estimates
+    score_: float
+        the concordance index of the model.
+    """
+
+    _tags = {"authors": ["CamDavidsonPilon", "JoseLlanes", "mathurinm", "fkiraly"]}
+    # CamDavidsonPilon, JoseLlanes, mathurinm credit for interfaced estimator
+
+    def __init__(
+        self,
+        alpha: float = 0.05,
+        penalizer: float = 0.0,
+        l1_ratio: float = 0.0,
+        fit_intercept: bool = True,
+    ):
+        self.alpha = alpha
+        self.penalizer = penalizer
+        self.l1_ratio = l1_ratio
+        self.fit_intercept = fit_intercept
+
+        super().__init__()
+
+    def _get_lifelines_class(self):
+        """Getter of the lifelines class to be used for the adapter."""
+        from lifelines.fitters.weibull_aft_fitter import WeibullAFTFitter
+
+        return WeibullAFTFitter
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+        params1 = {}
+
+        params2 = {
+            "baseline_estimation_method": "spline",
+            "penalizer": 0.1,
+            "l1_ratio": 0.1,
+            "n_baseline_knots": 3,
+        }
+
+
+        return [params1, params2]

--- a/skpro/survival/aft/_aft_lifelines_weibull.py
+++ b/skpro/survival/aft/_aft_lifelines_weibull.py
@@ -48,7 +48,7 @@ class AFTWeibull(_LifelinesAdapter, BaseSurvReg):
 
     fit_intercept: boolean, optional (default=True)
         Whether to fit an intercept term in the model.
-    
+
     alpha: float, optional (default=0.05)
       the level in the confidence intervals around the estimated survival function,
       for computation of ``confidence_intervals_`` fitted parameter.

--- a/skpro/survival/aft/_aft_lifelines_weibull.py
+++ b/skpro/survival/aft/_aft_lifelines_weibull.py
@@ -114,6 +114,18 @@ class AFTWeibull(_LifelinesAdapter, BaseSurvReg):
 
         return WeibullAFTFitter
 
+    def _get_lifelines_object(self):
+        """Abstract method to initialize lifelines object.
+
+        The default initializes result of _get_lifelines_class
+        with self.get_params.
+        """
+        cls = self._get_lifelines_class()
+        params = self.get_params()
+        params.pop("scale_cols", None)
+        params.pop("shape_cols", None)
+        return cls(params)
+
     def _add_extra_fit_args(self, X, y, C=None):
         """Get extra arguments for the fit method.
 

--- a/skpro/survival/aft/_aft_lifelines_weibull.py
+++ b/skpro/survival/aft/_aft_lifelines_weibull.py
@@ -85,8 +85,8 @@ class AFTWeibullLifelines(_LifelinesAdapter, BaseSurvReg):
         the concordance index of the model.
     """
 
-    _tags = {"authors": ["CamDavidsonPilon", "JoseLlanes", "mathurinm", "fkiraly"]}
-    # CamDavidsonPilon, JoseLlanes, mathurinm credit for interfaced estimator
+    _tags = {"authors": ["CamDavidsonPilon", "fkiraly"]}
+    # CamDavidsonPilon, credit for interfaced estimator
 
     def __init__(
         self,

--- a/skpro/survival/aft/_aft_lifelines_weibull.py
+++ b/skpro/survival/aft/_aft_lifelines_weibull.py
@@ -9,7 +9,7 @@ from skpro.survival.base import BaseSurvReg
 from skpro.utils.sklearn import prep_skl_df
 
 
-class AFTWeibullLifelines(_LifelinesAdapter, BaseSurvReg):
+class AFTWeibull(_LifelinesAdapter, BaseSurvReg):
     r"""Weibull AFT model, from lifelines.
 
     Direct interface to ``lifelines.fitters.WeibullAFTFitter``,

--- a/skpro/survival/aft/_aft_lifelines_weibull.py
+++ b/skpro/survival/aft/_aft_lifelines_weibull.py
@@ -124,7 +124,7 @@ class AFTWeibull(_LifelinesAdapter, BaseSurvReg):
         params = self.get_params()
         params.pop("scale_cols", None)
         params.pop("shape_cols", None)
-        return cls(params)
+        return cls(**params)
 
     def _add_extra_fit_args(self, X, y, C=None):
         """Get extra arguments for the fit method.

--- a/skpro/survival/aft/_aft_lifelines_weibull.py
+++ b/skpro/survival/aft/_aft_lifelines_weibull.py
@@ -3,6 +3,8 @@
 
 __author__ = ["fkiraly"]
 
+import numpy as np
+
 from skpro.distributions.weibull import Weibull
 from skpro.survival.adapters.lifelines import _LifelinesAdapter
 from skpro.survival.base import BaseSurvReg
@@ -181,6 +183,8 @@ class AFTWeibull(_LifelinesAdapter, BaseSurvReg):
         ll_pred_proba = lifelines_est._prep_inputs_for_prediction_and_return_scores
 
         scale, k = ll_pred_proba(df, ancillary)
+        scale = np.expand_dims(scale, axis=1)
+        k = np.expand_dims(k, axis=1)
 
         dist = Weibull(scale=scale, k=k, index=X.index, columns=self._y_cols)
         return dist

--- a/skpro/survival/aft/_aft_lifelines_weibull.py
+++ b/skpro/survival/aft/_aft_lifelines_weibull.py
@@ -6,7 +6,6 @@ __author__ = ["fkiraly"]
 from skpro.distributions.weibull import Weibull
 from skpro.survival.adapters.lifelines import _LifelinesAdapter
 from skpro.survival.base import BaseSurvReg
-from skpro.utils.sklearn import prep_skl_df
 
 
 class AFTWeibull(_LifelinesAdapter, BaseSurvReg):

--- a/skpro/survival/coxph/__init__.py
+++ b/skpro/survival/coxph/__init__.py
@@ -1,7 +1,8 @@
 """Cox proportional hazards models."""
 
 from skpro.survival.coxph._coxnet_sksurv import CoxNet
+from skpro.survival.coxph._coxph_lifelines import CoxPHlifelines
 from skpro.survival.coxph._coxph_sksurv import CoxPHSkSurv
 from skpro.survival.coxph._coxph_statsmodels import CoxPH
 
-__all__ = ["CoxNet", "CoxPH", "CoxPHSkSurv"]
+__all__ = ["CoxNet", "CoxPH", "CoxPHlifelines", "CoxPHSkSurv"]

--- a/skpro/survival/coxph/_coxph_lifelines.py
+++ b/skpro/survival/coxph/_coxph_lifelines.py
@@ -51,7 +51,8 @@ class CoxPHlifelines(_LifelinesAdapter, BaseSurvReg):
 
     baseline_estimation_method: string, default="breslow",
         one of: ``"breslow"``, ``"spline"``, or ``"piecewise"``.
-        Specifies algorithm for estimato of baseline hazard, see above.
+        Specifies algorithm for estimation of baseline hazard, see above.
+        If ``"piecewise"``, the ``breakpoints`` parameter must be set.
 
     penalizer: float or array, optional (default=0.0)
         Penalty to the size of the coefficients during regression.
@@ -92,7 +93,8 @@ class CoxPHlifelines(_LifelinesAdapter, BaseSurvReg):
         parameter can be employed instead.
 
     breakpoints: list, optional
-        Used only when ``baseline_estimation_method="piecewise"``.
+        Used only when ``baseline_estimation_method="piecewise"``,
+        must be passed in this case.
         Set the positions of the baseline hazard breakpoints.
 
     Attributes
@@ -203,6 +205,7 @@ class CoxPHlifelines(_LifelinesAdapter, BaseSurvReg):
             "baseline_estimation_method": "piecewise",
             "penalizer": 0.15,
             "l1_ratio": 0.05,
+            "breakpoints": [10, 20, 30, 100],
         }
 
         return [params1, params2, params3]

--- a/skpro/survival/coxph/_coxph_lifelines.py
+++ b/skpro/survival/coxph/_coxph_lifelines.py
@@ -1,0 +1,208 @@
+"""Interface adapter to lifelines Cox PH surival model."""
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+
+__author__ = ["fkiraly"]
+
+from skpro.survival.adapters.lifelines import _LifelinesAdapter
+from skpro.survival.base import BaseSurvReg
+
+
+class CoxPHlifelines(_LifelinesAdapter, BaseSurvReg):
+    r"""Cox proportional hazards models, from lifelines.
+
+    Direct interface to ``lifelines.fitters.CoxPHFitter``,
+    by ``CamDavidsonPilon``.
+
+    This class implements Cox proportional hazard model,
+
+    .. math::  h(t|x) = h_0(t) \exp((x - \overline{x})' \beta)
+
+    with different options to fit the baseline hazard, :math:`h_0(t)`.
+
+    The class offers multiple options via the ``baseline_estimation_method`` parameter:
+
+    ``"breslow"`` (default): non-parametric estimate via Breslow's method.
+    In this case, the entire model is the traditional semi-parametric Cox model.
+    Ties are handled using Efron's method.
+
+    ``"spline"``: parametric spline fit of baseline hazard,
+    via Royston-Parmar's method [1]_. The parametric form is
+
+    .. math:: H_0(t) = \exp{\left( \phi_0 + \phi_1\log{t} + \sum_{j=2}^N \phi_j v_j(\log{t})\right)}  # noqa E501
+
+    where :math:`v_j` are our cubic basis functions at predetermined knots,
+    and :math:`H_0` is the cumulative baseline hazard. See [1]_ for exact definition.
+
+    ``"piecewise"``: non-parametric, piecewise constant empirical baseline hazard.
+    The explicit form of the baseline hazard is
+
+    .. math::  h_0(t) = \begin{cases}
+        exp{\beta \cdot \text{center}(x)}  & \text{if $t \le \tau_0$} \\
+        exp{\beta \cdot \text{center}(x)} \cdot lambda_1 & \text{if $\tau_0 < t \le \tau_1$} \\  # noqa E501
+        exp{\beta \cdot \text{center}(x)} \cdot lambda_2 & \text{if $\tau_1 < t \le \tau_2$} \\  # noqa E501
+        ...
+        \end{cases}
+
+    Parameters
+    ----------
+    alpha: float, optional (default=0.05)
+      the level in the confidence intervals around the estimated survival function,
+      for computation of ``confidence_intervals_`` fitted parameter.
+
+    baseline_estimation_method: string, default="breslow",
+        one of: ``"breslow"``, ``"spline"``, or ``"piecewise"``.
+        Specifies algorithm for estimato of baseline hazard, see above.
+
+    penalizer: float or array, optional (default=0.0)
+        Penalty to the size of the coefficients during regression.
+        This improves stability of the estimates and controls for high correlation
+        between covariates.
+        For example, this shrinks the magnitude value of :math:`\beta_i`.
+        See ``l1_ratio`` below.
+        The penalty term is :math:`\text{penalizer} \left( \frac{1-\text{l1_ratio}}{2} ||\beta||_2^2 + \text{l1_ratio}||\beta||_1\right)`.  # noqa E501
+
+        If an array, must be equal in size to the number of parameters,
+        with penalty coefficients for specific variables. For
+        example, ``penalizer=0.01 * np.ones(p)`` is the same as ``penalizer=0.01``.
+
+    l1_ratio: float, optional (default=0.0)
+        Specify what ratio to assign to a L1 vs L2 penalty.
+        Same as in scikit-learn. See ``penalizer`` above.
+
+    strata: list, optional
+        specify a list of columns to use in stratification. This is useful if a
+        categorical covariate does not obey the proportional hazard assumption. This
+        is used similar to the ``strata`` expression in R.
+        See http://courses.washington.edu/b515/l17.pdf.
+
+    n_baseline_knots: int, optional, default=4
+        Used only when ``baseline_estimation_method="spline"``.
+        Set the number of knots (interior & exterior) in the baseline hazard,
+        which will be placed evenly along the time axis.
+        Should be at least 2.
+        Royston et. al, the authors of this model, suggest 4 to start,
+        but any values between 2 and 8 are reasonable.
+        If you need to customize the timestamps used to calculate the curve,
+        use the ``knots`` parameter instead.
+
+    knots: list, optional
+        Used only when ``baseline_estimation_method="spline"``.
+        Specifies custom points in the time axis for the baseline hazard curve.
+        To use evenly-spaced points in time, the ``n_baseline_knots``
+        parameter can be employed instead.
+
+    breakpoints: list, optional
+        Used only when ``baseline_estimation_method="piecewise"``.
+        Set the positions of the baseline hazard breakpoints.
+
+    Attributes
+    ----------
+    params_ : Series
+        The estimated coefficients.
+    hazard_ratios_ : Series
+        The exp(coefficients)
+    confidence_intervals_ : DataFrame
+        The lower and upper confidence intervals for the hazard coefficients
+    durations: Series
+        The durations provided
+    event_observed: Series
+        The event_observed variable provided
+    weights: Series
+        The event_observed variable provided
+    variance_matrix_ : DataFrame
+        The variance matrix of the coefficients
+    strata: list
+        the strata provided
+    standard_errors_: Series
+        the standard errors of the estimates
+    log_likelihood_: float
+        the log-likelihood at the fitted coefficients
+    AIC_: float
+        the AIC at the fitted coefficients (if using splines for baseline hazard)
+    partial_AIC_: float
+        the AIC at the fitted coefficients
+        (if using non-parametric inference for baseline hazard)
+    baseline_hazard_: DataFrame
+        the baseline hazard evaluated at the observed times.
+        Estimated using Breslow's method.
+    baseline_cumulative_hazard_: DataFrame
+        the baseline cumulative hazard evaluated at the observed times.
+        Estimated using Breslow's method.
+    baseline_survival_: DataFrame
+        the baseline survival evaluated at the observed times.
+        Estimated using Breslow's method.
+    summary: Dataframe
+        a Dataframe of the coefficients, p-values, CIs, etc.
+
+    References
+    ----------
+    .. [1] Royston, P., Parmar, M. K. B. (2002).
+      Flexible parametric proportional-hazards and proportional-odds
+      models for censored survival data, with application to prognostic
+      modelling and estimation of treatment effects.
+      Statistics in Medicine, 21(15), 2175–2197. doi:10.1002/sim.1203
+    """
+
+    _tags = {"authors": ["CamDavidsonPilon", "rocreguant", "fkiraly"]}
+    # CamDavidsonPilon, rocreguant credit for interfaced estimator
+
+    def __init__(
+        self,
+        baseline_estimation_method: str = "breslow",
+        penalizer=0.0,
+        strata=None,
+        l1_ratio=0.0,
+        n_baseline_knots=None,
+        knots=None,
+        breakpoints=None,
+    ):
+        self.baseline_estimation_method = baseline_estimation_method
+        self.penalizer = penalizer
+        self.strata = strata
+        self.l1_ratio = l1_ratio
+        self.n_baseline_knots = n_baseline_knots
+        self.knots = knots
+        self.breakpoints = breakpoints
+
+        super().__init__()
+
+    def _get_lifelines_class(self):
+        """Getter of the lifelines class to be used for the adapter."""
+        from lifelines.fitters.coxph_fitter import CoxPHFitter
+
+        return CoxPHFitter
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+        params1 = {}
+
+        params2 = {
+            "baseline_estimation_method": "spline",
+            "penalizer": 0.1,
+            "l1_ratio": 0.1,
+            "n_baseline_knots": 3,
+        }
+
+        params3 = {
+            "baseline_estimation_method": "piecewise",
+            "penalizer": 0.15,
+            "l1_ratio": 0.05,
+        }
+
+        return [params1, params2, params3]

--- a/skpro/survival/coxph/_coxph_lifelines.py
+++ b/skpro/survival/coxph/_coxph_lifelines.py
@@ -201,11 +201,14 @@ class CoxPHlifelines(_LifelinesAdapter, BaseSurvReg):
             "n_baseline_knots": 3,
         }
 
-        params3 = {
-            "baseline_estimation_method": "piecewise",
-            "penalizer": 0.15,
-            "l1_ratio": 0.05,
-            "breakpoints": [10, 20, 30, 100],
-        }
+        # breakpoints are specific to data ranges,
+        # but tests loop over various data sets, so this would break
+        #
+        # params3 = {
+        #     "baseline_estimation_method": "piecewise",
+        #     "penalizer": 0.15,
+        #     "l1_ratio": 0.05,
+        #     "breakpoints": [10, 20, 30, 100],
+        # }
 
-        return [params1, params2, params3]
+        return [params1, params2]

--- a/skpro/survival/coxph/_coxph_lifelines.py
+++ b/skpro/survival/coxph/_coxph_lifelines.py
@@ -143,8 +143,8 @@ class CoxPHlifelines(_LifelinesAdapter, BaseSurvReg):
       Statistics in Medicine, 21(15), 2175–2197. doi:10.1002/sim.1203
     """
 
-    _tags = {"authors": ["CamDavidsonPilon", "rocreguant", "fkiraly"]}
-    # CamDavidsonPilon, rocreguant credit for interfaced estimator
+    _tags = {"authors": ["CamDavidsonPilon", "JoseLlanes", "mathurinm", "fkiraly"]}
+    # CamDavidsonPilon, JoseLlanes, mathurinm credit for interfaced estimator
 
     def __init__(
         self,


### PR DESCRIPTION
Adds an adapter to `lifelines`, exposing array-like survival functions as `Empirical` distributions in `predict_proba`.

Adds all models from `lifelines` which are capable of full distributional predictions:

* `AalenAdditiveFitter`
* `CoxPHFitter`
* `WeibullAFTFitter`

Remaining AFT fitters require distributions not yet merged.