### PR TITLE
[ENH] Johnson QP-distributions - add some missing capability tags

### DIFF
--- a/skpro/distributions/qpd.py
+++ b/skpro/distributions/qpd.py
@@ -39,9 +39,9 @@ class QPD_S(BaseDistribution):
         quantile function value of quantile ``1 - alpha``
     lower : float
         lower bound of semi-bounded range (default is 0)
-    version: str
+    version: str, optional, default="normal"
         options are ``normal`` (default) or ``logistic``
-    dist_shape: str
+    dist_shape: float, optional, default=0.0
         parameter modifying the logistic base distribution via
         sinh/arcsinh-scaling (only active in sinhlogistic version)
 
@@ -272,9 +272,9 @@ class QPD_B(BaseDistribution):
         lower bound of semi-bounded range
     upper : float
         upper bound of supported range
-    version: str
+    version: str, optional, default="normal"
         options are ``normal`` (default) or ``logistic``
-    dist_shape: str
+    dist_shape: float, optional, default=0.0
         parameter modifying the logistic base distribution via
         sinh/arcsinh-scaling (only active in sinhlogistic version)
 
@@ -509,9 +509,9 @@ class QPD_U(BaseDistribution):
         quantile function value of quantile 0.5
     qv_high : float or array_like[float]
         quantile function value of quantile ``1 - alpha``
-    version: str
+    version: str, optional, default="normal"
         options are ``normal`` (default) or ``logistic``
-    dist_shape: str
+    dist_shape: float, optional, default=0.0
         parameter modifying the logistic base distribution via
         sinh/arcsinh-scaling (only active in sinhlogistic version)
 

--- a/skpro/distributions/qpd.py
+++ b/skpro/distributions/qpd.py
@@ -68,8 +68,8 @@ class QPD_S(BaseDistribution):
         "python_dependencies": "cyclic_boosting>=1.2.5",
         # estimator tags
         # --------------
-        "capabilities:approx": [],
-        "capabilities:exact": ["mean", "var", "cdf", "ppf"],
+        "capabilities:approx": ["pdfnorm", "energy"],
+        "capabilities:exact": ["mean", "var", "cdf", "ppf", "pdf", "log_pdf"],
         "distr:measuretype": "continuous",
     }
 
@@ -302,8 +302,8 @@ class QPD_B(BaseDistribution):
         "python_dependencies": "cyclic_boosting>=1.2.5",
         # estimator tags
         # --------------
-        "capabilities:approx": [],
-        "capabilities:exact": ["mean", "var", "cdf", "ppf"],
+        "capabilities:approx": ["pdfnorm", "energy"],
+        "capabilities:exact": ["mean", "var", "cdf", "ppf", "pdf", "log_pdf"],
         "distr:measuretype": "continuous",
     }
 
@@ -537,8 +537,8 @@ class QPD_U(BaseDistribution):
         "python_dependencies": "cyclic_boosting>=1.2.5",
         # estimator tags
         # --------------
-        "capabilities:approx": [],
-        "capabilities:exact": ["mean", "var", "cdf", "ppf"],
+        "capabilities:approx": ["pdfnorm", "energy"],
+        "capabilities:exact": ["mean", "var", "cdf", "ppf", "pdf", "log_pdf"],
         "distr:measuretype": "continuous",
     }
 


### PR DESCRIPTION
Adds some missing capability tags to the Johnson QPD distributions.

Includes minor improvements to the docstring.

FYI @setoguchi-naoki, @felixwick - I think these were simply missing, added them.