### PR TITLE
[ENH] remove stray `_get_bc_params` from `LogNormal`

### DIFF
--- a/skpro/distributions/lognormal.py
+++ b/skpro/distributions/lognormal.py
@@ -56,16 +56,6 @@ class LogNormal(BaseDistribution):
 
         super().__init__(index=index, columns=columns)
 
-    def _get_bc_params(self):
-        """Fully broadcast parameters of self, given param shapes and index, columns."""
-        to_broadcast = [self.mu, self.sigma]
-        if hasattr(self, "index") and self.index is not None:
-            to_broadcast += [self.index.to_numpy().reshape(-1, 1)]
-        if hasattr(self, "columns") and self.columns is not None:
-            to_broadcast += [self.columns.to_numpy()]
-        bc = np.broadcast_arrays(*to_broadcast)
-        return bc[0], bc[1]
-
     # commented out, seems incorrect
     # def energy(self, x=None):
     #     r"""Energy of self, w.r.t. self or a constant frame x.


### PR DESCRIPTION
It appears `_get_bc_params` got accidentally copied from the base class to `LogNormal`.

This PR removes the redundant copy.