### PR TITLE
[MNT] move GHA runners consistently to `ubuntu-latest`, `windows-latest`, `macos-13`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        os: [ubuntu-20.04, windows-latest, macOS-11]
+        os: [ubuntu-latest, windows-latest, macOS-13]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -108,7 +108,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macOS-13]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This PR moves GHA runners consistently to `ubuntu-latest`, `windows-latest`, `macos-13`.

`macos-latest` is failing with python 3.8 and 3.9 recently, and `macos-14` = `macos-latest` has half the memory of `macos-13`.