### PR TITLE
[ENH] `at` and `iat` subsetters for distributions

### DIFF
--- a/skpro/distributions/base/_base.py
+++ b/skpro/distributions/base/_base.py
@@ -218,16 +218,14 @@ class BaseDistribution(BaseObject):
                 subset_param_dict[param] = None
                 continue
             arr = np.array(val)
+            # if len(arr.shape) == 0:
+            # do nothing with arr
             if len(arr.shape) == 2 and rowidx is not None:
                 arr = arr[rowidx, :]
             if len(arr.shape) == 1 and colidx is not None:
                 arr = arr[colidx]
             if len(arr.shape) >= 2 and colidx is not None:
                 arr = arr[:, colidx]
-            # elif len(arr.shape) == 1 and rowidx is not None:
-            # do nothing with arr
-            # if len(arr.shape) == 0:
-            # do nothing with arr
             if np.issubdtype(arr.dtype, np.integer):
                 arr = arr.astype("float")
             if coerce_scalar and len(arr.shape) == 1:

--- a/skpro/distributions/base/_base.py
+++ b/skpro/distributions/base/_base.py
@@ -1058,6 +1058,15 @@ class _Indexer:
         self.ref = ref
         self.method = method
 
+    def __call__(self, *args, **kwargs):
+        """Error message to tell the user ot user [ ] instead of ( )."""
+        methodname = self.method[1:]
+        raise ValueError(
+            "Please use square brackets [] for indexing a distribution, i.e., "
+            f"mydist.{methodname}[index] or mydist.{methodname}[index1, index2], "
+            f"not mydist.{methodname}(index) or mydist.{methodname}(index1, index2)"
+        )
+
     def __getitem__(self, key):
         """Getitem dunder, for use in my_distr.loc[index] an my_distr.iloc[index]."""
 

--- a/skpro/distributions/base/_base.py
+++ b/skpro/distributions/base/_base.py
@@ -170,6 +170,13 @@ class BaseDistribution(BaseObject):
         return shape[0]
 
     def _loc(self, rowidx=None, colidx=None):
+        if is_scalar_notnone(rowidx) and is_scalar_notnone(colidx):
+            return self._at(rowidx, colidx)
+        if is_scalar_notnone(rowidx):
+            rowidx = pd.Index([rowidx])
+        if is_scalar_notnone(colidx):
+            colidx = pd.Index([colidx])
+
         if rowidx is not None:
             row_iloc = self.index.get_indexer_for(rowidx)
         else:

--- a/skpro/distributions/base/_base.py
+++ b/skpro/distributions/base/_base.py
@@ -228,12 +228,8 @@ class BaseDistribution(BaseObject):
                 arr = arr[:, colidx]
             if np.issubdtype(arr.dtype, np.integer):
                 arr = arr.astype("float")
-            if coerce_scalar and len(arr.shape) == 1:
-                arr = arr[0]
-            elif coerce_scalar and len(arr.shape) == 2:
-                arr = arr[0, 0]
-            elif coerce_scalar and len(arr.shape) == 0:
-                arr = arr[()]
+            if coerce_scalar:
+                arr = arr[(0,) * len(arr.shape)]
             subset_param_dict[param] = arr
         return subset_param_dict
 

--- a/skpro/distributions/base/_base.py
+++ b/skpro/distributions/base/_base.py
@@ -1059,7 +1059,7 @@ class _Indexer:
         self.method = method
 
     def __call__(self, *args, **kwargs):
-        """Error message to tell the user ot user [ ] instead of ( )."""
+        """Error message to tell the user to use [ ] instead of ( )."""
         methodname = self.method[1:]
         raise ValueError(
             "Please use square brackets [] for indexing a distribution, i.e., "

--- a/skpro/distributions/base/_base.py
+++ b/skpro/distributions/base/_base.py
@@ -218,14 +218,12 @@ class BaseDistribution(BaseObject):
                 subset_param_dict[param] = None
                 continue
             arr = np.array(val)
-            if len(arr.shape) >= 2 and rowidx is not None and colidx is not None:
-                arr = arr[rowidx, colidx]
-            elif len(arr.shape) >= 2 and colidx is not None:
-                arr = arr[:, colidx]
-            elif len(arr.shape) >= 2 and rowidx is not None:
+            if len(arr.shape) == 2 and rowidx is not None:
                 arr = arr[rowidx, :]
-            elif len(arr.shape) == 1 and colidx is not None:
+            if len(arr.shape) == 1 and colidx is not None:
                 arr = arr[colidx]
+            if len(arr.shape) >= 2 and colidx is not None:
+                arr = arr[:, colidx]
             # elif len(arr.shape) == 1 and rowidx is not None:
             # do nothing with arr
             # if len(arr.shape) == 0:

--- a/skpro/distributions/base/_base.py
+++ b/skpro/distributions/base/_base.py
@@ -194,6 +194,23 @@ class BaseDistribution(BaseObject):
         return self._iat(rowidx=row_iloc, colidx=col_iloc)
 
     def _subset_params(self, rowidx, colidx, coerce_scalar=False):
+        """Subset distribution parameters to given rows and columns.
+
+        Parameters
+        ----------
+        rowidx : None, numpy index/slice coercible, or int
+            Rows to subset to. If None, no subsetting is done.
+        colidx : None, numpy index/slice coercible, or int
+            Columns to subset to. If None, no subsetting is done.
+        coerce_scalar : bool, optional, default=False
+            If True, and the subsetted parameter is a scalar, coerce it to a scalar.
+
+        Returns
+        -------
+        dict
+            Dictionary with subsetted distribution parameters.
+            Keys are parameter names of ``self``, values are the subsetted parameters.
+        """
         params = self._get_dist_params()
 
         subset_param_dict = {}

--- a/skpro/distributions/base/_base.py
+++ b/skpro/distributions/base/_base.py
@@ -9,7 +9,6 @@ from warnings import warn
 
 import numpy as np
 import pandas as pd
-from pandas.api.types import is_scalar
 
 from skpro.base import BaseObject
 from skpro.utils.validation._dependencies import _check_estimator_deps

--- a/skpro/distributions/base/_base.py
+++ b/skpro/distributions/base/_base.py
@@ -242,11 +242,11 @@ class BaseDistribution(BaseObject):
         return type(self)(**subset_params)
 
     def _iloc(self, rowidx=None, colidx=None):
-        if is_scalar(rowidx) and is_scalar(colidx):
+        if is_scalar_notnone(rowidx) and is_scalar_notnone(colidx):
             return self._iat(rowidx, colidx)
-        if is_scalar(rowidx):
+        if is_scalar_notnone(rowidx):
             rowidx = pd.Index([rowidx])
-        if is_scalar(colidx):
+        if is_scalar_notnone(colidx):
             colidx = pd.Index([colidx])
 
         subset_params = self._subset_params(rowidx=rowidx, colidx=colidx)
@@ -1233,3 +1233,8 @@ def _prod_multiindex(ix1, ix2):
     res = pd.MultiIndex.from_product(rows)
     res.names = [None] * len(res.names)
     return res
+
+
+def is_scalar_notnone(obj):
+    """Check if obj is scalar and not None."""
+    return obj is not None and np.isscalar(obj)

--- a/skpro/distributions/base/_base.py
+++ b/skpro/distributions/base/_base.py
@@ -1068,7 +1068,7 @@ class _Indexer:
         )
 
     def __getitem__(self, key):
-        """Getitem dunder, for use in my_distr.loc[index] an my_distr.iloc[index]."""
+        """Getitem dunder, for use in my_distr.loc[index] and my_distr.iloc[index]."""
 
         def is_noneslice(obj):
             res = isinstance(obj, slice)

--- a/skpro/distributions/base/_base.py
+++ b/skpro/distributions/base/_base.py
@@ -1061,8 +1061,11 @@ class _Indexer:
     def __call__(self, *args, **kwargs):
         """Error message to tell the user to use [ ] instead of ( )."""
         methodname = self.method[1:]
+        clsname = self.ref.__class__.__name__
         raise ValueError(
-            "Please use square brackets [] for indexing a distribution, i.e., "
+            f"Error while attempting to index {clsname} probability "
+            f"distribution instance via {methodname}: "
+            f"Please use square brackets [] for indexing a distribution, i.e., "
             f"mydist.{methodname}[index] or mydist.{methodname}[index1, index2], "
             f"not mydist.{methodname}(index) or mydist.{methodname}(index1, index2)"
         )

--- a/skpro/distributions/base/_base.py
+++ b/skpro/distributions/base/_base.py
@@ -135,9 +135,8 @@ class BaseDistribution(BaseObject):
         """
         return _Indexer(ref=self, method="_iat")
 
-
     @property
-    def iat(self):
+    def at(self):
         """Integer location indexer, for single index.
 
         Use ``my_distribution.at[index]`` for ``pandas``-like row/column subsetting

--- a/skpro/distributions/tests/test_proba_basic.py
+++ b/skpro/distributions/tests/test_proba_basic.py
@@ -4,6 +4,8 @@
 
 __author__ = ["fkiraly"]
 
+import pytest
+
 
 def test_proba_example():
     """Test one subsetting case for BaseDistribution."""
@@ -16,3 +18,51 @@ def test_proba_example():
     one_row = n.loc[[1]]
     assert isinstance(one_row, Normal)
     assert one_row.shape == (1, 2)
+
+
+@pytest.mark.parametrize("subsetter", ["loc", "iloc"])
+def test_proba_subsetters_loc_iloc(subsetter):
+    """Test one subsetting case for BaseDistribution."""
+    from skpro.distributions.normal import Normal
+
+    n = Normal(mu=[[0, 1], [2, 3], [4, 5]], sigma=1)
+
+    assert n.shape == (3, 2)
+
+    # should result in 2D array distribution (1, 1)
+    nss = getattr(n, subsetter)[1, [1]]
+    assert isinstance(nss, Normal)
+    assert nss.shape == (1, 1)
+    assert nss.mu.shape == (1, 1)
+
+    nss = getattr(n, subsetter)[[1], 1]
+    assert isinstance(nss, Normal)
+    assert nss.shape == (1, 1)
+    assert nss.mu.shape == (1, 1)
+
+    # should result in scalar distribution
+    nss = getattr(n, subsetter)[1, 1]
+    assert isinstance(nss, Normal)
+    assert nss.shape == ()
+
+    nss = getattr(n, subsetter)[1, 1]
+    assert isinstance(nss, Normal)
+    assert nss.shape == ()
+
+
+def test_proba_subsetters_at_iat():
+    """Test one subsetting case for BaseDistribution."""
+    from skpro.distributions.normal import Normal
+
+    n = Normal(mu=[[0, 1], [2, 3], [4, 5]], sigma=1)
+
+    # should result in scalar distribution
+    nss = n.iat[1, 1]
+    assert isinstance(nss, Normal)
+    assert nss.shape == ()
+    assert nss == n.iloc[1, 1]
+
+    nss = n.at[1, 1]
+    assert isinstance(nss, Normal)
+    assert nss.shape == ()
+    assert nss == n.loc[1, 1]

--- a/skpro/registry/_tags.py
+++ b/skpro/registry/_tags.py
@@ -200,8 +200,14 @@ OBJECT_TAG_REGISTER = [
     (
         "broadcast_init",
         "distribution",
-        "str",
+        ("str", ["on", "off"]),
         "whether to initialize broadcast parameters in __init__, 'on' or 'off'",
+    ),
+    (
+        "broadcast_inner",
+        "distribution",
+        ("str", ["array", "scalar"]),
+        "if inner logic is vectorized ('array') or scalar ('scalar')",
     ),
     # ---------------
     # BaseProbaMetric


### PR DESCRIPTION
This adds `at` and `iat` subsetters for distributions.

If a scalar version of the distribution is implemented, produces a scalar distribution at that entry.