### PR TITLE
[ENH] probability distirbutions: convenience feature to coerce `index` and `columns` to `pd.Index`

### DIFF
--- a/skpro/distributions/base/_base.py
+++ b/skpro/distributions/base/_base.py
@@ -44,7 +44,7 @@ class BaseDistribution(BaseObject):
 
     def __init__(self, index=None, columns=None):
         self.index = _coerce_to_pd_index_or_none(index)
-        self.columns = _coerce_to_pd_index_or_none(index)
+        self.columns = _coerce_to_pd_index_or_none(columns)
 
         super().__init__()
         _check_estimator_deps(self)

--- a/skpro/distributions/base/_base.py
+++ b/skpro/distributions/base/_base.py
@@ -43,8 +43,8 @@ class BaseDistribution(BaseObject):
     }
 
     def __init__(self, index=None, columns=None):
-        self.index = index
-        self.columns = columns
+        self.index = _coerce_to_pd_index_or_none(index)
+        self.columns = _coerce_to_pd_index_or_none(index)
 
         super().__init__()
         _check_estimator_deps(self)
@@ -1256,3 +1256,12 @@ def _prod_multiindex(ix1, ix2):
 def is_scalar_notnone(obj):
     """Check if obj is scalar and not None."""
     return obj is not None and np.isscalar(obj)
+
+
+def _coerce_to_pd_index_or_none(x):
+    """Coerce to pd.Index, if not None, else return None."""
+    if x is None:
+        return None
+    if isinstance(x, pd.Index):
+        return x
+    return pd.Index(x)

--- a/skpro/distributions/tests/test_proba_basic.py
+++ b/skpro/distributions/tests/test_proba_basic.py
@@ -73,7 +73,7 @@ def test_proba_index_coercion():
     """Test index coercion for BaseDistribution."""
     from skpro.distributions.normal import Normal
 
-    n = Normal(mu=[[0, 1], [2, 3], [4, 5]], sigma=1, columns = ["foo", "bar"])
+    n = Normal(mu=[[0, 1], [2, 3], [4, 5]], sigma=1, columns=["foo", "bar"])
 
     assert n.shape == (3, 2)
     assert isinstance(n.index, pd.Index)
@@ -81,7 +81,7 @@ def test_proba_index_coercion():
     assert n.index.equals(pd.RangeIndex(3))
     assert n.columns.equals(pd.Index(["foo", "bar"]))
 
-    n = Normal(mu=[[0, 1], [2, 3], [4, 5]], sigma=1, index = ["2", 1, 0])
+    n = Normal(mu=[[0, 1], [2, 3], [4, 5]], sigma=1, index=["2", 1, 0])
 
     assert n.shape == (3, 2)
     assert isinstance(n.index, pd.Index)

--- a/skpro/distributions/tests/test_proba_basic.py
+++ b/skpro/distributions/tests/test_proba_basic.py
@@ -4,6 +4,7 @@
 
 __author__ = ["fkiraly"]
 
+import pandas as pd
 import pytest
 
 
@@ -66,3 +67,33 @@ def test_proba_subsetters_at_iat():
     assert isinstance(nss, Normal)
     assert nss.shape == ()
     assert nss == n.loc[1, 1]
+
+
+def test_proba_index_coercion():
+    """Test index coercion for BaseDistribution."""
+    from skpro.distributions.normal import Normal
+
+    n = Normal(mu=[[0, 1], [2, 3], [4, 5]], sigma=1, columns = ["foo", "bar"])
+
+    assert n.shape == (3, 2)
+    assert isinstance(n.index, pd.Index)
+    assert isinstance(n.columns, pd.Index)
+    assert n.index.equals(pd.RangeIndex(3))
+    assert n.columns.equals(pd.Index(["foo", "bar"]))
+
+    n = Normal(mu=[[0, 1], [2, 3], [4, 5]], sigma=1, index = ["2", 1, 0])
+
+    assert n.shape == (3, 2)
+    assert isinstance(n.index, pd.Index)
+    assert isinstance(n.columns, pd.Index)
+    assert n.index.equals(pd.Index(["2", 1, 0]))
+    assert n.columns.equals(pd.RangeIndex(2))
+
+    # this should coerce to a 2D array of shape (1, 3)
+    n = Normal(0, 1, columns=[1, 2, 3])
+
+    assert n.shape == (1, 3)
+    assert isinstance(n.index, pd.Index)
+    assert isinstance(n.columns, pd.Index)
+    assert n.index.equals(pd.RangeIndex(1))
+    assert n.columns.equals(pd.Index([1, 2, 3]))


### PR DESCRIPTION
This PR adds convenience sugar to coerce `index` and `columns` to `pd.Index`.

Does not impact existing functionality.

Tests are added for the new call cases.