### PR TITLE
[ENH] scalar test cases for probability distributions

### DIFF
--- a/skpro/distributions/base/_base.py
+++ b/skpro/distributions/base/_base.py
@@ -831,15 +831,21 @@ class BaseDistribution(BaseObject):
         if x is None:
             splx = self.sample(N)
             sply = self.sample(N)
-        else:
+        elif self.ndim > 0:  # and x is not None
             x = pd.DataFrame(x, index=self.index, columns=self.columns)
             splx = pd.concat([x] * N, keys=range(N))
+            sply = self.sample(N)
+        else:  # if self.ndim == 0 and x is not None
+            splx = pd.DataFrame([x] * N)
             sply = self.sample(N)
 
         # approx E[abs(X-Y)] via mean of samples of abs(X-Y) obtained from splx, sply
         spl = splx - sply
         energy = spl.apply(np.linalg.norm, axis=1, ord=1)
-        energy = energy.groupby(level=1, sort=False).mean()
+
+        if self.ndim > 0:
+            energy = energy.groupby(level=1, sort=False)
+        energy = energy.mean()
         if self.ndim > 0:
             energy = pd.DataFrame(energy, index=self.index, columns=["energy"])
         return energy

--- a/skpro/distributions/fisk.py
+++ b/skpro/distributions/fisk.py
@@ -154,6 +154,7 @@ class Fisk(BaseDistribution):
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Return testing parameter settings for the estimator."""
+        # array case examples
         params1 = {"alpha": [[1, 1], [2, 3], [4, 5]], "beta": 3}
         params2 = {
             "alpha": 2,
@@ -161,4 +162,7 @@ class Fisk(BaseDistribution):
             "index": pd.Index([1, 2, 5]),
             "columns": pd.Index(["a", "b"]),
         }
-        return [params1, params2]
+        # scalar case examples
+        params3 = {"alpha": 1.5, "beta": 2.1}
+
+        return [params1, params2, paramse]

--- a/skpro/distributions/fisk.py
+++ b/skpro/distributions/fisk.py
@@ -165,4 +165,4 @@ class Fisk(BaseDistribution):
         # scalar case examples
         params3 = {"alpha": 1.5, "beta": 2.1}
 
-        return [params1, params2, paramse]
+        return [params1, params2, params3]

--- a/skpro/distributions/laplace.py
+++ b/skpro/distributions/laplace.py
@@ -205,6 +205,7 @@ class Laplace(BaseDistribution):
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Return testing parameter settings for the estimator."""
+        # array case examples
         params1 = {"mu": [[0, 1], [2, 3], [4, 5]], "scale": 1}
         params2 = {
             "mu": 0,
@@ -212,4 +213,7 @@ class Laplace(BaseDistribution):
             "index": pd.Index([1, 2, 5]),
             "columns": pd.Index(["a", "b"]),
         }
-        return [params1, params2]
+        # scalar case examples
+        params3 = {"mu": -0.5, "scale": 3}
+
+        return [params1, params2, params3]

--- a/skpro/distributions/logistic.py
+++ b/skpro/distributions/logistic.py
@@ -156,6 +156,7 @@ class Logistic(BaseDistribution):
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Return testing parameter settings for the estimator."""
+        # array case examples
         params1 = {"mu": [[0, 1], [2, 3], [4, 5]], "scale": 1}
         params2 = {
             "mu": 0,
@@ -163,4 +164,7 @@ class Logistic(BaseDistribution):
             "index": pd.Index([1, 2, 5]),
             "columns": pd.Index(["a", "b"]),
         }
-        return [params1, params2]
+        # scalar case examples
+        params3 = {"mu": -2, "scale": 2}
+
+        return [params1, params2, params3]

--- a/skpro/distributions/lognormal.py
+++ b/skpro/distributions/lognormal.py
@@ -196,6 +196,7 @@ class LogNormal(BaseDistribution):
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Return testing parameter settings for the estimator."""
+        # array case examples
         params1 = {"mu": [[0, 1], [2, 3], [4, 5]], "sigma": 1}
         params2 = {
             "mu": 0,
@@ -203,4 +204,7 @@ class LogNormal(BaseDistribution):
             "index": pd.Index([1, 2, 5]),
             "columns": pd.Index(["a", "b"]),
         }
-        return [params1, params2]
+        # scalar case examples
+        params3 = {"mu": -2, "sigma": 2}
+
+        return [params1, params2, params3]

--- a/skpro/distributions/t.py
+++ b/skpro/distributions/t.py
@@ -206,11 +206,19 @@ class TDistribution(BaseDistribution):
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Return testing parameter settings for the estimator."""
-        params1 = {"mu": [[0, 1], [2, 3], [4, 5]], "sigma": 1}
+        # array case examples
+        params1 = {
+            "mu": [[0, 1], [2, 3], [4, 5]],
+            "sigma": 1,
+            "df": [2, 3],
+        }
         params2 = {
             "mu": 0,
             "sigma": 1,
             "index": pd.Index([1, 2, 5]),
             "columns": pd.Index(["a", "b"]),
         }
-        return [params1, params2]
+        # scalar case examples
+        params3 = {"mu": -2, "sigma": 3, "df": 4}
+
+        return [params1, params2, params3]

--- a/skpro/distributions/weibull.py
+++ b/skpro/distributions/weibull.py
@@ -142,7 +142,7 @@ class Weibull(BaseDistribution):
         scale = self._bc_params["scale"]
 
         cdf_arr = 1 - np.exp(-((x / scale) ** k))
-        cdf_arr[x < 0] = 0  # if x < 0, cdf = 0
+        cdf_arr = cdf_arr * (x >= 0)  # if x < 0, cdf = 0
         return cdf_arr
 
     def _ppf(self, p):

--- a/skpro/distributions/weibull.py
+++ b/skpro/distributions/weibull.py
@@ -167,6 +167,7 @@ class Weibull(BaseDistribution):
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Return testing parameter settings for the estimator."""
+        # array case examples
         params1 = {"scale": [[1, 1], [2, 3], [4, 5]], "k": 1}
         params2 = {
             "scale": 1,
@@ -174,4 +175,7 @@ class Weibull(BaseDistribution):
             "index": pd.Index([1, 2, 5]),
             "columns": pd.Index(["a", "b"]),
         }
-        return [params1, params2]
+        # scalar case examples
+        params3 = {"scale": 2, "k": 3}
+
+        return [params1, params2, params3]

--- a/skpro/distributions/weibull.py
+++ b/skpro/distributions/weibull.py
@@ -102,7 +102,7 @@ class Weibull(BaseDistribution):
         scale = self._bc_params["scale"]
 
         pdf_arr = (k / scale) * (x / scale) ** (k - 1) * np.exp(-((x / scale) ** k))
-        pdf_arr[x < 0] = 0  # if x < 0, pdf = 0
+        pdf_arr = pdf_arr * (x >= 0)  # if x < 0, pdf = 0
         return pdf_arr
 
     def _log_pdf(self, x):
@@ -122,7 +122,7 @@ class Weibull(BaseDistribution):
         scale = self._bc_params["scale"]
 
         lpdf_arr = np.log(k / scale) + (k - 1) * np.log(x / scale) - (x / scale) ** k
-        lpdf_arr[x < 0] = -np.inf  # if x < 0, pdf = 0, so log pdf = -inf
+        lpdf_arr = lpdf_arr + np.log(x >= 0)  # if x < 0, pdf = 0, so log pdf = -inf
         return lpdf_arr
 
     def _cdf(self, x):


### PR DESCRIPTION
Adds scalar test cases for probability distributions which support scalar polymorphism to cover that type case.

Includes bugfixes for bugs detected through this:

* Weibull distribution `pdf`, `log_pdf`, `cdf` in scalar case
* default implementation of `_energy` in scalar case