### PR TITLE
[DOC] add missing contributors - @an20805, @duydl, @sukjingitsit

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -156,6 +156,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "duydl",
+      "name": "Duy Do Le",
+      "avatar_url": "https://avatars.githubusercontent.com/u/56506156?v=4",
+      "profile": "https://github.com/duydl",
+      "contributions": [
+        "maintenance"
+      ]
     }
   ]
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -138,6 +138,24 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "sukjingitsit",
+      "name": "Sukrit Jindal",
+      "avatar_url": "https://avatars.githubusercontent.com/u/132339317?v=4",
+      "profile": "https://github.com/sukjingitsit",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "an20805",
+      "name": "Anshuman Dangwal",
+      "avatar_url": "https://avatars.githubusercontent.com/u/115940865?v=4",
+      "profile": "https://github.com/an20805",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }


### PR DESCRIPTION
This adds some contributors from recent PR to the `all-contributorsrc` file who forgot to add themselves: @an20805, @duydl, @sukjingitsit