### PR TITLE
[ENH] fix `Empirical` index to be `pd.MultiIndex` for hierarchical data index

### DIFF
--- a/skpro/distributions/empirical.py
+++ b/skpro/distributions/empirical.py
@@ -62,7 +62,7 @@ class Empirical(BaseDistribution):
         self._N = len(_spl_instances)
 
         if index is None:
-            index = pd.Index(_timestamps)
+            index = _timestamps
 
         if columns is None:
             columns = spl.columns


### PR DESCRIPTION
The `Empirical` distribution would produce `pd.Index` of tuples instead of `pd.MultiIndex` in some methods, causing failures in https://github.com/sktime/sktime/pull/6052.

This PR fixes that - mirror of https://github.com/sktime/sktime/pull/6341