### PR TITLE
[ENH] faster collection of differential tests through caching, test if pyproject change

### DIFF
--- a/skpro/tests/_config.py
+++ b/skpro/tests/_config.py
@@ -2,7 +2,6 @@
 
 from skpro.tests._config_test_dummy import DummySkipped
 
-
 # list of str, names of estimators to exclude from testing
 # WARNING: tests for these estimators will be skipped
 EXCLUDE_ESTIMATORS = [DummySkipped]

--- a/skpro/tests/_config.py
+++ b/skpro/tests/_config.py
@@ -3,3 +3,11 @@
 # list of str, names of estimators to exclude from testing
 # WARNING: tests for these estimators will be skipped
 EXCLUDE_ESTIMATORS = []
+
+
+from skpro.regression.base import BaseProbaRegressor  # noqa: E402
+
+
+class DummySkipped(BaseProbaRegressor):
+    """Dummy regressor to test exclusion."""
+    pass

--- a/skpro/tests/_config.py
+++ b/skpro/tests/_config.py
@@ -1,13 +1,8 @@
 """Test configs."""
 
+from skpro.tests._config_test_dummy import DummySkipped
+
+
 # list of str, names of estimators to exclude from testing
 # WARNING: tests for these estimators will be skipped
-EXCLUDE_ESTIMATORS = []
-
-
-from skpro.regression.base import BaseProbaRegressor  # noqa: E402
-
-
-class DummySkipped(BaseProbaRegressor):
-    """Dummy regressor to test exclusion."""
-    pass
+EXCLUDE_ESTIMATORS = [DummySkipped]

--- a/skpro/tests/_config.py
+++ b/skpro/tests/_config.py
@@ -1,7 +1,5 @@
 """Test configs."""
 
-from skpro.tests._config_test_dummy import DummySkipped
-
 # list of str, names of estimators to exclude from testing
 # WARNING: tests for these estimators will be skipped
-EXCLUDE_ESTIMATORS = [DummySkipped]
+EXCLUDE_ESTIMATORS = ["DummySkipped"]

--- a/skpro/tests/_config.py
+++ b/skpro/tests/_config.py
@@ -1,0 +1,5 @@
+"""Test configs."""
+
+# list of str, names of estimators to exclude from testing
+# WARNING: tests for these estimators will be skipped
+EXCLUDE_ESTIMATORS = []

--- a/skpro/tests/_config_test_dummy.py
+++ b/skpro/tests/_config_test_dummy.py
@@ -1,0 +1,10 @@
+"""Test dummy for testing config skips."""
+
+
+from skpro.regression.base import BaseProbaRegressor  # noqa: E402
+
+
+class DummySkipped(BaseProbaRegressor):
+    """Dummy regressor to test exclusion."""
+
+    pass

--- a/skpro/tests/test_switch.py
+++ b/skpro/tests/test_switch.py
@@ -4,36 +4,142 @@
 
 __author__ = ["fkiraly"]
 
+from functools import lru_cache
 from inspect import getmro, isclass
 
+from skpro.tests._config import EXCLUDE_ESTIMATORS
 
-def run_test_for_class(cls):
+LOCAL_PACKAGE = "skpro"
+
+
+def run_test_for_class(cls, return_reason=False):
     """Check if test should run for a class or function.
 
     This checks the following conditions:
 
     1. whether all required soft dependencies are present.
        If not, does not run the test.
-       If yes, runs the test if and only if
-       at least one of conditions 2, 3 below are met.
+       If yes, behaviour depends on ONLY_CHANGED_MODULES setting:
+       if off (False), always runs the test (return True);
+       if on (True), runs test if and only if
+       at least one of conditions 2, 3, 4 below are met.
 
     2. Condition 2:
 
-      * if ONLY_CHANGED_MODULES setting is on, condition 2 is met if and only
-      if the module containing the class/func has changed according to is_class_changed
-      * if ONLY_CHANGED_MODULES if off, condition 2 is always met.
+      If the module containing the class/func has changed according to is_class_changed,
+      or one of the modules containing any parent classes in sktime,
+      then condition 2 is met.
 
     3. Condition 3:
 
-      If the object is an sktime BaseObject, and one of the test classes
+      If the object is an sktime ``BaseObject``, and one of the test classes
       covering the class have changed, then condition 3 is met.
 
+    4. Condition 4:
+
+      If the object is an sktime ``BaseObject``, and the package requirements
+      for any of its dependencies have changed in ``pyproject.toml``,
+      condition 4 is met.
+
     cls can also be a list of classes or functions,
-    in this case the test is run if and only if:
+    in this case the test is run if and only if both of the following are True:
 
     * all required soft dependencies are present
-    * if yes, if any of the estimators in the list should be tested by
-      criterion 2 or 3 above
+    * if ``ONLY_CHANGED_MODULES`` is True, additionally,
+      if any of the estimators in the list should be tested by
+      at least one of criteria 2-4 above.
+      If ``ONLY_CHANGED_MODULES`` is False, this condition is always True.
+
+    Also checks whether the class or function is on the exclude override list,
+    EXCLUDE_ESTIMATORS in sktime.tests._config (a list of strings, of names).
+    If so, the tests are always skipped, irrespective of the other conditions.
+
+    Parameters
+    ----------
+    cls : class, function or list of classes/functions
+        class for which to determine whether it should be tested
+    return_reason: bool, optional, default=False
+        whether to return the reason for running or skipping the test
+
+    Returns
+    -------
+    bool : True if class should be tested, False otherwise
+        if cls was a list, is True iff True for at least one of the classes in the list
+    reason: str, reason to run or skip the test, returned only if ``return_reason=True``
+
+        * "False_exclude_list" - skip reason, class is on the exclude list
+        * "False_required_deps_missing" - skip reason, required dependencies are missing
+        * "False_no_change" - skip reason, no change in class or dependencies
+        * "True_run_always" - run reason, run always, as ``ONLY_CHANGED_MODULES=False``
+        * "True_pyproject_change" - run reason, dep(s) in ``pyproject.toml`` changed
+        * "True_changed_tests" - run reason, test(s) covering class have changed
+        * "True_changed_class" - run reason, module(s) containing class changed
+
+        If multiple reasons are present, the first one in the above list is returned.
+
+        If ``cls`` was a list, then:
+
+        * reasons to skip - except "no change" - cause the entire list to be skipped
+        * otherwise, any reasons to run cause the entire list to be run
+        * otherwise, the list is not run due to "no change"
+    """
+
+    def _return(run, reason):
+        if return_reason:
+            return run, reason
+        return run
+
+    if isinstance(cls, (list, tuple)):
+        runs = [run_test_for_class(x, return_reason=True) for x in cls]
+        reasons = [x[1] for x in runs]
+
+        # check the negative reasons that would cause the test to be skipped
+        #
+        # this excludes the "no change" reason, because:
+        # * special negative reasons cause entire list to be skipped
+        # * otherwise, positive reason causes the entire list to be run
+        # * if no positive reason, then list is skipped due to lack of positive reason
+        #
+        # if any of the classes are on the skip list, return False
+        # if any of the classes are missing dependencies, return False
+        NEG_REASONS = [
+            "False_exclude_list",
+            "False_required_deps_missing",
+        ]
+        for neg_reason in NEG_REASONS:
+            if any(reason == neg_reason for reason in reasons):
+                return _return(False, neg_reason)
+
+        # now check the "any of the classes should be tested" condition
+        POS_REASONS = [
+            "True_run_always",
+            "True_pyproject_change",
+            "True_changed_tests",
+            "True_changed_class",
+        ]
+        for pos_reason in POS_REASONS:
+            if any(reason == pos_reason for reason in reasons):
+                return _return(True, pos_reason)
+
+        # otherwise, we do not run, and the reason is "no change"
+        return _return(False, "False_no_change")
+
+    # if object is passed, obtain the class - objects are not hashable
+    if hasattr(cls, "get_class_tag") and not isclass(cls):
+        cls = cls.__class__
+    # check whether estimator is on the exclude override list
+    if cls.__name__ in EXCLUDE_ESTIMATORS:
+        return _return(False, "False_exclude_list")
+
+    # now we know that cls is a class or function,
+    # and not on the exclude list
+    run, reason = _run_test_for_class(cls)
+    return _return(run, reason)
+
+
+@lru_cache
+def _run_test_for_class(cls):
+    """Check if test should run - cached with hashable cls.
 
     Parameters
     ----------
@@ -43,14 +149,23 @@ def run_test_for_class(cls):
     Returns
     -------
     bool : True if class should be tested, False otherwise
-        if cls was a list, is True iff True for at least one of the classes in the list
+    reason : str, reason to run or skip the test, one of:
+
+        * "False_required_deps_missing" - skip reason, required dependencies are missing
+        * "False_no_change" - skip reason, no change in class or dependencies
+        * "True_run_always" - run reason, run always, as ``ONLY_CHANGED_MODULES=False``
+        * "True_pyproject_change" - run reason, dep(s) in ``pyproject.toml`` changed
+        * "True_changed_tests" - run reason, test(s) covering class have changed
+        * "True_changed_class" - run reason, module(s) containing class changed
+
+        If multiple reasons are present, the first one in the above list is returned.
     """
-    if not isinstance(cls, list):
-        cls = [cls]
 
     from skpro.tests.test_all_estimators import ONLY_CHANGED_MODULES
-    from skpro.utils.git_diff import is_class_changed
+    from skpro.utils.git_diff import get_packages_with_changed_specs, is_class_changed
     from skpro.utils.validation._dependencies import _check_estimator_deps
+
+    PACKAGE_REQ_CHANGED = get_packages_with_changed_specs()
 
     def _required_deps_present(obj):
         """Check if all required soft dependencies are present, return bool."""
@@ -68,7 +183,7 @@ def run_test_for_class(cls):
         # now we know cls is a class, so has an mro
         cls_and_parents = getmro(cls)
         cls_and_parents = [
-            x for x in cls_and_parents if x.__module__.startswith("skpro")
+            x for x in cls_and_parents if x.__module__.startswith(LOCAL_PACKAGE)
         ]
         return any(is_class_changed(x) for x in cls_and_parents)
 
@@ -79,24 +194,56 @@ def run_test_for_class(cls):
         test_classes = get_test_classes_for_obj(cls)
         return any(is_class_changed(x) for x in test_classes)
 
+    def _is_impacted_by_pyproject_change(cls):
+        """Check if the dep specifications of cls have changed, return bool."""
+        from packaging.requirements import Requirement
+
+        if not isclass(cls) or not hasattr(cls, "get_class_tags"):
+            return False
+
+        cls_reqs = cls.get_class_tag("python_dependencies", [])
+        if cls_reqs is None:
+            cls_reqs = []
+        if not isinstance(cls_reqs, list):
+            cls_reqs = [cls_reqs]
+        package_deps = [Requirement(req).name for req in cls_reqs]
+
+        return any(x in PACKAGE_REQ_CHANGED for x in package_deps)
+
     # Condition 1:
     # if any of the required soft dependencies are not present, do not run the test
-    if not all(_required_deps_present(x) for x in cls):
-        return False
+    if not _required_deps_present(cls):
+        return False, "False_required_deps_missing"
     # otherwise, continue
 
-    # Condition 2:
-    # if ONLY_CHANGED_MODULES is on, run the test if and only if
-    # any of the modules containing any of the classes in the list have changed
-    if ONLY_CHANGED_MODULES:
-        cond2 = any(_is_class_changed_or_parents(x) for x in cls)
-    else:
-        cond2 = True
+    # if ONLY_CHANGED_MODULES is off: always True
+    # tests are always run if soft dependencies are present
+    if not ONLY_CHANGED_MODULES:
+        return True, "True_run_always"
+
+    # run the test if and only if at least one of the conditions 2-4 are met
+    # conditions are checked in order to minimize runtime due to git diff etc
+
+    # Condition 4:
+    # the package requirements for any dependency in pyproject.toml have changed
+    cond4 = _is_impacted_by_pyproject_change(cls)
+    if cond4:
+        return True, "True_pyproject_change"
 
     # Condition 3:
     # if the object is an sktime BaseObject, and one of the test classes
     # covering the class have changed, then run the test
-    cond3 = any(_tests_covering_class_changed(x) for x in cls)
+    cond3 = _tests_covering_class_changed(cls)
+    if cond3:
+        return True, "True_changed_tests"
 
-    # run the test if and only if at least one of the conditions 2, 3 are met
-    return cond2 or cond3
+    # Condition 2:
+    # any of the modules containing any of the classes in the list have changed
+    # or any of the modules containing any parent classes in sktime have changed
+    cond2 = _is_class_changed_or_parents(cls)
+    if cond2:
+        return True, "True_changed_class"
+
+    # if none of the conditions are met, do not run the test
+    # reason is that there was no change
+    return False, "False_no_change"

--- a/skpro/tests/tests/__init__.py
+++ b/skpro/tests/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the test utilities."""

--- a/skpro/tests/tests/test_test_utils.py
+++ b/skpro/tests/tests/test_test_utils.py
@@ -1,0 +1,143 @@
+"""Tests for the test utilities."""
+
+from skpro.tests._config import EXCLUDE_ESTIMATORS
+from skpro.tests.test_switch import run_test_for_class
+from skpro.utils.validation._dependencies import _check_estimator_deps
+
+
+def test_exclude_estimators():
+    """Test that EXCLUDE_ESTIMATORS is a list of strings."""
+    assert isinstance(EXCLUDE_ESTIMATORS, list)
+    assert all(isinstance(estimator, str) for estimator in EXCLUDE_ESTIMATORS)
+
+
+def test_run_test_for_class():
+    """Test that run_test_for_class runs tests for various cases."""
+    # estimator on the exception list
+    from skpro.tests._config import DummySkipped
+
+    # estimator without soft deps
+    from skpro.regression.bootstrap import BootstrapRegressor
+
+    # estimator with soft deps
+    from skpro.regression.mapie import MapieRegressor
+
+    # boolean flag for whether to run tests for all estimators
+    from skpro.tests.test_all_estimators import ONLY_CHANGED_MODULES
+
+    # shorthands
+    f_on_excl_list = DummySkipped
+    f_no_deps = BootstrapRegressor
+    f_with_deps = MapieRegressor
+
+    # test that assumptions on being on exception list are correct
+    assert f_on_excl_list in EXCLUDE_ESTIMATORS  # if this fails, switch the example
+    assert f_no_deps not in EXCLUDE_ESTIMATORS  # same here
+    assert f_with_deps not in EXCLUDE_ESTIMATORS  # same here
+
+    # check result for skipped estimator
+    run = run_test_for_class(f_on_excl_list)
+    # run should be False, as the estimator is on the exception list
+    assert isinstance(run, bool)
+    assert not run
+    # same with reason returned
+    res = run_test_for_class(f_on_excl_list, return_reason=True)
+    assert isinstance(res, tuple)
+    assert len(res) == 2
+    run, reason = res
+    assert isinstance(run, bool)
+    assert not run
+    assert isinstance(reason, str)
+    assert reason == "False_exclude_list"
+
+    # check result for estimator without soft deps
+    run = run_test_for_class(f_no_deps)
+    assert isinstance(run, bool)
+    if not ONLY_CHANGED_MODULES:  # if we run all tests, we should run this one
+        assert run
+
+    # result depends now on whether there is a change in the classes
+    res = run_test_for_class(f_no_deps, return_reason=True)
+    assert isinstance(res, tuple)
+    assert len(res) == 2
+    run_nodep, reason_nodep = res
+    assert isinstance(run_nodep, bool)
+    assert isinstance(reason_nodep, str)
+
+    POS_REASONS = ["True_pyproject_change", "True_changed_class", "True_changed_tests"]
+
+    if not ONLY_CHANGED_MODULES:
+        assert run_nodep
+        assert reason_nodep == "True_run_always"
+    elif run_nodep:
+        # otherwise, if we run, it must be due to changes in class or pyproject
+        assert reason_nodep in POS_REASONS
+    else:  # not run and only changed modules
+        assert reason_nodep == "False_no_change"
+
+    # now check estimator with soft deps
+    run_nodep = run_test_for_class(f_with_deps)
+    assert isinstance(run, bool)
+
+    dep_present = _check_estimator_deps(f_with_deps, severity="none")
+    if not dep_present:
+        assert not run_nodep
+
+    res = run_test_for_class(f_with_deps, return_reason=True)
+    assert isinstance(res, tuple)
+    assert len(res) == 2
+    run_wdep, reason_wdep = res
+
+    if not dep_present:
+        assert not run_wdep
+        assert reason_wdep == "False_required_deps_missing"
+    elif not ONLY_CHANGED_MODULES:
+        assert run_wdep
+        assert reason_wdep == "True_run_always"
+    elif run_wdep:
+        assert reason_wdep in POS_REASONS
+    else:  # not run and only changed modules
+        assert reason_wdep == "False_no_change"
+
+    # now a list of estimator with exception plus one estimator
+    run = run_test_for_class([f_on_excl_list, f_no_deps])
+    assert isinstance(run, bool)
+    assert not run
+
+    res = run_test_for_class([f_on_excl_list, f_no_deps], return_reason=True)
+    assert isinstance(res, tuple)
+    assert len(res) == 2
+    run, reason = res
+    assert isinstance(run, bool)
+    assert not run
+    assert reason == "False_exclude_list"
+
+    # now a list of the estimator with and without soft deps
+    run = run_test_for_class([f_no_deps, f_with_deps])
+    assert isinstance(run, bool)
+
+    # if deps are not present, we do not run the test
+    # otherwise we run the test iff we run one of the two
+    if not dep_present:
+        assert not run
+    else:
+        assert run == run_nodep or run_wdep
+
+    res = run_test_for_class([f_no_deps, f_with_deps], return_reason=True)
+    assert isinstance(res, tuple)
+    assert len(res) == 2
+    run, reason = res
+
+    if not dep_present:
+        assert not run
+        assert reason == "False_required_deps_missing"
+    elif not ONLY_CHANGED_MODULES:
+        assert run
+        assert reason == "True_run_always"
+    elif run:
+        assert reason in POS_REASONS
+        assert reason_wdep == reason or reason_nodep == reason
+    else:
+        assert reason == "False_no_change"
+        assert reason_wdep == "False_no_change"
+        assert reason_nodep == "False_no_change"

--- a/skpro/tests/tests/test_test_utils.py
+++ b/skpro/tests/tests/test_test_utils.py
@@ -13,14 +13,14 @@ def test_exclude_estimators():
 
 def test_run_test_for_class():
     """Test that run_test_for_class runs tests for various cases."""
-    # estimator on the exception list
-    from skpro.tests._config import DummySkipped
-
     # estimator without soft deps
     from skpro.regression.bootstrap import BootstrapRegressor
 
     # estimator with soft deps
     from skpro.regression.mapie import MapieRegressor
+
+    # estimator on the exception list
+    from skpro.tests._config import DummySkipped
 
     # boolean flag for whether to run tests for all estimators
     from skpro.tests.test_all_estimators import ONLY_CHANGED_MODULES

--- a/skpro/tests/tests/test_test_utils.py
+++ b/skpro/tests/tests/test_test_utils.py
@@ -20,7 +20,7 @@ def test_run_test_for_class():
     from skpro.regression.mapie import MapieRegressor
 
     # estimator on the exception list
-    from skpro.tests._config import DummySkipped
+    from skpro.tests._config_test_dummy import DummySkipped
 
     # boolean flag for whether to run tests for all estimators
     from skpro.tests.test_all_estimators import ONLY_CHANGED_MODULES

--- a/skpro/tests/tests/test_test_utils.py
+++ b/skpro/tests/tests/test_test_utils.py
@@ -31,9 +31,10 @@ def test_run_test_for_class():
     f_with_deps = MapieRegressor
 
     # test that assumptions on being on exception list are correct
-    assert f_on_excl_list in EXCLUDE_ESTIMATORS  # if this fails, switch the example
-    assert f_no_deps not in EXCLUDE_ESTIMATORS  # same here
-    assert f_with_deps not in EXCLUDE_ESTIMATORS  # same here
+    # if any of the below fail, switch the example
+    assert f_on_excl_list.__name__ in EXCLUDE_ESTIMATORS
+    assert f_no_deps.__name__ not in EXCLUDE_ESTIMATORS
+    assert f_with_deps.__name__ not in EXCLUDE_ESTIMATORS
 
     # check result for skipped estimator
     run = run_test_for_class(f_on_excl_list)

--- a/skpro/utils/git_diff.py
+++ b/skpro/utils/git_diff.py
@@ -6,8 +6,10 @@ __all__ = []
 import importlib.util
 import inspect
 import subprocess
+from functools import lru_cache
 
 
+@lru_cache
 def get_module_from_class(cls):
     """Get full parent module string from class.
 
@@ -24,6 +26,7 @@ def get_module_from_class(cls):
     return module.__name__ if module else None
 
 
+@lru_cache
 def get_path_from_module(module_str):
     r"""Get local path string from module string.
 
@@ -47,6 +50,7 @@ def get_path_from_module(module_str):
         raise ImportError(f"Error finding module '{module_str}'") from e
 
 
+@lru_cache
 def is_module_changed(module_str):
     """Check if a module has changed compared to the main branch.
 
@@ -64,6 +68,7 @@ def is_module_changed(module_str):
         return True
 
 
+@lru_cache
 def is_class_changed(cls):
     """Check if a class' parent module has changed compared to the main branch.
 
@@ -78,3 +83,84 @@ def is_class_changed(cls):
     """
     module_str = get_module_from_class(cls)
     return is_module_changed(module_str)
+
+
+def get_changed_lines(file_path, only_indented=True):
+    """Get changed or added lines from a file.
+
+    Compares the current branch to the origin-main branch.
+
+    Parameters
+    ----------
+    file_path : str
+        path to file to get changed lines from
+    only_indented : bool, default=True
+        if True, only indented lines are returned, otherwise all lines are returned;
+        more precisely, only changed/added lines starting with a space are returned
+
+    Returns
+    -------
+    list of str : changed or added lines on current branch
+    """
+    cmd = f"git diff remotes/origin/main -- {file_path}"
+
+    try:
+        # Run 'git diff' command to get the changes in the specified file
+        result = subprocess.check_output(cmd, shell=True, text=True)
+
+        # if only indented lines are requested, add space to start_chars
+        start_chars = "+"
+        if only_indented:
+            start_chars += " "
+
+        # Extract the changed or new lines and return as a list of strings
+        changed_lines = [
+            line.strip() for line in result.split("\n") if line.startswith(start_chars)
+        ]
+        # remove first character ('+') from each line
+        changed_lines = [line[1:] for line in changed_lines]
+
+        return changed_lines
+
+    except subprocess.CalledProcessError:
+        return []
+
+
+@lru_cache
+def get_packages_with_changed_specs():
+    """Get packages with changed or added specs.
+
+    Returns
+    -------
+    list of str : names of packages with changed or added specs
+    """
+    from packaging.requirements import Requirement
+
+    changed_lines = get_changed_lines("pyproject.toml")
+
+    packages = []
+    for line in changed_lines:
+        if line.find("'") > line.find('"') and line.find('"') != -1:
+            sep = '"'
+        elif line.find("'") == -1:
+            sep = '"'
+        else:
+            sep = "'"
+
+        splits = line.split(sep)
+        if len(splits) < 2:
+            continue
+
+        req = line.split(sep)[1]
+
+        # deal with ; python_version >= "3.7" in requirements
+        if ";" in req:
+            req = req.split(";")[0]
+
+        pkg = Requirement(req).name
+        packages.append(pkg)
+
+    # make unique
+    packages = list(set(packages))
+
+    return packages


### PR DESCRIPTION
This speeds up collection of differential tests through caching, and adds a test condition if a relevant `pyproject` dependency line changes.

Mirrors https://github.com/sktime/sktime/pull/6357 for the caching extension.