### PR TITLE
[BUG] fix `CoxPH` handling of `statsmodels` `status` variable

### DIFF
--- a/skpro/distributions/adapters/statsmodels/_empirical.py
+++ b/skpro/distributions/adapters/statsmodels/_empirical.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 
 def empirical_from_rvdf(dist, index=None, columns=None):
-    """Convert a statsmodels rv_discrte_float to an skpro Empirical object.
+    """Convert a statsmodels rv_discrete_float to an skpro Empirical object.
 
     Parameters
     ----------

--- a/skpro/survival/coxph/_coxph_statsmodels.py
+++ b/skpro/survival/coxph/_coxph_statsmodels.py
@@ -104,7 +104,7 @@ class CoxPH(BaseSurvReg):
 
         endog = y.to_numpy().flatten()
         exog = X
-        status = C.to_numpy().flatten() if C is not None else None
+        status = 1 - C.to_numpy().flatten() if C is not None else None
 
         params = {
             "ties": self.ties,


### PR DESCRIPTION
This PR fixes an unreported bug where `CoxPH` interfaced `statsmodels` incorrectly.

In `statsmodels`, `status=1` means uncensored, and `status=0` means censored. In `sktime`, `C=1` means censored, and `C=0` means uncensored.

This flipping was missing in the adapter.