### PR TITLE
[ENH] improved `Empirical` distribution - scalar mode, new API compatibility

### DIFF
--- a/skpro/distributions/empirical.py
+++ b/skpro/distributions/empirical.py
@@ -151,6 +151,9 @@ class Empirical(BaseDistribution):
         sorted = self._sorted
         weights = self._weights
 
+        if self.ndim == 0:
+            return func(spl=sorted, weights=weights, x=x, **params)
+
         if x is not None and hasattr(x, "index"):
             index = x.index
         else:

--- a/skpro/distributions/empirical.py
+++ b/skpro/distributions/empirical.py
@@ -10,13 +10,30 @@ from skpro.distributions.base import BaseDistribution
 
 
 class Empirical(BaseDistribution):
-    """Empirical distribution (skpro native).
+    """Empirical distribution, or weighted sum of delta distributions.
+
+    This distribution represents an empirical distribution, or, more generally,
+    a weighted sum of delta distributions.
+
+    The distribution is parameterized by support in ``spl``, and optionally
+    weights in ``weights``.
+
+    For the scalar case, the distribution is parameterized as follows:
+    let :math:`s_i, i = 1 \dots N` the entries of ``spl``,
+    and :math:`w_i, i = 1 \dots N` the entries of ``weights``; if ``weights=None``,
+    by default we define :math:`p_i = \frac{1}{N}`, otherwise we
+    define :math:`p_i := \frac{w_i}{\sum_{i=1}^N w_i}`
+
+    The distribution is the unique distribution that takes value :math:`s_i` with
+    probability :math:`p_i`. In particluar, if ``weights`` was ``None``,
+    the distribution is the uniform distribution supported on the :math:`s_i`.
 
     Parameters
     ----------
-    spl : pd.DataFrame with pd.MultiIndex
-        empirical sample
-        last (highest) index is instance, first (lowest) index is sample
+    spl : pd.DataFrame
+        empirical sample; for scalar distributions, rows are samples;
+        for dataframe-like distributions,
+        first (lowest) index is sample, further indices are instance indices
     weights : pd.Series, with same index and length as spl, optional, default=None
         if not passed, ``spl`` is assumed to be unweighted
     time_indep : bool, optional, default=True
@@ -42,7 +59,7 @@ class Empirical(BaseDistribution):
     >>> empirical_sample = dist.sample(3)
 
     scalar distribution:
-    >>> spl = pd.DataFrame([1, 2, 3, 4, 3])
+    >>> spl = pd.Series([1, 2, 3, 4, 3])
     >>> dist = Empirical(spl)
     >>> empirical_sample = dist.sample(3)
     """

--- a/skpro/distributions/empirical.py
+++ b/skpro/distributions/empirical.py
@@ -210,7 +210,7 @@ class Empirical(BaseDistribution):
         if rowidx is None or colidx is None:
             raise ValueError("iat method requires both row and column index")
         self_subset = self[[rowidx], [colidx]]
-        spl_subset = self_subsets.spl.droplevel(0)
+        spl_subset = self_subset.spl.droplevel(0)
         if self.weights is not None:
             wts_subset = self_subset.weights.droplevel(0)
         else:
@@ -240,7 +240,7 @@ class Empirical(BaseDistribution):
         energy_arr = self._apply_per_ix(_energy_np, {"assume_sorted": True}, x=x)
         if energy_arr.ndim > 0:
             energy_arr = np.sum(energy_arr, axis=1)
-        return res
+        return energy_arr
 
     def _mean(self):
         r"""Return expected value of the distribution.

--- a/skpro/distributions/empirical.py
+++ b/skpro/distributions/empirical.py
@@ -206,6 +206,19 @@ class Empirical(BaseDistribution):
             columns=subs_colidx,
         )
 
+    def _iat(self, rowidx=None, colidx=None):
+        if rowidx is None or colidx is None:
+            raise ValueError("iat method requires both row and column index")
+        self_subset = self[[rowidx], [colidx]]
+        spl_subset = self_subsets.spl.droplevel(0)
+        if self.weights is not None:
+            wts_subset = self_subset.weights.droplevel(0)
+        else:
+            wts_subset = None
+
+        subset_params = {"spl": spl_subset, "weights": wts_subset}
+        return type(self)(**subset_params)
+
     def energy(self, x=None):
         r"""Energy of self, w.r.t. self or a constant frame x.
 

--- a/skpro/distributions/empirical.py
+++ b/skpro/distributions/empirical.py
@@ -10,7 +10,7 @@ from skpro.distributions.base import BaseDistribution
 
 
 class Empirical(BaseDistribution):
-    """Empirical distribution, or weighted sum of delta distributions.
+    r"""Empirical distribution, or weighted sum of delta distributions.
 
     This distribution represents an empirical distribution, or, more generally,
     a weighted sum of delta distributions.

--- a/skpro/distributions/empirical.py
+++ b/skpro/distributions/empirical.py
@@ -219,7 +219,7 @@ class Empirical(BaseDistribution):
         subset_params = {"spl": spl_subset, "weights": wts_subset}
         return type(self)(**subset_params)
 
-    def energy(self, x=None):
+    def _energy_default(self, x=None):
         r"""Energy of self, w.r.t. self or a constant frame x.
 
         Let :math:`X, Y` be i.i.d. random variables with the distribution of `self`.
@@ -237,8 +237,9 @@ class Empirical(BaseDistribution):
         pd.DataFrame with same rows as `self`, single column `"energy"`
         each row contains one float, self-energy/energy as described above.
         """
-        energy = self._apply_per_ix(_energy_np, {"assume_sorted": True}, x=x)
-        res = pd.DataFrame(energy.sum(axis=1), columns=["energy"])
+        energy_arr = self._apply_per_ix(_energy_np, {"assume_sorted": True}, x=x)
+        if energy_arr.ndim > 0:
+            energy_arr = np.sum(energy_arr, axis=1)
         return res
 
     def _mean(self):

--- a/skpro/distributions/empirical.py
+++ b/skpro/distributions/empirical.py
@@ -173,6 +173,13 @@ class Empirical(BaseDistribution):
         return res.apply(pd.to_numeric)
 
     def _iloc(self, rowidx=None, colidx=None):
+        if is_scalar_notnone(rowidx) and is_scalar_notnone(colidx):
+            return self._iat(rowidx, colidx)
+        if is_scalar_notnone(rowidx):
+            rowidx = pd.Index([rowidx])
+        if is_scalar_notnone(colidx):
+            colidx = pd.Index([colidx])
+
         index = self.index
         columns = self.columns
         weights = self.weights
@@ -209,7 +216,7 @@ class Empirical(BaseDistribution):
     def _iat(self, rowidx=None, colidx=None):
         if rowidx is None or colidx is None:
             raise ValueError("iat method requires both row and column index")
-        self_subset = self[[rowidx], [colidx]]
+        self_subset = self.iloc[[rowidx], [colidx]]
         spl_subset = self_subset.spl.droplevel(0)
         if self.weights is not None:
             wts_subset = self_subset.weights.droplevel(0)
@@ -546,3 +553,8 @@ def _ppf_np(spl, x, weights=None, assume_sorted=False):
     ppf_val = spl[ix_val]
 
     return ppf_val
+
+
+def is_scalar_notnone(obj):
+    """Check if obj is scalar and not None."""
+    return obj is not None and np.isscalar(obj)


### PR DESCRIPTION
Towards #283.

* adds a scalar mode to the `Empirical` distribution.
* otherwise refactors the `Empirical` distribution to adopt the new extender API