### PR TITLE
[ENH] increase distribution default `plot` resolution

### DIFF
--- a/skpro/distributions/base/_base.py
+++ b/skpro/distributions/base/_base.py
@@ -1415,7 +1415,7 @@ class BaseDistribution(BaseObject):
         if fun == "ppf":
             lower, upper = 0.001, 0.999
 
-        x_arr = np.linspace(lower, upper, 100)
+        x_arr = np.linspace(lower, upper, 1000)
         y_arr = [getattr(self, fun)(x) for x in x_arr]
         y_arr = np.array(y_arr)
 


### PR DESCRIPTION
This PR increases the default resolution of `plot` figures from 100 to 1000 points.

This is to prevent step functions from looking piecweise linear and not like step functions.