### PR TITLE
[ENH] `head` and `tail` for distribution objects

### DIFF
--- a/skpro/distributions/base/_base.py
+++ b/skpro/distributions/base/_base.py
@@ -178,6 +178,58 @@ class BaseDistribution(BaseObject):
             return 1
         return shape[0]
 
+    def head(self, n=5):
+        """Returns the first n rows.
+
+        If there are less than n rows in ``self``, returns clone of ``self``.
+
+        For negative n, returns all rows except the last n.
+
+        Parameters
+        ----------
+        n : int, default=5
+            Number of rows to return.
+
+        Returns
+        -------
+        ``self`` subset to the first n rows, i.e., ``self.iloc[0:min(n, len(self))]``
+        """
+        if self.ndim < 2:
+            return self
+        assert isinstance(n, int)
+        N = len(self)
+        if n < 0:
+            n = N - n
+        n = min(n, N)
+        return self.iloc[range(n)]
+
+    def tail(self, n=5):
+        """Returns the last n rows.
+
+        If there are less than n rows in ``self``, returns clone of ``self``.
+
+        For negative n, returns all rows except the first n.
+
+        Parameters
+        ----------
+        n : int, default=5
+            Number of rows to return.
+
+        Returns
+        -------
+        ``self`` subset to the last n rows, i.e., ``self.iloc[max(len(self) - n, 0):]``
+        """
+        if self.ndim < 2:
+            return self
+        assert isinstance(n, int)
+        N = len(self)
+        if n < 0:
+            start = n
+        else:
+            start = N - n
+        start = max(0, start)
+        return self.iloc[range(start, N)]
+
     def _loc(self, rowidx=None, colidx=None):
         if is_scalar_notnone(rowidx) and is_scalar_notnone(colidx):
             return self._at(rowidx, colidx)

--- a/skpro/distributions/base/_base.py
+++ b/skpro/distributions/base/_base.py
@@ -179,7 +179,7 @@ class BaseDistribution(BaseObject):
         return shape[0]
 
     def head(self, n=5):
-        """Returns the first n rows.
+        """Return the first n rows.
 
         If there are less than n rows in ``self``, returns clone of ``self``.
 
@@ -204,7 +204,7 @@ class BaseDistribution(BaseObject):
         return self.iloc[range(n)]
 
     def tail(self, n=5):
-        """Returns the last n rows.
+        """Return the last n rows.
 
         If there are less than n rows in ``self``, returns clone of ``self``.
 

--- a/skpro/distributions/base/_base.py
+++ b/skpro/distributions/base/_base.py
@@ -179,7 +179,7 @@ class BaseDistribution(BaseObject):
         return shape[0]
 
     def head(self, n=5):
-        """Return the first n rows.
+        """Returns the first n rows.
 
         If there are less than n rows in ``self``, returns clone of ``self``.
 
@@ -204,7 +204,7 @@ class BaseDistribution(BaseObject):
         return self.iloc[range(n)]
 
     def tail(self, n=5):
-        """Return the last n rows.
+        """Returns the last n rows.
 
         If there are less than n rows in ``self``, returns clone of ``self``.
 

--- a/skpro/distributions/tests/test_proba_basic.py
+++ b/skpro/distributions/tests/test_proba_basic.py
@@ -217,7 +217,7 @@ def test_head_tail():
     assert (nt.columns == n.columns).all()
     assert (nt.index == n.index[1:]).all()
 
-    nt2 = nt.tail()
+    nt2 = n.tail()
     assert isinstance(nt2, Normal)
     assert nt2.shape == (3, 2)
     assert (nt2.columns == n.columns).all()

--- a/skpro/distributions/tests/test_proba_basic.py
+++ b/skpro/distributions/tests/test_proba_basic.py
@@ -188,3 +188,46 @@ def test_to_df_parametric():
     for ix in all_params_df.columns:
         assert ix in param_names
         assert ix not in ["index", "columns"]
+
+
+def test_head_tail():
+    """Test head and tail utility functions."""
+    from skpro.distributions.normal import Normal
+
+    cols = ["foo", "bar"]
+
+    # default case, 2D distribution with n_columns>1
+    n = Normal(mu=[[0, 1], [2, 3], [4, 5]], sigma=1, columns=cols)
+
+    nh = n.head(2)
+    assert isinstance(nh, Normal)
+    assert nh.shape == (2, 2)
+    assert (nh.columns == n.columns).all()
+    assert (nh.index == n.index[:2]).all()
+
+    nh2 = n.head()
+    assert isinstance(nh2, Normal)
+    assert nh2.shape == (3, 2)
+    assert (nh2.columns == n.columns).all()
+    assert (nh2.index == n.index).all()
+
+    nt = n.tail(2)
+    assert isinstance(nt, Normal)
+    assert nt.shape == (2, 2)
+    assert (nt.columns == n.columns).all()
+    assert (nt.index == n.index[1:]).all()
+
+    nt2 = nt.tail()
+    assert isinstance(nt2, Normal)
+    assert nt2.shape == (3, 2)
+    assert (nt2.columns == n.columns).all()
+    assert (nt2.index == n.index).all()
+
+    # scalar case
+    n = Normal(mu=2, sigma=3)
+
+    nh = n.head()
+    assert nh.ndim == 0
+
+    nt = n.tail(42)
+    assert nt.ndim == 0


### PR DESCRIPTION
Adds `head` and `tail` methods for distribution objects, with same syntax and behaviour as for `pd.DataFrame`. Includes tests.