### PR TITLE
[ENH] full support of hierarchical `MultiIndex` `index` in `Empirical` distirbution, tests

### DIFF
--- a/skpro/distributions/empirical.py
+++ b/skpro/distributions/empirical.py
@@ -150,10 +150,6 @@ class Empirical(BaseDistribution):
                 spl_t_sorted = spl_t[sorter]
                 sorted[t][col] = spl_t_sorted
                 if self.weights is not None:
-                    if isinstance(t, tuple):
-                        sl = (slice(None),) + t
-                    else:
-                        sl = (slice(None), t)
                     weights_t = self.weights.loc[sl].values
                     weights_t_sorted = weights_t[sorter]
                     weights[t][col] = weights_t_sorted

--- a/skpro/distributions/empirical.py
+++ b/skpro/distributions/empirical.py
@@ -227,9 +227,7 @@ class Empirical(BaseDistribution):
             prod_ix = [(v,) + (i,) for v in obj_vals for i in ix]
         prod_ix = pd.MultiIndex.from_tuples(prod_ix)
 
-        ilocs = prod_ix.get_indexer(obj_ix)
-        ilocs = ilocs[ilocs >= 0]
-        return obj.iloc[ilocs]
+        return obj.loc[prod_ix]
 
     def _iloc(self, rowidx=None, colidx=None):
         if is_scalar_notnone(rowidx) and is_scalar_notnone(colidx):

--- a/skpro/distributions/empirical.py
+++ b/skpro/distributions/empirical.py
@@ -489,13 +489,21 @@ class Empirical(BaseDistribution):
         wts_scalar = pd.Series([0.2, 0.2, 0.3, 0.3, 0.1])
         params4 = {"spl": spl_scalar, "weights": wts_scalar}
 
-        # nested index, important for sktime
+        # hierarchical MultiIndex, important for sktime
         spl_idx = pd.MultiIndex.from_product(
             [[0, 1], [0, 1, 2], [0, 1]], names=["sample", "instance", "time"]
         )
         param5 = {"spl": pd.DataFrame(np.random.rand(12, 2), index=spl_idx)}
 
-        return [params1, params2, params3, params4, param5]
+        # hierarchical MultiIndex, important for sktime, weighted
+        spl_idx = pd.MultiIndex.from_product(
+            [[0, 1], [0, 1, 2], [0, 1]], names=["sample", "instance", "time"]
+        )
+        weights = pd.Series(list(range(1, 13)), index=spl_idx)
+        spl = pd.DataFrame(np.random.rand(12, 2), index=spl_idx)
+        param6 = {"spl": spl, "weights": weights}
+
+        return [params1, params2, params3, params4, param5, param6]
 
 
 def _energy_np(spl, x=None, weights=None, assume_sorted=False):

--- a/skpro/distributions/empirical.py
+++ b/skpro/distributions/empirical.py
@@ -150,7 +150,11 @@ class Empirical(BaseDistribution):
                 spl_t_sorted = spl_t[sorter]
                 sorted[t][col] = spl_t_sorted
                 if self.weights is not None:
-                    weights_t = self.weights.loc[(slice(None), t)].values
+                    if isinstance(t, tuple):
+                        sl = (slice(None),) + t
+                    else:
+                        sl = (slice(None), t)
+                    weights_t = self.weights.loc[sl].values
                     weights_t_sorted = weights_t[sorter]
                     weights[t][col] = weights_t_sorted
                 else:


### PR DESCRIPTION
This PR adds full support of hierarchical `MultiIndex` `index` in `Empirical` distribution, and tests, via `get_test_params`.