### PR TITLE
[BUG] fix survival metrics if `C_true=None` is passed

### DIFF
--- a/skpro/metrics/base.py
+++ b/skpro/metrics/base.py
@@ -428,6 +428,8 @@ class BaseDistrMetric(BaseProbaMetric):
         obj : object
             Coerced object
         """
+        if obj is None:
+            return None
         obj = convert_to(obj, to_type="pd_DataFrame_Table", as_scitype="Table")
         obj = _coerce_to_df(obj)
         return obj

--- a/skpro/metrics/survival/_c_harrell.py
+++ b/skpro/metrics/survival/_c_harrell.py
@@ -208,9 +208,9 @@ class ConcordanceHarrell(BaseDistrMetric):
             # weighting is such that rows contain simple fractions
             # but the average over rows is not the overall C-index,
             # as number of comparable pairs is in general not the same for each index
-            n_comp_mat[n_comp_mat==0] = 1  # handling of case 0 / 0, avoid nans
+            ncomp_mat[ncomp_mat == 0] = 1  # handling of case 0 / 0, avoid nans
             result = nconc_mat / ncomp_mat
-            result[n_comp_mat==1] = tie_score  # handling of case 0 / 0
+            result[ncomp_mat == 1] = tie_score  # handling of case 0 / 0
 
         res_df = pd.DataFrame(result, index=ix, columns=cols)
 

--- a/skpro/metrics/survival/_c_harrell.py
+++ b/skpro/metrics/survival/_c_harrell.py
@@ -167,7 +167,8 @@ class ConcordanceHarrell(BaseDistrMetric):
                 rij = rj[i]
                 Cij = Cj[i]
                 nCij = ~Cij
-                one_unc = ~(Cj & Cij)
+                one_unc = ~(Cj & Cij)  # at least one uncensored in the pair
+                xone_unc = ~(Cj & Cij) & (Cj | Cij)  # exactly one uncensored
 
                 # mark concordant pairs (no ties)
                 comp1 = nCij & (yj > yij)  # comparable, > type
@@ -187,7 +188,7 @@ class ConcordanceHarrell(BaseDistrMetric):
                 if tie_score != 0:
                     nconc = nconc.astype(float)
                     nconc += np.sum((yj != yij) & (rj == rij)) * tie_score
-                    nconc += np.sum(one_unc & (yj == yij) & (rj == rij)) * tie_score
+                    nconc += np.sum(xone_unc & (yj == yij) & (rj == rij)) * tie_score
 
                 # count comparable pairs
                 comp3 = one_unc & (yj == yij)

--- a/skpro/metrics/survival/_c_harrell.py
+++ b/skpro/metrics/survival/_c_harrell.py
@@ -208,7 +208,9 @@ class ConcordanceHarrell(BaseDistrMetric):
             # weighting is such that rows contain simple fractions
             # but the average over rows is not the overall C-index,
             # as number of comparable pairs is in general not the same for each index
+            n_comp_mat[n_comp_mat==0] = 1  # handling of case 0 / 0, avoid nans
             result = nconc_mat / ncomp_mat
+            result[n_comp_mat==1] = tie_score  # handling of case 0 / 0
 
         res_df = pd.DataFrame(result, index=ix, columns=cols)
 

--- a/skpro/metrics/survival/_c_harrell.py
+++ b/skpro/metrics/survival/_c_harrell.py
@@ -208,9 +208,9 @@ class ConcordanceHarrell(BaseDistrMetric):
             # weighting is such that rows contain simple fractions
             # but the average over rows is not the overall C-index,
             # as number of comparable pairs is in general not the same for each index
-            ncomp_mat[ncomp_mat == 0] = 1  # handling of case 0 / 0, avoid nans
+            n_comp_mat[n_comp_mat==0] = 1  # handling of case 0 / 0, avoid nans
             result = nconc_mat / ncomp_mat
-            result[ncomp_mat == 1] = tie_score  # handling of case 0 / 0
+            result[n_comp_mat==1] = tie_score  # handling of case 0 / 0
 
         res_df = pd.DataFrame(result, index=ix, columns=cols)
 

--- a/skpro/metrics/survival/tests/test_c_harrell.py
+++ b/skpro/metrics/survival/tests/test_c_harrell.py
@@ -37,7 +37,7 @@ def test_charrell_logic(concordant, pass_c, normalization):
     y_pred = Normal(y_pred_mean, sigma=1, columns=pd.Index(["a", "b"]))
 
     # evaluate the metric
-    metric = ConcordanceHarrell(normalization=normalization)
+    metric = ConcordanceHarrell(normalization=normalization, tie_score=int(concordant))
     metric_args = {"y_true": y_true, "y_pred": y_pred}
     if pass_c == "True":
         metric_args["C_true"] = c_true
@@ -47,9 +47,12 @@ def test_charrell_logic(concordant, pass_c, normalization):
     res = metric(**metric_args)
     res_by_index = metric.evaluate_by_index(**metric_args)
 
+    assert res_by_index.shape == y_true.shape
+
     # test assumptions
     # if concordant, the result should be 1
     # if discordant, the result should be 0
     assert res == concordant
-    assert res_by_index.shape == y_true.shape
-    assert (res_by_index == concordant).all().all()
+
+    if normalization == "index":
+        assert (res_by_index == concordant).all().all()

--- a/skpro/metrics/survival/tests/test_c_harrell.py
+++ b/skpro/metrics/survival/tests/test_c_harrell.py
@@ -6,7 +6,7 @@ import pytest
 
 
 @pytest.mark.parametrize("concordant", [True, False])
-@pytest.mark.parametrize("pass_c", [True, False])
+@pytest.mark.parametrize("pass_c", ["True", "False", "None"])
 @pytest.mark.parametrize("normalization", ["overall", "index"])
 def test_charrell_logic(concordant, pass_c, normalization):
     """Test the logic of the Harrell's C-index metric.
@@ -17,8 +17,9 @@ def test_charrell_logic(concordant, pass_c, normalization):
         If True, the test examples are fully concordant.
         If False, the test examples are fully discordant.
     pass_c : bool, optional, default=True
-        If True, the `c_true` argument is passed to the metric.
-        If False, the `c_true` argument is not passed to the metric.
+        If True, the ``C_true`` argument is passed to the metric, with censoring data.
+        If None, the ``C_true`` argument is passed to the metric, with value None.
+        If False, the ``C_true`` argument is not passed to the metric.
     normalization : str, optional, default="overall"
         The normalization method for the metric.
     """
@@ -38,8 +39,10 @@ def test_charrell_logic(concordant, pass_c, normalization):
     # evaluate the metric
     metric = ConcordanceHarrell(normalization=normalization)
     metric_args = {"y_true": y_true, "y_pred": y_pred}
-    if pass_c:
-        metric_args["c_true"] = c_true
+    if pass_c == "True":
+        metric_args["C_true"] = c_true
+    elif pass_c == "None":
+        metric_args["C_true"] = c_true
 
     res = metric(**metric_args)
     res_by_index = metric.evaluate_by_index(**metric_args)


### PR DESCRIPTION
This fixes an unreported bug in which survival metrics break if `C_true=None` is passed as part of `kwargs`, as opposed to not being passed.

This is due to the boilerplate layer passing passing an empty `pd.DataFrame` to the inner `_evaluate` (due to coercion if the argument is present), which may lead to breakage in metrics that do not ignore it, e.g., `ConcordanceHarrell`.

The fix is ensuring that the boilerplate layer passes on `None` in this case.

Also fixes some minor issues with `ConcordanceHarrell` masked by this problem:

* `evaluate_by_index` could return `nan` if a sample was not comparable. This is replaced by `tie_score`
* the `test_charell_logic` test made incorrect assumption about resulting concordances, this has been fixed.