### PR TITLE
[ENH] in `ConditionUncensored` reducer, ensure coercion to float of `C`

### DIFF
--- a/skpro/survival/compose/_reduce_cond_unc.py
+++ b/skpro/survival/compose/_reduce_cond_unc.py
@@ -78,7 +78,7 @@ class ConditionUncensored(BaseProbaRegressor):
         if C is None:
             C = pd.DataFrame(0, index=index, columns=columns)
         else:
-            C = C.copy()
+            C = C.copy().astype("float")
         X_and_C = pd.concat([X, C], axis=1)
         return X_and_C
 


### PR DESCRIPTION
This PR ensures coercion to float, of the `C` argument, in the `ConditionUncensored` reducer.

This makes the estimator safer to non-compliant inputs.