### PR TITLE
[ENH] native implementation of Johnson QPD family, explicit pdf

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
 [project.optional-dependencies]
 all_extras = [
     "attrs",
+    "cyclic-boosting>=1.4.0; python_version < '3.12'",
     "distfit",
     "lifelines<0.29.0",
     "mapie",
@@ -63,8 +64,6 @@ all_extras = [
     "statsmodels>=0.12.1",
     "tabulate",
     "uncertainties",
-    "cyclic-boosting>=1.4.0; python_version < '3.12'",
-    "findiff",
 ]
 
 dev = [

--- a/skpro/distributions/qpd.py
+++ b/skpro/distributions/qpd.py
@@ -272,17 +272,17 @@ class QPD_S(BaseDistribution):
         phi = _resolve_phi(version)
         self.phi = phi
 
-        params = _prep_qpd_vars(phi=phi, mode="S", **self._bc_params)
-        self.params = params
+        qpd_params = _prep_qpd_vars(phi=phi, mode="S", **self._bc_params)
+        self._qpd_params = qpd_params
 
     def _ppf(self, p: np.ndarray):
         """Quantile function = percent point function = inverse cdf."""
         lower = self._bc_params["lower"]
-        delta = self.params["delta"]
-        kappa = self.params["kappa"]
-        c = self.params["c"]
-        n = self.params["n"]
-        theta = self.params["theta"]
+        delta = self._qpd_params["delta"]
+        kappa = self._qpd_params["kappa"]
+        c = self._qpd_params["c"]
+        n = self._qpd_params["n"]
+        theta = self._qpd_params["theta"]
 
         phi = self.phi
 
@@ -295,11 +295,11 @@ class QPD_S(BaseDistribution):
     def _pdf(self, x: np.ndarray):
         """Probability density function."""
         lower = self._bc_params["lower"]
-        delta = self.params["delta"]
-        kappa = self.params["kappa"]
-        c = self.params["c"]
-        n = self.params["n"]
-        theta = self.params["theta"]
+        delta = self._qpd_params["delta"]
+        kappa = self._qpd_params["kappa"]
+        c = self._qpd_params["c"]
+        n = self._qpd_params["n"]
+        theta = self._qpd_params["theta"]
 
         phi = self.phi
 
@@ -325,11 +325,11 @@ class QPD_S(BaseDistribution):
     def _cdf(self, x: np.ndarray):
         """Cumulative distribution function."""
         lower = self._bc_params["lower"]
-        delta = self.params["delta"]
-        kappa = self.params["kappa"]
-        c = self.params["c"]
-        n = self.params["n"]
-        theta = self.params["theta"]
+        delta = self._qpd_params["delta"]
+        kappa = self._qpd_params["kappa"]
+        c = self._qpd_params["c"]
+        n = self._qpd_params["n"]
+        theta = self._qpd_params["theta"]
 
         phi = self.phi
 
@@ -455,18 +455,18 @@ class QPD_B(BaseDistribution):
         phi = _resolve_phi(version)
         self.phi = phi
 
-        params = _prep_qpd_vars(phi=phi, mode="B", **self._bc_params)
-        self.params = params
+        qpd_params = _prep_qpd_vars(phi=phi, mode="B", **self._bc_params)
+        self._qpd_params = qpd_params
 
     def _ppf(self, p: np.ndarray):
         """Quantile function = percent point function = inverse cdf."""
         lower = self._bc_params["lower"]
-        rnge = self.params["rnge"]
-        delta = self.params["delta"]
-        kappa = self.params["kappa"]
-        c = self.params["c"]
-        n = self.params["n"]
-        xi = self.params["xi"]
+        rnge = self._qpd_params["rnge"]
+        delta = self._qpd_params["delta"]
+        kappa = self._qpd_params["kappa"]
+        c = self._qpd_params["c"]
+        n = self._qpd_params["n"]
+        xi = self._qpd_params["xi"]
 
         phi = self.phi
 
@@ -477,12 +477,12 @@ class QPD_B(BaseDistribution):
     def _pdf(self, x: np.ndarray):
         """Probability density function."""
         lower = self._bc_params["lower"]
-        rnge = self.params["rnge"]
-        delta = self.params["delta"]
-        kappa = self.params["kappa"]
-        c = self.params["c"]
-        n = self.params["n"]
-        xi = self.params["xi"]
+        rnge = self._qpd_params["rnge"]
+        delta = self._qpd_params["delta"]
+        kappa = self._qpd_params["kappa"]
+        c = self._qpd_params["c"]
+        n = self._qpd_params["n"]
+        xi = self._qpd_params["xi"]
 
         phi = self.phi
 
@@ -509,12 +509,12 @@ class QPD_B(BaseDistribution):
     def _cdf(self, x: np.ndarray):
         """Cumulative distribution function."""
         lower = self._bc_params["lower"]
-        rnge = self.params["rnge"]
-        delta = self.params["delta"]
-        kappa = self.params["kappa"]
-        c = self.params["c"]
-        n = self.params["n"]
-        xi = self.params["xi"]
+        rnge = self._qpd_params["rnge"]
+        delta = self._qpd_params["delta"]
+        kappa = self._qpd_params["kappa"]
+        c = self._qpd_params["c"]
+        n = self._qpd_params["n"]
+        xi = self._qpd_params["xi"]
 
         phi = self.phi
 
@@ -645,16 +645,16 @@ class QPD_U(BaseDistribution):
         phi = _resolve_phi(version)
         self.phi = phi
 
-        params = _prep_qpd_vars(phi=phi, mode="U", **self._bc_params)
-        self.params = params
+        qpd_params = _prep_qpd_vars(phi=phi, mode="U", **self._bc_params)
+        self._qpd_params = qpd_params
 
     def _ppf(self, p: np.ndarray):
         """Quantile function = percent point function = inverse cdf."""
         alpha = self._bc_params["alpha"]
-        xi = self.params["xi"]
-        gamma = self.params["gamma"]
-        delta = self.params["delta"]
-        kappa = self.params["kappa"]
+        xi = self._qpd_params["xi"]
+        gamma = self._qpd_params["gamma"]
+        delta = self._qpd_params["delta"]
+        kappa = self._qpd_params["kappa"]
 
         phi = self.phi
 
@@ -667,10 +667,10 @@ class QPD_U(BaseDistribution):
     def _pdf(self, x: np.ndarray):
         """Probability density function."""
         alpha = self._bc_params["alpha"]
-        xi = self.params["xi"]
-        gamma = self.params["gamma"]
-        delta = self.params["delta"]
-        kappa = self.params["kappa"]
+        xi = self._qpd_params["xi"]
+        gamma = self._qpd_params["gamma"]
+        delta = self._qpd_params["delta"]
+        kappa = self._qpd_params["kappa"]
 
         phi = self.phi
 
@@ -686,10 +686,10 @@ class QPD_U(BaseDistribution):
     def _cdf(self, x: np.ndarray):
         """Cumulative distribution function."""
         alpha = self._bc_params["alpha"]
-        xi = self.params["xi"]
-        gamma = self.params["gamma"]
-        delta = self.params["delta"]
-        kappa = self.params["kappa"]
+        xi = self._qpd_params["xi"]
+        gamma = self._qpd_params["gamma"]
+        delta = self._qpd_params["delta"]
+        kappa = self._qpd_params["kappa"]
 
         phi = self.phi
 

--- a/skpro/distributions/qpd.py
+++ b/skpro/distributions/qpd.py
@@ -85,7 +85,6 @@ class QPD_Johnson(_DelegatedDistribution):
         # --------------
         "authors": ["setoguchi-naoki", "felix-wick", "fkiraly"],
         "maintainers": ["setoguchi-naoki"],
-        "python_dependencies": ["cyclic_boosting>=1.4.0", "findiff"],
         # estimator tags
         # --------------
         "capabilities:approx": ["pdfnorm", "energy"],

--- a/skpro/distributions/qpd.py
+++ b/skpro/distributions/qpd.py
@@ -785,7 +785,7 @@ def _prep_qpd_vars(
         in_arccosh = HL / (2 * HBL)
         delta_unn = np.arccosh(in_arccosh)
         if mode == "S":
-            delta = np.sinh(delta_unn)
+            delta_unn = np.sinh(delta_unn)
         delta = delta_unn / c
     elif mode == "U":
         delta = 1.0 / np.arccosh(1 / (2.0 * theta))

--- a/skpro/distributions/qpd.py
+++ b/skpro/distributions/qpd.py
@@ -295,8 +295,8 @@ class QPD_S(BaseDistribution):
 
         phi = self.phi
 
-        in_sinh = np.arcsinh(phi.ppf(p) * delta)
-        in_exp = kappa * np.sinh(in_sinh) + np.arcsinh(n * c * delta)
+        in_sinh = np.arcsinh(phi.ppf(p) * delta) + np.arcsinh(n * c * delta)
+        in_exp = kappa * np.sinh(in_sinh)
         ppf_arr = lower + theta * np.exp(in_exp)
 
         return ppf_arr

--- a/skpro/distributions/qpd.py
+++ b/skpro/distributions/qpd.py
@@ -776,15 +776,30 @@ def _prep_qpd_vars(
         B = bounded mode, S = lower semi-bounded mode
     """
     c = phi.ppf(1 - alpha)
-    rnge = upper - lower
+
+    if mode == "U":
+        lower = 0
 
     qll = qv_low - lower
     qml = qv_median - lower
     qhl = qv_high - lower
 
-    L = phi.ppf(qll / rnge)
-    H = phi.ppf(qhl / rnge)
-    B = phi.ppf(qml / rnge)
+    if mode == "B":
+        rnge = upper - lower
+
+        def tfun(x):        
+            return phi.ppf(x / rnge)
+
+    elif mode == "S":
+        tfun = np.log
+    elif mode == "U":
+
+        def tfun(x):
+            return x
+
+    L = tfun(qll)
+    H = tfun(qhl)
+    B = tfun(qml)
     HL = H - L
     BL = B - L
     HB = H - B
@@ -824,7 +839,6 @@ def _prep_qpd_vars(
 
     params = {
         "c": c,
-        "rnge": rnge,
         "L": L,
         "H": H,
         "B": B,
@@ -835,6 +849,8 @@ def _prep_qpd_vars(
 
     if mode == "S":
         params["theta"] = theta
+    if mode == "B":
+        params["rnge"] = rnge
     if mode in ["B", "U"]:
         params["xi"] = xi
     if mode == "U":

--- a/skpro/distributions/qpd.py
+++ b/skpro/distributions/qpd.py
@@ -9,7 +9,12 @@ __author__ = [
     "setoguchi-naoki",
 ]  # interface only. Cyclic boosting authors in cyclic_boosting package
 
+import typing
+import warnings
 from typing import Sequence
+
+if typing.TYPE_CHECKING:
+    from cyclic_boosting.quantile_matching import J_QPD_S, J_QPD_B
 
 import numpy as np
 import pandas as pd
@@ -715,6 +720,81 @@ class QPD_U(BaseDistribution):
             "columns": pd.Index(["a"]),
         }
         return [params1, params2]
+
+
+def calc_pdf(cdf: np.ndarray) -> np.ndarray:
+    """Return pdf value for all samples."""
+    from findiff import FinDiff
+
+    dx = 1e-6
+    derivative = FinDiff(1, dx, 1)
+    pdf = np.asarray(derivative(cdf))
+    return pdf
+
+
+def exp_func(x: np.ndarray, cdf: np.ndarray, size: int):
+    """Return Expectation."""
+    pdf = calc_pdf(cdf)
+    x = np.tile(x, (size, 1))
+    loc = np.trapz(x * pdf, x, dx=1e-6, axis=1)
+    return loc
+
+
+def var_func(x: np.ndarray, mu: np.ndarray, cdf: np.ndarray, size: int):
+    """Return Variance."""
+    pdf = calc_pdf(cdf)
+    x = np.tile(x, (size, 1))
+    var = np.trapz(((x - mu) ** 2) * pdf, x, dx=1e-6, axis=1)
+    return var
+
+
+def pdf_func(x: np.ndarray, qpd: J_QPD_S | J_QPD_B | list):
+    """Return pdf value."""
+    pdf = np.zeros_like(x)
+    for r in range(x.shape[0]):
+        for c in range(x.shape[1]):
+            element = x[r][c]
+            x0 = np.linspace(element, element + 1e-3, num=3)
+            if isinstance(qpd, list):
+                cdf = np.asarray([func.cdf(x0) for func in qpd])
+                cdf = cdf.reshape(cdf.shape[0], -1)
+            else:
+                cdf = qpd.cdf(x0)
+                if cdf.ndim < 2:
+                    for _ in range(2 - cdf.ndim):
+                        cdf = cdf[:, np.newaxis]
+                cdf = cdf.T
+            pdf_part = calc_pdf(cdf)
+            pdf[r][c] = pdf_part[0][0]
+    return pdf
+
+
+def ppf_func(x: np.ndarray, qpd: J_QPD_S | J_QPD_B | list):
+    """Return ppf value."""
+    if isinstance(qpd, list):
+        ppf = np.asarray([func.ppf(x) for func in qpd])
+        ppf = ppf.reshape(ppf.shape[0], -1)
+    else:
+        ppf = qpd.ppf(x)
+        if ppf.ndim < 2:
+            for _ in range(2 - ppf.ndim):
+                ppf = ppf[np.newaxis]
+    ppf = ppf.T
+    return ppf
+
+
+def cdf_func(x: np.ndarray, qpd: J_QPD_S | J_QPD_B | list):
+    """Return cdf value."""
+    if isinstance(qpd, list):
+        cdf = np.asarray([func.cdf(x) for func in qpd])
+        cdf = cdf.reshape(cdf.shape[0], -1)
+    else:
+        cdf = qpd.cdf(x)
+        if cdf.ndim < 2:
+            for _ in range(2 - cdf.ndim):
+                cdf = cdf[np.newaxis]
+    cdf = cdf.T
+    return cdf
 
 
 def _resolve_phi(phi):

--- a/skpro/distributions/qpd.py
+++ b/skpro/distributions/qpd.py
@@ -787,7 +787,7 @@ def _prep_qpd_vars(
     if mode == "B":
         rnge = upper - lower
 
-        def tfun(x):        
+        def tfun(x):
             return phi.ppf(x / rnge)
 
     elif mode == "S":

--- a/skpro/distributions/qpd.py
+++ b/skpro/distributions/qpd.py
@@ -152,9 +152,9 @@ class QPD_Johnson(_DelegatedDistribution):
         params2 = {
             "alpha": 0.1,
             "version": "normal",
-            "qv_low": [0.2, 0.2, 0.2],
-            "qv_median": [0.5, 0.5, 0.5],
-            "qv_high": [0.8, 0.8, 0.8],
+            "qv_low": [[-0.3], [-0.2], [-0.1]],
+            "qv_median": [[-0.1], [0.0], [0.1]],
+            "qv_high": [[0.2], [0.3], [0.4]],
             "index": pd.Index([1, 2, 5]),
             "columns": pd.Index(["a"]),
         }

--- a/skpro/distributions/qpd.py
+++ b/skpro/distributions/qpd.py
@@ -234,7 +234,12 @@ class QPD_S(BaseDistribution):
         "distr:measuretype": "continuous",
         "broadcast_init": "on",
         "broadcast_params": [
-            "alpha", "qv_low", "qv_median", "qv_high", "lower", "upper"
+            "alpha",
+            "qv_low",
+            "qv_median",
+            "qv_high",
+            "lower",
+            "upper",
         ],
     }
 
@@ -417,7 +422,12 @@ class QPD_B(BaseDistribution):
         "distr:measuretype": "continuous",
         "broadcast_init": "on",
         "broadcast_params": [
-            "alpha", "qv_low", "qv_median", "qv_high", "lower", "upper"
+            "alpha",
+            "qv_low",
+            "qv_median",
+            "qv_high",
+            "lower",
+            "upper",
         ],
     }
 
@@ -604,7 +614,12 @@ class QPD_U(BaseDistribution):
         "distr:measuretype": "continuous",
         "broadcast_init": "on",
         "broadcast_params": [
-            "alpha", "qv_low", "qv_median", "qv_high", "lower", "upper"
+            "alpha",
+            "qv_low",
+            "qv_median",
+            "qv_high",
+            "lower",
+            "upper",
         ],
     }
 
@@ -728,7 +743,15 @@ def _resolve_phi(phi):
 
 
 def _prep_qpd_vars(
-    alpha, qv_low, qv_median, qv_high, lower, upper, phi, mode="B", **kwargs,
+    alpha,
+    qv_low,
+    qv_median,
+    qv_high,
+    lower,
+    upper,
+    phi,
+    mode="B",
+    **kwargs,
 ):
     """Prepare parameters for Johnson Quantile-Parameterized Distributions.
 
@@ -822,4 +845,4 @@ def _prep_qpd_vars(
 
 def arcsinh_der(x):
     """Return derivative of arcsinh."""
-    return 1 / np.sqrt(1 + x ** 2)
+    return 1 / np.sqrt(1 + x**2)

--- a/skpro/distributions/tests/test_qpd.py
+++ b/skpro/distributions/tests/test_qpd.py
@@ -37,8 +37,8 @@ def test_qpd_b_pdf():
         upper=0.5,
     )
     x = np.linspace(-0.45, 0.45, 100)
-    pdf = [qpd_linear.pdf(x_) for x_ in x]
-    assert np.testing.assert_allclose(np.sum(pdf), 1.0, rtol=1e-5)
+    pdf_vals = [qpd_linear.pdf(x_) for x_ in x]
+    np.testing.assert_allclose(pdf_vals, 1.0, rtol=1e-5)
 
 
 @pytest.mark.skipif(

--- a/skpro/distributions/tests/test_qpd.py
+++ b/skpro/distributions/tests/test_qpd.py
@@ -1,5 +1,6 @@
 """Tests for quantile-parameterized distributions."""
 
+import numpy as np
 import pytest
 
 from skpro.distributions.qpd import QPD_B, QPD_S, QPD_U
@@ -22,6 +23,22 @@ def test_qpd_b_simple_use():
     )
 
     qpd.mean()
+
+
+def test_qpd_b_pdf():
+    """Test pdf of qpd with bounded mode."""
+    # these parameters should produce a uniform on -0.5, 0.5
+    qpd_linear = QPD_B(
+        alpha=0.2,
+        qv_low=-0.3,
+        qv_median=0,
+        qv_high=0.3,
+        lower=-0.5,
+        upper=0.5,
+    )
+    x = np.linspace(-0.45, 0.45, 100)
+    pdf = [qpd_linear.pdf(x_) for x_ in x]
+    assert np.testing.assert_allclose(np.sum(pdf), 1.0, rtol=1e-5)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
This PR reworks the family of QPD family of distributions for efficiency and to allow removal of the newly introduced dependency `findiff` in #232.

The dependency `findiff` was introduced for approximation of `pdf`, but in fact it is unnecessary as the `pdf` can be analytically derived by applying the chain rule. True, it has to be applied three or four times, but it's still the chain rule... efficiency and accuracy gains are significant, and it helps us avoid computing numerical derivatives for all entries in a large matrix, together with the now unnecessary `findiff` dependency.

Makes the following changes:

* refactoring of the three QPD distributions tp use `skpro` machinery:
    * use of the `skpro` native parameter broadcasting system instead of ad-hoc broadcasting
    * use of the `skpro` native approximation for `mean`, `var`, instead of three copies of similar (and partially duplicative) approximation inside the distributions
* refactoring between the three QPD distributions with the end of simplification
    * refactoring QPD parameter computation into a single, fully vectorized function, `_prep_qpd_vars`
* clean room reimplementation of `cdf`, `ppf` of the three distributions based on the `cyclic_boosting` reference
* new implementation of `pdf`, as derivative of `cdf`

As side effects of the rework:
* all parameters now broadcast in numpy-like fashion, including `alpha`, `lower`, `upper`, which previously was not possible
* the distributions can be 2D with more than 1 column, which previously was not possible
* `version` (the base distribution) can now be an arbitrary continuous `scipy` distribution
* `pdf` is numerically exact
* the distributions do not have soft dependencies anymore

Regarding the relation to `cyclic_boosting`:

* this is clean room reimplementation and credit is given, so I hope this is fine license-wise - @felixwick?
* this is the result of trying to remove the `findiff` dependency for computing the `pdf` from the `cdf` that was introduced in #232, as well as cleanup before release. I ended up simplifying a lot, ending up here. In this sense, the work of @setoguchi-naoki was crucial in arriving at this point.
* I would have no issue at all with you moving the improved code into `cyclic_boosting`. We can even restore the dependency and maintain the distribution logic in `cyclic_boosting` if that were your preference, e.g., for ownership reasons.

FYI @felixwick, @setoguchi-naoki, review appreciated - I would like to remove the `findiff` dependency before the next release.