### PR TITLE
[MNT] remove `findiff` soft dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
 [project.optional-dependencies]
 all_extras = [
     "attrs",
+    "cyclic-boosting>=1.4.0; python_version < '3.12'",
     "distfit",
     "lifelines<0.29.0",
     "mapie",
@@ -63,8 +64,6 @@ all_extras = [
     "statsmodels>=0.12.1",
     "tabulate",
     "uncertainties",
-    "cyclic-boosting>=1.4.0; python_version < '3.12'",
-    "findiff",
 ]
 
 dev = [


### PR DESCRIPTION
PR https://github.com/sktime/skpro/pull/327 shows that the `findiff` soft dependency is not necessary - with this, I hence remove it.

We should either merge #327, or leave the QPDs with a soft dependency that users then have to install independently.