### PR TITLE
[MNT] deprecation handling for `CyclicBoosting`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
 [project.optional-dependencies]
 all_extras = [
     "attrs",
+    "cyclic-boosting>=1.4.0; python_version < '3.12'",
     "distfit",
     "lifelines<0.29.0",
     "mapie",
@@ -63,8 +64,6 @@ all_extras = [
     "statsmodels>=0.12.1",
     "tabulate",
     "uncertainties",
-    "cyclic-boosting>=1.4.0; python_version < '3.12'",
-    "findiff",
 ]
 
 dev = [

--- a/skpro/regression/cyclic_boosting.py
+++ b/skpro/regression/cyclic_boosting.py
@@ -184,16 +184,14 @@ class CyclicBoosting(BaseProbaRegressor):
 
         # todo 2.4.0: remove this block
         # translate bound to lower and upper
-        if lower is None:
-            if bound in ["S", "B"]:
-                self._lower = 0.0
-            else:
-                self._lower = None
-        if upper is None:
-            if bound == "B":
-                self._upper = 1.0
-            else:
-                self._upper = None
+        if lower is None and bound in ["S", "B"]:
+            self._lower = 0.0
+        else:
+            self._lower = None
+        if upper is None and bound == "B":
+            self._upper = 1.0
+        else:
+            self._upper = upper
         # end block
 
         # check parameters

--- a/skpro/regression/cyclic_boosting.py
+++ b/skpro/regression/cyclic_boosting.py
@@ -49,6 +49,9 @@ class CyclicBoosting(BaseProbaRegressor):
         lower quantile for QPD's parameter alpha
     mode : str, default='multiplicative'
         the type of quantile regressor. 'multiplicative' or 'additive'
+    bound : str, default='U', one of ``'S'``, ``'B'``, ``'U'``
+        Mode for the predictive distribution range, options are ``S``
+        (semi-bounded), ``B`` (bounded), and ``U`` (unbound).
     lower : float, default=None
         lower bound of supported range (only active for bound and semi-bound
         modes). If neither 'lower' nor 'upper' is specified, `QPD_U` will be used as
@@ -56,13 +59,13 @@ class CyclicBoosting(BaseProbaRegressor):
     upper : float, default=None
         upper bound of supported range (only active for bound mode). If neither
         'lower' nor 'upper' is specified, `QPD_U` will be used as unbound-mode
-    version: str, one of ``'normal'`` (default), ``'logistic'``
+    maximal_iterations : int, default=10
+        number of iterations
+    dist_type: str, one of ``'normal'`` (default), ``'logistic'``
         options are ``'normal'`` (default) or ``'logistic'``
     dist_shape: float, optional, default=0.0
         parameter modifying the logistic base distribution via
         sinh/arcsinh-scaling (only active in sinhlogistic version)
-    maximal_iterations : int, default=10
-        number of iterations
 
     Attributes
     ----------

--- a/skpro/regression/cyclic_boosting.py
+++ b/skpro/regression/cyclic_boosting.py
@@ -149,20 +149,18 @@ class CyclicBoosting(BaseProbaRegressor):
         self.feature_groups = feature_groups
         self.feature_properties = feature_properties
         self.alpha = alpha
-        self.mode = mode
-        self.bound = bound
-        self.lower = lower
-        self.upper = upper
-        self.maximal_iterations = maximal_iterations
-        self.dist_type = dist_type
-        self.dist_shape = dist_shape
-
-        super().__init__()
-
         self.quantiles = [self.alpha, 0.5, 1 - self.alpha]
         self.quantile_values = list()
         self.quantile_est = list()
         self.qpd = None
+        self.mode = mode
+        self.lower = lower
+        self.upper = upper
+        self.dist_type = dist_type
+        self.dist_shape = dist_shape
+        self.maximal_iterations = maximal_iterations
+
+        super().__init__()
 
         # todo 2.4.0: remove bound parameter and this deprecation warning
         if bound == "deprecated":

--- a/skpro/regression/cyclic_boosting.py
+++ b/skpro/regression/cyclic_boosting.py
@@ -184,14 +184,16 @@ class CyclicBoosting(BaseProbaRegressor):
 
         # todo 2.4.0: remove this block
         # translate bound to lower and upper
-        if lower is None and bound in ["S", "B"]:
-            self._lower = 0.0
-        else:
-            self._lower = None
-        if upper is None and bound == "B":
-            self._upper = 1.0
-        else:
-            self._upper = upper
+        if lower is None:
+            if bound in ["S", "B"]:
+                self._lower = 0.0
+            else:
+                self._lower = None
+        if upper is None:
+            if bound == "B":
+                self._upper = 1.0
+            else:
+                self._upper = None
         # end block
 
         # check parameters

--- a/skpro/regression/cyclic_boosting.py
+++ b/skpro/regression/cyclic_boosting.py
@@ -149,18 +149,20 @@ class CyclicBoosting(BaseProbaRegressor):
         self.feature_groups = feature_groups
         self.feature_properties = feature_properties
         self.alpha = alpha
+        self.mode = mode
+        self.bound = bound
+        self.lower = lower
+        self.upper = upper
+        self.maximal_iterations = maximal_iterations
+        self.dist_type = dist_type
+        self.dist_shape = dist_shape
+
+        super().__init__()
+
         self.quantiles = [self.alpha, 0.5, 1 - self.alpha]
         self.quantile_values = list()
         self.quantile_est = list()
         self.qpd = None
-        self.mode = mode
-        self.lower = lower
-        self.upper = upper
-        self.dist_type = dist_type
-        self.dist_shape = dist_shape
-        self.maximal_iterations = maximal_iterations
-
-        super().__init__()
 
         # todo 2.4.0: remove bound parameter and this deprecation warning
         if bound == "deprecated":


### PR DESCRIPTION
Deprecation messages for `CyclicBoosting` for deprecations and changes in 2.4.0.
Alternative to #320.

* restores sequence of parameters to sequence in version 2.2.2, to avoid breakage in the 2.3.0 release
* adds deprecation message for `bound` parameter
* renames new `version` parameter to `dist_type` - the name is a bit misleading, as it will probably imply "version" in the semantic versioning sense to an ordinary user. Does not require deprecation, because added since 2.2.2.

Also makes improvements to the docstring of the `CyclicBoosting` estimator.

Difference to #320: does not carry out deprecations for distributions, under a working assumption that #327 will be merged.