### PR TITLE
[BUG] `BaseDistribution._var`: fix missing factor 2 in Monte Carlo variance default method

### DIFF
--- a/skpro/distributions/base/_base.py
+++ b/skpro/distributions/base/_base.py
@@ -1271,7 +1271,7 @@ class BaseDistribution(BaseObject):
         spl1 = self.sample(approx_spl_size)
         spl2 = self.sample(approx_spl_size)
         spl = (spl1 - spl2) ** 2
-        return self._sample_mean(spl)
+        return self._sample_mean(spl) / 2
 
     def pdfnorm(self, a=2):
         r"""a-norm of pdf, defaults to 2-norm.


### PR DESCRIPTION
The approximation fallback for Monte Carlo estimation of a distribution's variance, in `BaseDistribution._var`, was missing a factor two by accident.

This PR adds that missing factor.