### PR TITLE
[ENH] fix distribution row/column convention in `CyclicBoosting`

### DIFF
--- a/skpro/regression/cyclic_boosting.py
+++ b/skpro/regression/cyclic_boosting.py
@@ -284,9 +284,9 @@ class CyclicBoosting(BaseProbaRegressor):
         # Johnson Quantile-Parameterized Distributions
         params = {
             "alpha": self.alpha,
-            "qv_low": self.quantile_values[0],
-            "qv_median": self.quantile_values[1],
-            "qv_high": self.quantile_values[2],
+            "qv_low": self.quantile_values[0].reshape(-1, 1),
+            "qv_median": self.quantile_values[1].reshape(-1, 1),
+            "qv_high": self.quantile_values[2].reshape(-1, 1),
             "lower": self.lower,
             "upper": self.upper,
             "version": self.version,


### PR DESCRIPTION
Recent PR brought the QPDistributions in line with unified `skpro` row/column conventions, where 1D vectors are interpreted as row vectors.

This clashes with assumed coercion about the now-changed QPDistributions (it assumed column vectors) inside `CyclicBoosting`, which needed to be fixed.