### PR TITLE
[DOC] Fix typos throughout the codebase

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -175,6 +175,15 @@
       "contributions": [
         "maintenance"
       ]
+    },
+    {
+      "login": "szepeviktor",
+      "name": "Viktor Szépe",
+      "avatar_url": "https://avatars.githubusercontent.com/u/952007?v=4",
+      "profile": "https://github.com/szepeviktor",
+      "contributions": [
+        "doc"
+      ]
     }
   ]
 }

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -33,7 +33,7 @@ Let's have a look at an example of Boston Housing price prediction (using sklear
 
 If you are familiar with scikit-learn you will recognise that we define and train a model on the boston housing dataset and obtain the test prediction ``y_pred``. Furthermore, we use a loss function to calculate the loss between the predicted points and the true values -- nothing unexpected there.
 
-Crucially, however, the skpro model does not just return a list of numbers or point predictions here. Instead, ``y_pred`` is a probablistic prediction, i.e. it represents probability distributions for each individual data point.
+Crucially, however, the skpro model does not just return a list of numbers or point predictions here. Instead, ``y_pred`` is a probabilistic prediction, i.e. it represents probability distributions for each individual data point.
 We can, for instance, obtain the standard deviation of the predicted distribution that corresponds with the first (0th) test point (or any other test point distribution) ::
 
     >>> y_pred[0].std()
@@ -44,7 +44,7 @@ Notably, the interface represents all distributional properties, including the d
     >>> y_pred[0].pdf(x=42)
     0.00192808538756
 
-Furthermore, it is possible to conveniently access the distributional properties in their vectorized form accross the test sample::
+Furthermore, it is possible to conveniently access the distributional properties in their vectorized form across the test sample::
 
     >>> y_pred.std().shape
     (152,)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-All notable changes to this project beggining with version 0.1.0 will be
+All notable changes to this project beginning with version 0.1.0 will be
 documented in this file. The format is based on
 `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_ and we adhere
 to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_. The source

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -197,6 +197,7 @@ Documentation
 * [DOC] tutorial notebook for survival prediction (:pr:`305`) :user:`fkiraly`
 * [DOC] visualizations for first intro vignette in intro notebook and minor updates (:pr:`311`) :user:`fkiraly`
 * [DOC] improve docstrings of metrics (:pr:`317`) :user:`fkiraly`
+* [DOC] Fix typos throughout the codebase (:pr:`338`) :user:`szepeviktor`
 
 Contributors
 ~~~~~~~~~~~~
@@ -207,7 +208,8 @@ Contributors
 :user:`nilesh05apr`,
 :user:`setoguchi-naoki`,
 :user:`ShreeshaM07`,
-:user:`sukjingitsit`
+:user:`sukjingitsit`,
+:user:`szepeviktor`
 
 
 [2.2.2] - 2024-04-20

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -267,7 +267,7 @@ nbsphinx_execute = "never"  # always  # whether to run notebooks
 nbsphinx_allow_errors = False  # False
 nbsphinx_timeout = 600  # seconds, set to -1 to disable timeout
 
-# add Binder launch buttom at the top
+# add Binder launch button at the top
 current_file = "{{ env.doc2path( env.docname, base=None) }}"
 
 # make sure Binder points to latest stable release, not main

--- a/docs/source/contribute/code_of_conduct.rst
+++ b/docs/source/contribute/code_of_conduct.rst
@@ -5,7 +5,7 @@ Code of conduct
 ===============
 
 The ``skpro`` project believes that everyone should be able to participate
-in our community without fear of harrassment or discrimination. All contributors
+in our community without fear of harassment or discrimination. All contributors
 are expected to show respect and courtesy to other members of the community
 at all times.
 
@@ -22,4 +22,4 @@ to Dr. Franz Király by email at franz.kiraly@sktime.net.
     Code of Conduct processes (including how to report incidents).
     This may change as the project matures.
     However, ``skpro``'s Code of Conduct will remain
-    dedicated to promoting a community without harrassment and discrimination.
+    dedicated to promoting a community without harassment and discrimination.

--- a/docs/source/developer_guide/dependencies.rst
+++ b/docs/source/developer_guide/dependencies.rst
@@ -18,7 +18,7 @@ Types of dependencies
 
 Making it easy to install and use ``skpro`` in a variety of projects is
 on of ``skpro``'s goals. Therefore, we seeks to minimizing the number of
-dependencies needed to provide the proejct's functionality.
+dependencies needed to provide the project's functionality.
 
 Soft Dependencies
 =================

--- a/docs/source/developer_guide/deprecation.rst
+++ b/docs/source/developer_guide/deprecation.rst
@@ -81,7 +81,7 @@ The release manager process happens at every release and is as follows:
 Special deprecations
 ====================
 
-This section outlines the deprecation process for some advaned cases.
+This section outlines the deprecation process for some advanced cases.
 
 Deprecating tags
 ----------------

--- a/docs/source/developer_guide/reviewer_guide.rst
+++ b/docs/source/developer_guide/reviewer_guide.rst
@@ -43,7 +43,7 @@ Code Review
 
 .. _reviewer_guide_doc:
 
-Documenation Review
+Documentation Review
 ====================
 
 * Are the docstrings complete and understandable to users?

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -76,17 +76,17 @@ To install the latest development version of ``skpro``, the sequence
 of steps is as follows:
 
 
-1. Clone the ``skpro`` `Github repository`_
+1. Clone the ``skpro`` `GitHub repository`_
 2. Create a new virtual environment via ``conda`` and activate it.
 3. Use ``pip`` to build ``skpro`` from source and install development dependencies
 
 
 Detail instructions for each step is provided below.
 
-Step 1 - Clone Github repository
+Step 1 - Clone GitHub repository
 --------------------------------
 
-The ``skpro`` `Github repository`_ should be cloned to a local directory.
+The ``skpro`` `GitHub repository`_ should be cloned to a local directory.
 
 To install the latest version using the ``git`` command line, use the following steps:
 
@@ -97,7 +97,7 @@ To install the latest version using the ``git`` command line, use the following 
 4. Make sure you are on the main branch: :code:`git checkout main`
 5. Make sure your local version is up-to-date: :code:`git pull`
 
-See Github's `repository clone documentation`_
+See GitHub's `repository clone documentation`_
 for additional details.
 
 .. hint::
@@ -108,7 +108,7 @@ for additional details.
     Where ``<VERSION>`` is a valid version string that can be found by inspecting the
     repository's ``git`` tags, by running ``git tag``.
 
-    You can also download a specific release version from the Github repository's
+    You can also download a specific release version from the GitHub repository's
     zip archive of `releases <https://github.com/sktime/skpro/releases>`_.
 
 Step 2 - Create a new virtual environment

--- a/examples/01_skpro_intro.ipynb
+++ b/examples/01_skpro_intro.ipynb
@@ -2487,7 +2487,7 @@
        "      <td>capability:survival</td>\n",
        "      <td>regressor_proba</td>\n",
        "      <td>bool</td>\n",
-       "      <td>whether estimator can use censoring informatio...</td>\n",
+       "      <td>whether estimator can use censoring information...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
@@ -2514,7 +2514,7 @@
        "1  which machine type(s) is the internal _fit/_pr...  \n",
        "2          whether estimator supports missing values  \n",
        "3  whether estimator supports multioutput regression  \n",
-       "4  whether estimator can use censoring informatio...  \n",
+       "4  whether estimator can use censoring information...  \n",
        "5  which machine type(s) is the internal _fit/_pr...  "
       ]
      },
@@ -4423,7 +4423,7 @@
     "* predicting variance equal to training residual variance - `ResidualDouble` with standard settings\n",
     "    * or other unconditional distribution estimate for residuals\n",
     "* \"squaring the residual\" two-step prediction - `ResidualDouble`\n",
-    "* boostrap prediction intervals - `BootstrapRegressor`\n",
+    "* bootstrap prediction intervals - `BootstrapRegressor`\n",
     "* MAPIE model agnostic prediction intervals - `MapieRegressor` (from `mapie` package)\n",
     "* natural gradient boosting aka NGBoost - `NGBoostRegressor` (from `ngboost` package)"
    ]
@@ -5095,7 +5095,7 @@
     "1. Read through the [probabilistic regression extension template](https://github.com/sktime/skpro/blob/main/extension_templates/regression.py) - this is a `python` file with `todo` blocks that mark the places in which changes need to be added.\n",
     "2. Copy the proba regressor extension template to a local folder in your own repository (local/private extension), or to a suitable location in your clone of the `skpro` or affiliated repository (if contributed extension), inside `skpro.regression`; rename the file and update the file docstring appropriately.\n",
     "3. Address the \"todo\" parts. Usually, this means: changing the name of the class, setting the tag values, specifying hyper-parameters, filling in `__init__`, `_fit`, and at least one of the probabilistic prediction methods, preferably `_predict_proba` (for details see the extension template). You can add private methods as long as they do not override the default public interface. For more details, see the extension template.\n",
-    "4. To test your estimator manually: import your estimator and run it in the worfklows in Section 1; then use it in the compositors in Section 3.\n",
+    "4. To test your estimator manually: import your estimator and run it in the workflows in Section 1; then use it in the compositors in Section 3.\n",
     "5. To test your estimator automatically: call `skpro.utils.check_estimator` on your estimator. You can call this on a class or object instance. Ensure you have specified test parameters in the `get_test_params` method, according to the extension template.\n",
     "\n",
     "In case of direct contribution to `skpro` or one of its affiliated packages, additionally:\n",

--- a/examples/02_skpro_survival.ipynb
+++ b/examples/02_skpro_survival.ipynb
@@ -30,7 +30,7 @@
    "source": [
     "`skpro` provides a unified interface to time-to-event prediction models, also known as survival prediction models.\n",
     "\n",
-    "**Time-to-event prediction** is a form of probabilistic regression where **labels can be \"censored\"**, i.e., of the form \"time is t or later\" instead of exat observations.\n",
+    "**Time-to-event prediction** is a form of probabilistic regression where **labels can be \"censored\"**, i.e., of the form \"time is t or later\" instead of exact observations.\n",
     "\n",
     "**Section 1** provides an overview of the basic **time-to-event prediction workflows** supported by `skpro`.\n",
     "\n",
@@ -103,7 +103,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# simulated toy datset, lung cancer survival times\n",
+    "# simulated toy dataset, lung cancer survival times\n",
     "import numpy as np\n",
     "\n",
     "# demographics - age and smoker yes/no\n",
@@ -567,7 +567,7 @@
     }
    ],
    "source": [
-    "# plotting survival funtions in one figure, smokers in red\n",
+    "# plotting survival functions in one figure, smokers in red\n",
     "from matplotlib.pyplot import subplots\n",
     "\n",
     "_, ax = subplots()\n",
@@ -636,7 +636,7 @@
     }
    ],
    "source": [
-    "# plotting survival funtions in one figure, smokers in red\n",
+    "# plotting survival functions in one figure, smokers in red\n",
     "from matplotlib.pyplot import subplots\n",
     "\n",
     "_, ax = subplots()\n",
@@ -705,7 +705,7 @@
     }
    ],
    "source": [
-    "# plotting survival funtions in one figure, smokers in red\n",
+    "# plotting survival functions in one figure, smokers in red\n",
     "from matplotlib.pyplot import subplots\n",
     "\n",
     "_, ax = subplots()\n",
@@ -954,7 +954,7 @@
     "* metrics will compare probabilistic prediction to tabular ground truth and\n",
     "  censoring indicator\n",
     "* the metric needs to be of a compatible type, e.g., for distribution predictions\n",
-    "* special survival metrics are avaliable to take into account censoring;\n",
+    "* special survival metrics are available to take into account censoring;\n",
     "  if a non-survival metric is used, the censoring indicator will be ignored"
    ]
   },
@@ -1296,7 +1296,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "the three main reduction stratgies to create survival regressors:\n",
+    "the three main reduction strategies to create survival regressors:\n",
     "\n",
     "1. adding the capability to handle censoring information to a probabilistic supervised regressor\n",
     "2. the above, combined with any strategy to create a probabilistic regressor from an `sklearn` (non-probabilistic) regressors\n",
@@ -1757,7 +1757,7 @@
     "1. Read through the [survival regression extension template](https://github.com/sktime/skpro/blob/main/extension_templates/survival.py) - this is a `python` file with `todo` blocks that mark the places in which changes need to be added.\n",
     "2. Copy the proba regressor extension template to a local folder in your own repository (local/private extension), or to a suitable location in your clone of the `skpro` or affiliated repository (if contributed extension), inside `skpro.survival`; rename the file and update the file docstring appropriately.\n",
     "3. Address the \"todo\" parts. Usually, this means: changing the name of the class, setting the tag values, specifying hyper-parameters, filling in `__init__`, `_fit`, and at least one of the probabilistic prediction methods, preferably `_predict_proba` (for details see the extension template). You can add private methods as long as they do not override the default public interface. For more details, see the extension template.\n",
-    "4. To test your estimator manually: import your estimator and run it in the worfklows in Section 1; then use it in the compositors in Section 3.\n",
+    "4. To test your estimator manually: import your estimator and run it in the workflows in Section 1; then use it in the compositors in Section 3.\n",
     "5. To test your estimator automatically: call `skpro.utils.check_estimator` on your estimator. You can call this on a class or object instance. Ensure you have specified test parameters in the `get_test_params` method, according to the extension template.\n",
     "\n",
     "In case of direct contribution to `skpro` or one of its affiliated packages, additionally:\n",

--- a/examples/03_skpro_distributions.ipynb
+++ b/examples/03_skpro_distributions.ipynb
@@ -1196,7 +1196,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "at construction, all (simple) probabilty distributions broadcast parameters:\n",
+    "at construction, all (simple) probability distributions broadcast parameters:\n",
     "\n",
     "* if `index` or `columns` are passed, always broadcasts to 2D\n",
     "* 1D iterables are interpreted as row vectors, i.e., of shape (1, n)\n",
@@ -1375,7 +1375,7 @@
     "\n",
     "n = Normal(mu=[[1, 2], [2, 3]], sigma=2)\n",
     "# results in a shape (2, 2) distribution\n",
-    "# sigma is broadcast ot the shape of mu\n",
+    "# sigma is broadcast to the shape of mu\n",
     "# index, columns are RangeIndex, i.e., [0, 1]\n",
     "n.shape"
    ]
@@ -1463,7 +1463,7 @@
     "n = Normal(mu=[1, 2, 3], sigma=2)\n",
     "# results in a shape (1, 3) distribution\n",
     "# mu is interpreted as (1, 3) row vector\n",
-    "# sigma is broadcast ot the shape of mu\n",
+    "# sigma is broadcast to the shape of mu\n",
     "# index, columns are RangeIndex, i.e., index=[0] and columns=[0, 1, 2]\n",
     "n.shape"
    ]
@@ -1537,7 +1537,7 @@
    "source": [
     "as first-class citizens, all objects in `skpro` are indexed via the `registry` utility `all_objects`.\n",
     "\n",
-    "To find probabilisty distirbutions, use `all_objects` with the type `distribution`:"
+    "To find probabilisty distributions, use `all_objects` with the type `distribution`:"
    ]
   },
   {
@@ -2447,7 +2447,7 @@
    ],
    "source": [
     "# dataframe distributions convert to a DataFrame\n",
-    "# with column MultiIndex (variable, parmaeter)\n",
+    "# with column MultiIndex (variable, parameter)\n",
     "d = Normal(mu=[[1, 2], [3, 4], [5, 6]], sigma=2, columns=[\"var1\", \"var2\"])\n",
     "d.to_df()"
    ]
@@ -2648,10 +2648,10 @@
     "* Follow the [\"implementing estimator\" developer guide](https://skpro.readthedocs.io/en/stable/developer_guide/add_estimators.html)\n",
     "* Use the [probabilistic regressor template](https://github.com/sktime/skpro/blob/main/extension_templates/regression.py) to get started\n",
     "\n",
-    "1. Read through the [probability distibution extension template](https://github.com/sktime/skpro/blob/main/extension_templates/distributions.py) - this is a `python` file with `todo` blocks that mark the places in which changes need to be added.\n",
+    "1. Read through the [probability distribution extension template](https://github.com/sktime/skpro/blob/main/extension_templates/distributions.py) - this is a `python` file with `todo` blocks that mark the places in which changes need to be added.\n",
     "2. Copy the distribution extension template to a local folder in your own repository (local/private extension), or to a suitable location in your clone of the `skpro` or affiliated repository (if contributed extension), inside `skpro.distributions`; rename the file and update the file docstring appropriately.\n",
     "3. Address the \"todo\" parts. Usually, this means: changing the name of the class, setting the tag values, specifying hyper-parameters, filling in `__init__`, and as many methods as possible, most importantly `_ppf`, and possibly other common methods such as `_pdf` or `_pmf`, `_cdf`. You can add private methods as long as they do not override the default public interface. For more details, see the extension template.\n",
-    "4. To test your estimator manually: import your estimator and run it in the worfklows in Section 1; then use it in the compositors in Section 3.\n",
+    "4. To test your estimator manually: import your estimator and run it in the workflows in Section 1; then use it in the compositors in Section 3.\n",
     "5. To test your estimator automatically: call `skpro.utils.check_estimator` on your estimator. You can call this on a class or object instance. Ensure you have specified test parameters in the `get_test_params` method, according to the extension template.\n",
     "\n",
     "In case of direct contribution to `skpro` or one of its affiliated packages, additionally:\n",
@@ -2670,7 +2670,7 @@
     "\n",
     "* `skpro` provides a unified interface for probability distributions, with an interface inspired by `scikit-learn` and `pandas`\n",
     "\n",
-    "* `skpro` distributions are parametric first class objects. They are symbolic representations of probability distibution, and come with methods such as `pdf`, `cdf`, `sample`, `plot`, etc\n",
+    "* `skpro` distributions are parametric first class objects. They are symbolic representations of probability distribution, and come with methods such as `pdf`, `cdf`, `sample`, `plot`, etc\n",
     "\n",
     "* `skpro` distributions can be scalar-valued, or data frame valued. The latter broadcast parameters and arguments of methods to 2D, and are returned by `skpro` probabilistic regressors or survival regressors `predict_proba`\n",
     "\n",

--- a/extension_templates/regression.py
+++ b/extension_templates/regression.py
@@ -70,7 +70,7 @@ class ClassName(BaseProbaRegressor):
     # parameter checks can go after super call
     def __init__(self, paramname, paramname2="paramname2default"):
         # estimators should precede parameters
-        #  if estimators have default values, set None and initalize below
+        #  if estimators have default values, set None and initialize below
 
         # todo: write any hyper-parameters and components to self
         self.paramname = paramname

--- a/extension_templates/survival.py
+++ b/extension_templates/survival.py
@@ -49,7 +49,7 @@ class ClassName(BaseSurvReg):
     # parameter checks can go after super call
     def __init__(self, paramname, paramname2="paramname2default"):
         # estimators should precede parameters
-        #  if estimators have default values, set None and initalize below
+        #  if estimators have default values, set None and initialize below
 
         # todo: write any hyper-parameters and components to self
         self.paramname = paramname

--- a/skpro/datatypes/_convert.py
+++ b/skpro/datatypes/_convert.py
@@ -4,7 +4,7 @@
 Exports
 -------
 convert_to(obj, to_type: str, as_scitype: str, store=None)
-    converts object "obj" to type "to_type", considerd as "as_scitype"
+    converts object "obj" to type "to_type", considered as "as_scitype"
 
 convert(obj, from_type: str, to_type: str, as_scitype: str, store=None)
     same as convert_to, without automatic identification of "from_type"
@@ -159,7 +159,7 @@ def convert(
         pass
     else:
         raise ValueError(
-            "bug: unrechable condition error, store_behaviour has unexpected value"
+            "bug: unreachable condition error, store_behaviour has unexpected value"
         )
 
     converted_obj = convert_dict[key](obj, store=store)
@@ -167,7 +167,7 @@ def convert(
     return converted_obj
 
 
-# conversion based on queriable type to specified target
+# conversion based on queryable type to specified target
 def convert_to(
     obj,
     to_type: str,

--- a/skpro/datatypes/_convert_utils/_convert.py
+++ b/skpro/datatypes/_convert_utils/_convert.py
@@ -52,12 +52,12 @@ def _extend_conversions(mtype, anchor_mtype, convert_dict, mtype_universe=None):
     anchor_mtype : mtype string in convert_dict
     convert_dict : conversion dictionary with entries of converter signature
         see docstring of datatypes._convert
-    mtype_universe : iterable of mtype strings in convert_dict, coercable to list or set
+    mtype_universe : iterable of mtype strings in convert_dict, coercible to list or set
 
     Returns
     -------
     reference to convert_dict
-    CAVEAT: convert_dict passed to this function gets mutated, this is a referene
+    CAVEAT: convert_dict passed to this function gets mutated, this is a reference
     """
     keys = convert_dict.keys()
     scitype = list(keys)[0][2]

--- a/skpro/datatypes/tests/test_convert_to.py
+++ b/skpro/datatypes/tests/test_convert_to.py
@@ -1,4 +1,4 @@
-"""Testing machine type converters for scitypes - covert_to utility."""
+"""Testing machine type converters for scitypes - convert_to utility."""
 
 __author__ = ["fkiraly"]
 

--- a/skpro/distributions/base/_base.py
+++ b/skpro/distributions/base/_base.py
@@ -67,7 +67,7 @@ class BaseDistribution(BaseObject):
         default broadcasting and pre-initialization is not desired or applicable,
         e.g., distribution parameters are not array-like.
 
-        If overriden, must set ``self._shape``: this should be an empty tuple
+        If overridden, must set ``self._shape``: this should be an empty tuple
         if the distribution is scalar, or a pair of integers otherwise.
         """
         if self.get_tags()["broadcast_init"] == "off":
@@ -1572,7 +1572,7 @@ class BaseDistribution(BaseObject):
             fig.supxlabel(f"{x_argname}")
             return fig, ax
 
-        # for now, all plots default ot this function
+        # for now, all plots default to this function
         # but this could be changed to a dispatch mechanism
         # e.g., using this line instead
         # plot_fun_name = f"_plot_{fun}"

--- a/skpro/distributions/delta.py
+++ b/skpro/distributions/delta.py
@@ -10,7 +10,7 @@ from skpro.distributions.base import BaseDistribution
 
 
 class Delta(BaseDistribution):
-    r"""Delta distribution aka constant distibution aka certain distribution.
+    r"""Delta distribution aka constant distribution aka certain distribution.
 
     This distribution always produces the same value when sampling - ``c``.
     It it useful to represent a constant value as a distribution, e.g., as a baseline

--- a/skpro/distributions/empirical.py
+++ b/skpro/distributions/empirical.py
@@ -193,7 +193,7 @@ class Empirical(BaseDistribution):
     def _slice_ix(self, obj, ix):
         """Slice obj by index ix, applied to MultiIndex levels 1 ... last.
 
-        obj is assumed to have MultiIndex, and slicing occurrs on the
+        obj is assumed to have MultiIndex, and slicing occurs on the
         last levels, 1 ... last.
 
         ix can be a simple index or MultiIndex,

--- a/skpro/metrics/base.py
+++ b/skpro/metrics/base.py
@@ -343,7 +343,7 @@ class BaseProbaMetric(BaseObject):
         return alpha
 
     def _handle_multioutput(self, loss, multioutput):
-        """Specificies how multivariate outputs should be handled.
+        """Specifies how multivariate outputs should be handled.
 
         Parameters
         ----------

--- a/skpro/metrics/base.py
+++ b/skpro/metrics/base.py
@@ -343,7 +343,7 @@ class BaseProbaMetric(BaseObject):
         return alpha
 
     def _handle_multioutput(self, loss, multioutput):
-        """Specifies how multivariate outputs should be handled.
+        """Handle output according to multioutput parameter.
 
         Parameters
         ----------

--- a/skpro/regression/cyclic_boosting.py
+++ b/skpro/regression/cyclic_boosting.py
@@ -70,7 +70,7 @@ class CyclicBoosting(BaseProbaRegressor):
     lower : float, default=None
         lower bound of predictive distribution support.
         If ``None`` (default), ``upper`` should also be ``None``, and the
-        predictive distibution will have unbounded support, i.e., the entire reals.
+        predictive distribution will have unbounded support, i.e., the entire reals.
         If a float, and ``upper`` is ``None``, prediction will be of
         semi-bounded support, with support between ``lower`` and infinity.
         If a float, and ``upper`` is also a float, prediction will be on a bounded
@@ -84,7 +84,7 @@ class CyclicBoosting(BaseProbaRegressor):
     maximal_iterations : int, default=10
         maximum number of iterations for the cyclic boosting algorithm
     dist_type: str, one of ``'normal'`` (default), ``'logistic'``
-        inner base distirbution to use for the Johnson QPD, i.e., before
+        inner base distribution to use for the Johnson QPD, i.e., before
         arcosh and similar transformations.
         Available options are ``'normal'`` (default), ``'logistic'``,
         or ``'sinhlogistic'``.

--- a/skpro/regression/density.py
+++ b/skpro/regression/density.py
@@ -53,7 +53,7 @@ def step_function(xs, ys):
 
 class DensityAdapter(BaseEstimator, metaclass=abc.ABCMeta):
     """
-    Abtract base class for density adapter
+    Abstract base class for density adapter
     that transform an input into an
     density cdf/pdf interface
     """

--- a/skpro/regression/tests/test_cyclic_boosting.py
+++ b/skpro/regression/tests/test_cyclic_boosting.py
@@ -33,8 +33,8 @@ def test_cyclic_boosting_simple_use():
     not run_test_for_class(CyclicBoosting),
     reason="run test only if softdeps are present and incrementally (if requested)",
 )
-def test_cyclic_boosting_with_manual_paramaters():
-    """Test use of cyclic boosting regressor with_manual_paramaters."""
+def test_cyclic_boosting_with_manual_parameters():
+    """Test use of cyclic boosting regressor with_manual_parameters."""
     from cyclic_boosting import flags
     from sklearn.datasets import load_diabetes
     from sklearn.model_selection import train_test_split

--- a/skpro/survival/ensemble/_survforest_sksurv.py
+++ b/skpro/survival/ensemble/_survforest_sksurv.py
@@ -81,7 +81,7 @@ class SurvivalForestSkSurv(_SksurvAdapter, BaseSurvReg):
 
     bootstrap : boolean, optional, default: True
         Whether bootstrap samples are used when building trees. If False, the
-        whole datset is used to build each tree.
+        whole dataset is used to build each tree.
 
     oob_score : bool, default: False
         Whether to use out-of-bag samples to estimate
@@ -293,7 +293,7 @@ class SurvivalForestXtraSkSurv(_SksurvAdapter, BaseSurvReg):
 
     bootstrap : boolean, optional, default: True
         Whether bootstrap samples are used when building trees. If False, the
-        whole datset is used to build each tree.
+        whole dataset is used to build each tree.
 
     oob_score : bool, default: False
         Whether to use out-of-bag samples to estimate

--- a/skpro/tests/scenarios/scenarios_getter.py
+++ b/skpro/tests/scenarios/scenarios_getter.py
@@ -27,7 +27,7 @@ def retrieve_scenarios(obj, filter_tags=None):
         If string(s), must be in registry.BASE_CLASS_REGISTER (first col)
             for instance 'classifier', 'regressor', 'transformer', 'forecaster'
     filter_tags: dict of (str or list of str), default=None
-        subsets the returned objectss as follows:
+        subsets the returned objects as follows:
             each key/value pair is statement in "and"/conjunction
                 key is tag name to sub-set on
                 value str or list of string are tag values
@@ -85,7 +85,7 @@ def _check_tag_cond(obj, filter_tags=None):
     ----------
     obj: object inheriting from sktime BaseObject
     filter_tags: dict of (str or list of str), default=None
-        subsets the returned objectss as follows:
+        subsets the returned objects as follows:
             each key/value pair is statement in "and"/conjunction
                 key is tag name to sub-set on
                 value str or list of string are tag values

--- a/skpro/utils/_maint/tests/test_show_versions.py
+++ b/skpro/utils/_maint/tests/test_show_versions.py
@@ -9,7 +9,7 @@ from skpro.utils.validation._dependencies import _check_soft_dependencies
 
 
 def test_show_versions_runs():
-    """Test that show_versions runs without exeptions."""
+    """Test that show_versions runs without exceptions."""
     # only prints, should return None
     assert show_versions() is None
 

--- a/skpro/utils/numpy.py
+++ b/skpro/utils/numpy.py
@@ -15,7 +15,7 @@ def flatten_to_1D_if_colvector(y):
     -------
     y_flat : numpy array
         1D flattened array if y was 2D column vector, or 1D already
-        otherwise, returne y unchanged
+        otherwise, return y unchanged
     """
     if len(y.shape) == 2 and y.shape[1] == 1:
         y_flat = y.flatten()


### PR DESCRIPTION
Found few misspellings all over the project.

@fkiraly https://github.com/crate-ci/typos

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
