### PR TITLE
[ENH] EnbPI regressor for conformal prediction intervals

### DIFF
--- a/docs/source/api_reference/regression.rst
+++ b/docs/source/api_reference/regression.rst
@@ -74,6 +74,14 @@ take one or multiple ``sklearn`` estimators and adda probabilistic prediction mo
 
     MultipleQuantileRegressor
 
+.. currentmodule:: skpro.regression.enbpi
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    EnbpiRegressor
+
 .. currentmodule:: skpro.regression.mapie
 
 .. autosummary::

--- a/examples/01_skpro_intro.ipynb
+++ b/examples/01_skpro_intro.ipynb
@@ -4424,6 +4424,7 @@
     "    * or other unconditional distribution estimate for residuals\n",
     "* \"squaring the residual\" two-step prediction - `ResidualDouble`\n",
     "* bootstrap prediction intervals - `BootstrapRegressor`\n",
+    "* conformal prediction intervals - `EnbpiRegressor`\n",
     "* MAPIE model agnostic prediction intervals - `MapieRegressor` (from `mapie` package)\n",
     "* natural gradient boosting aka NGBoost - `NGBoostRegressor` (from `ngboost` package)"
    ]

--- a/examples/01_skpro_intro.ipynb
+++ b/examples/01_skpro_intro.ipynb
@@ -4433,6 +4433,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "This section presents some examples with visualizations.\n",
+    "\n",
+    "Not all of the above estimators are presented, but they can be used in the same way."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### 3.1.1 constant variance prediction <a class=\"anchor\" id=\"section3_1_1\"></a>"
    ]
   },

--- a/skpro/regression/enbpi.py
+++ b/skpro/regression/enbpi.py
@@ -6,6 +6,7 @@ __all__ = ["EnbpiRegressor"]
 import numpy as np
 import pandas as pd
 from sklearn import clone
+from sklearn.utils import check_random_state
 
 from skpro.distributions.empirical import Empirical
 from skpro.regression.base import BaseProbaRegressor
@@ -109,6 +110,7 @@ class EnbpiRegressor(BaseProbaRegressor):
         self.agg_fun = agg_fun
         self.symmetrize = symmetrize
         self.random_state = random_state
+        self._random_state = check_random_state(random_state)
 
         super().__init__()
 
@@ -162,7 +164,9 @@ class EnbpiRegressor(BaseProbaRegressor):
         for i in range(n_bootstrap_samples):
             esti = clone(estimator)
             row_iloc = pd.RangeIndex(n)
-            row_ss = _random_ss_ix(row_iloc, size=n, replace=True)
+            row_ss = _random_ss_ix(
+                row_iloc, size=n, replace=True, random_state=self._random_state
+            )
             inst_ix_i = inst_ix[row_ss]
 
             Xi = X.loc[inst_ix_i]
@@ -300,10 +304,13 @@ class EnbpiRegressor(BaseProbaRegressor):
         return [params1, params2, params3]
 
 
-def _random_ss_ix(ix, size, replace=True):
+def _random_ss_ix(ix, size, replace=True, random_state=None):
     """Randomly uniformly sample indices from a list of indices."""
+    if random_state is None:
+        random_state = np.random.RandomState()
+
     a = range(len(ix))
-    ixs = ix[np.random.choice(a, size=size, replace=replace)]
+    ixs = ix[random_state.choice(a, size=size, replace=replace)]
     return ixs
 
 

--- a/skpro/regression/enbpi.py
+++ b/skpro/regression/enbpi.py
@@ -91,7 +91,10 @@ class EnbpiRegressor(BaseProbaRegressor):
     >>> y_pred = reg_proba.predict_proba(X_test)
     """
 
-    _tags = {"authors": "fkiraly", "capability:missing": True}
+    _tags = {
+        "authors": ["fkiraly", "hamrel-cxu"],
+        "capability:missing": True,
+    }
 
     def __init__(
         self,

--- a/skpro/tests/tests/test_test_utils.py
+++ b/skpro/tests/tests/test_test_utils.py
@@ -77,12 +77,12 @@ def test_run_test_for_class():
         assert reason_nodep == "False_no_change"
 
     # now check estimator with soft deps
-    run_nodep = run_test_for_class(f_with_deps)
+    run_wdep = run_test_for_class(f_with_deps)
     assert isinstance(run, bool)
 
     dep_present = _check_estimator_deps(f_with_deps, severity="none")
     if not dep_present:
-        assert not run_nodep
+        assert not run_wdep
 
     res = run_test_for_class(f_with_deps, return_reason=True)
     assert isinstance(res, tuple)


### PR DESCRIPTION
This implements an EnbPI tabular regressor wrapper, see https://github.com/sktime/sktime/issues/6446.

This is a de-novo implementation based on the paper [Conformal Prediction Interval for Dynamic Time-series](http://proceedings.mlr.press/v139/xu21h.html) (Xu et al. 2021a)

FYI @hamrel-cxu, a review would be appreciated. Let me know if you would like to take on maintenance and become owner of this algorithm.