### PR TITLE
[BUG] fix `spl` index when subsetting `Empirical` distribution via `iat`

### DIFF
--- a/skpro/distributions/empirical.py
+++ b/skpro/distributions/empirical.py
@@ -274,7 +274,7 @@ class Empirical(BaseDistribution):
         if rowidx is None or colidx is None:
             raise ValueError("iat method requires both row and column index")
         self_subset = self.iloc[[rowidx], [colidx]]
-        levels_to_drop = range(1, self_subset.spl.index.nlevels)
+        levels_to_drop = list(range(1, self_subset.spl.index.nlevels))
         spl_subset = self_subset.spl.droplevel(levels_to_drop)
         if self.weights is not None:
             wts_subset = self_subset.weights.droplevel(levels_to_drop)

--- a/skpro/distributions/empirical.py
+++ b/skpro/distributions/empirical.py
@@ -274,9 +274,10 @@ class Empirical(BaseDistribution):
         if rowidx is None or colidx is None:
             raise ValueError("iat method requires both row and column index")
         self_subset = self.iloc[[rowidx], [colidx]]
-        spl_subset = self_subset.spl.droplevel(-1)
+        levels_to_drop = range(1, self_subset.spl.index.nlevels)
+        spl_subset = self_subset.spl.droplevel(levels_to_drop)
         if self.weights is not None:
-            wts_subset = self_subset.weights.droplevel(-1)
+            wts_subset = self_subset.weights.droplevel(levels_to_drop)
         else:
             wts_subset = None
 

--- a/skpro/distributions/empirical.py
+++ b/skpro/distributions/empirical.py
@@ -274,9 +274,9 @@ class Empirical(BaseDistribution):
         if rowidx is None or colidx is None:
             raise ValueError("iat method requires both row and column index")
         self_subset = self.iloc[[rowidx], [colidx]]
-        spl_subset = self_subset.spl.droplevel(0)
+        spl_subset = self_subset.spl.droplevel(-1)
         if self.weights is not None:
-            wts_subset = self_subset.weights.droplevel(0)
+            wts_subset = self_subset.weights.droplevel(-1)
         else:
             wts_subset = None
 

--- a/skpro/distributions/empirical.py
+++ b/skpro/distributions/empirical.py
@@ -274,10 +274,9 @@ class Empirical(BaseDistribution):
         if rowidx is None or colidx is None:
             raise ValueError("iat method requires both row and column index")
         self_subset = self.iloc[[rowidx], [colidx]]
-        levels_to_drop = range(1, self_subset.spl.index.nlevels)
-        spl_subset = self_subset.spl.droplevel(levels_to_drop)
+        spl_subset = self_subset.spl.droplevel(-1)
         if self.weights is not None:
-            wts_subset = self_subset.weights.droplevel(levels_to_drop)
+            wts_subset = self_subset.weights.droplevel(-1)
         else:
             wts_subset = None
 

--- a/skpro/distributions/tests/test_empirical.py
+++ b/skpro/distributions/tests/test_empirical.py
@@ -7,9 +7,7 @@ from skpro.distributions.empirical import Empirical
 
 def test_empirical_iat_index():
     """Test that the index is correctly set after iat call."""
-    spl_idx = pd.MultiIndex.from_product(
-        [[0, 1], [0, 1, 2]], names=["sample", "time"]
-    )
+    spl_idx = pd.MultiIndex.from_product([[0, 1], [0, 1, 2]], names=["sample", "time"])
     spl = pd.DataFrame(
         [[0, 1], [2, 3], [10, 11], [6, 7], [8, 9], [4, 5]],
         index=spl_idx,

--- a/skpro/distributions/tests/test_empirical.py
+++ b/skpro/distributions/tests/test_empirical.py
@@ -1,0 +1,24 @@
+"""Tests for Empirical distributions."""
+
+import pandas as pd
+
+from skpro.distributions.empirical import Empirical
+
+
+def test_empirical_iat_index():
+    """Test that the index is correctly set after iat call."""
+    spl_idx = pd.MultiIndex.from_product(
+        [[0, 1], [0, 1, 2]], names=["sample", "time"]
+    )
+    spl = pd.DataFrame(
+        [[0, 1], [2, 3], [10, 11], [6, 7], [8, 9], [4, 5]],
+        index=spl_idx,
+        columns=["a", "b"],
+    )
+    emp = Empirical(spl, columns=["a", "b"])
+
+    emp_iat = emp.iat[0, 0]
+    assert emp_iat.shape == ()
+
+    assert not isinstance(emp_iat.spl.index, pd.MultiIndex)
+    assert (emp_iat.spl.index == [0, 1]).all()


### PR DESCRIPTION
Fixes the index of `spl` in the resulting distribution when subsetting `Empirical` distributions via `iat`.

At current `main`, the wrong index level was dropped. The resulting index should be the index with the lowest index, not the index with the highest index.