### PR TITLE
[DOC] fix typo in survival models API reference

### DIFF
--- a/docs/source/api_reference/survival.rst
+++ b/docs/source/api_reference/survival.rst
@@ -112,7 +112,7 @@ Generalized additive survival models
     :toctree: auto_generated/
     :template: class.rst
 
-    AalenAdditiveLifelines
+    AalenAdditive
 
 Tree models
 -----------


### PR DESCRIPTION
Fixes a typo that caused an empty GAM survival model section in the API reference.