### PR TITLE
[ENH] Half Logistic Distribution

### DIFF
--- a/docs/source/api_reference/distributions.rst
+++ b/docs/source/api_reference/distributions.rst
@@ -42,6 +42,7 @@ Continuous support
     Fisk
     Gamma
     HalfCauchy
+    HalfLogistic
     HalfNormal
     Laplace
     Logistic

--- a/skpro/distributions/__init__.py
+++ b/skpro/distributions/__init__.py
@@ -13,6 +13,7 @@ __all__ = [
     "Fisk",
     "Gamma",
     "HalfCauchy",
+    "HalfLogistic",
     "HalfNormal",
     "IID",
     "Laplace",
@@ -41,6 +42,7 @@ from skpro.distributions.exponential import Exponential
 from skpro.distributions.fisk import Fisk
 from skpro.distributions.gamma import Gamma
 from skpro.distributions.halfcauchy import HalfCauchy
+from skpro.distributions.halflogistic import HalfLogistic
 from skpro.distributions.halfnormal import HalfNormal
 from skpro.distributions.laplace import Laplace
 from skpro.distributions.logistic import Logistic

--- a/skpro/distributions/halflogistic.py
+++ b/skpro/distributions/halflogistic.py
@@ -1,0 +1,80 @@
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+"""Half-Logistic probability distribution."""
+
+__author__ = ["SaiRevanth25"]
+
+import pandas as pd
+from scipy.stats import halflogistic, rv_continuous
+
+from skpro.distributions.adapters.scipy import _ScipyAdapter
+
+
+class HalfLogistic(_ScipyAdapter):
+    r"""Half-Logistic distribution.
+
+    This distribution is univariate, without correlation between dimensions
+    for the array-valued case.
+
+    The half-logistic distribution is a continuous probability distribution derived
+    from the logistic distribution by taking only the positive half.It is particularly
+    useful in reliability analysis, lifetime modeling, and other applications where
+    non-negative values are required.
+
+    The half-logistic distribution is parametrized by the scale parameter
+    :math:`\beta`, such that the pdf is
+
+    .. math::
+
+        f(x) = \frac{2 \exp\left(-\frac{x}{\beta}\right)}
+                {\beta \left(1 + \exp\left(-\frac{x}{\beta}\right)\right)^2},
+                x>0 otherwise 0
+
+    The scale parameter :math:`\beta` is represented by the parameter ``beta``.
+
+    Parameters
+    ----------
+    beta : float or array of float (1D or 2D), must be positive
+        scale parameter of the half-logistic distribution
+    index : pd.Index, optional, default = RangeIndex
+    columns : pd.Index, optional, default = RangeIndex
+
+    Example
+    -------
+    >>> from skpro.distributions.halflogistic import HalfLogistic
+
+    >>> hl = HalfLogistic(beta=1)
+    """
+
+    _tags = {
+        "capabilities:approx": ["pdfnorm"],
+        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
+        "distr:measuretype": "continuous",
+        "distr:paramtype": "parametric",
+        "broadcast_init": "on",
+    }
+
+    def __init__(self, beta, index=None, columns=None):
+        self.beta = beta
+
+        super().__init__(index=index, columns=columns)
+
+    def _get_scipy_object(self) -> rv_continuous:
+        return halflogistic
+
+    def _get_scipy_param(self):
+        beta = self._bc_params["beta"]
+        return [beta], {}
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator."""
+        # array case examples
+        params1 = {"beta": [[1, 2], [3, 4]]}
+        params2 = {
+            "beta": 1,
+            "index": pd.Index([1, 2, 5]),
+            "columns": pd.Index(["a", "b"]),
+        }
+        # scalar case examples
+        params3 = {"beta": 2}
+        return [params1, params2, params3]

--- a/skpro/distributions/halflogistic.py
+++ b/skpro/distributions/halflogistic.py
@@ -16,7 +16,7 @@ class HalfLogistic(_ScipyAdapter):
     for the array-valued case.
 
     The half-logistic distribution is a continuous probability distribution derived
-    from the logistic distribution by taking only the positive half.It is particularly
+    from the logistic distribution by taking only the positive half. It is particularly
     useful in reliability analysis, lifetime modeling, and other applications where
     non-negative values are required.
 


### PR DESCRIPTION


#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
--> #22 


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
--> Implements Half Logistic distribution

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new core dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core skpro package to a minimum.
--> No

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [x] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [x] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
