### PR TITLE
[ENH] Log Laplace Distribution

### DIFF
--- a/docs/source/api_reference/distributions.rst
+++ b/docs/source/api_reference/distributions.rst
@@ -45,6 +45,7 @@ Continuous support
     HalfNormal
     Laplace
     Logistic
+    LogLaplace
     Normal
     TDistribution
     Weibull

--- a/skpro/distributions/__init__.py
+++ b/skpro/distributions/__init__.py
@@ -17,6 +17,7 @@ __all__ = [
     "IID",
     "Laplace",
     "Logistic",
+    "LogLaplace",
     "LogNormal",
     "Mixture",
     "Normal",
@@ -44,6 +45,7 @@ from skpro.distributions.halfcauchy import HalfCauchy
 from skpro.distributions.halfnormal import HalfNormal
 from skpro.distributions.laplace import Laplace
 from skpro.distributions.logistic import Logistic
+from skpro.distributions.loglaplace import LogLaplace
 from skpro.distributions.lognormal import LogNormal
 from skpro.distributions.mixture import Mixture
 from skpro.distributions.normal import Normal

--- a/skpro/distributions/loglaplace.py
+++ b/skpro/distributions/loglaplace.py
@@ -22,9 +22,11 @@ class LogLaplace(_ScipyAdapter):
     The log-Laplace distribution is parametrized by the scale parameter
     :math:`\c`, such that the pdf is
 
-    .. math:: f(x) = \frac{c}{2} x^{c-1}, 0<x<1
+    .. math:: f(x) = \frac{c}{2} x^{c-1}, \quad 0<x<1
+
     and
-    .. math:: f(x) = \frac{c}{2} x^{-c-1}, x >= 1
+
+    .. math:: f(x) = \frac{c}{2} x^{-c-1}, \quad x >= 1
 
     The scale parameter :math:`c` is represented by the parameter ``c``.
 

--- a/skpro/distributions/loglaplace.py
+++ b/skpro/distributions/loglaplace.py
@@ -1,0 +1,77 @@
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+"""Log-Laplace probability distribution."""
+
+__author__ = ["SaiRevanth25"]
+
+import pandas as pd
+from scipy.stats import loglaplace, rv_continuous
+
+from skpro.distributions.adapters.scipy import _ScipyAdapter
+
+
+class LogLaplace(_ScipyAdapter):
+    r"""Log-Laplace distribution.
+
+    This distribution is univariate, without correlation between dimensions
+    for the array-valued case.
+
+    The log-Laplace distribution is a continuous probability distribution obtained by
+    taking the logarithm of the Laplace distribution, commonly used in finance and
+    hydrology due to its heavy tails and asymmetry.
+
+    The log-Laplace distribution is parametrized by the scale parameter
+    :math:`\c`, such that the pdf is
+
+    .. math:: f(x) = \frac{c}{2} x^{c-1}, 0<x<1
+    and
+    .. math:: f(x) = \frac{c}{2} x^{-c-1}, x >= 1
+
+    The scale parameter :math:`c` is represented by the parameter ``c``.
+
+    Parameters
+    ----------
+    scale : float or array of float (1D or 2D), must be positive
+        scale parameter of the log-Laplace distribution
+    index : pd.Index, optional, default = RangeIndex
+    columns : pd.Index, optional, default = RangeIndex
+
+    Example
+    -------
+    >>> from skpro.distributions.loglaplace import LogLaplace
+
+    >>> ll = LogLaplace(scale=1)
+    """
+
+    _tags = {
+        "capabilities:approx": ["pdfnorm"],
+        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
+        "distr:measuretype": "continuous",
+        "distr:paramtype": "parametric",
+        "broadcast_init": "on",
+    }
+
+    def __init__(self, scale, index=None, columns=None):
+        self.scale = scale
+
+        super().__init__(index=index, columns=columns)
+
+    def _get_scipy_object(self) -> rv_continuous:
+        return loglaplace
+
+    def _get_scipy_param(self):
+        scale = self._bc_params["scale"]
+        return [scale], {}
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator."""
+        # array case examples
+        params1 = {"scale": [[1, 2], [3, 4]]}
+        params2 = {
+            "scale": 1,
+            "index": pd.Index([1, 2, 5]),
+            "columns": pd.Index(["a", "b"]),
+        }
+        # scalar case examples
+        params3 = {"scale": 2}
+        return [params1, params2, params3]

--- a/skpro/distributions/loglaplace.py
+++ b/skpro/distributions/loglaplace.py
@@ -19,18 +19,18 @@ class LogLaplace(_ScipyAdapter):
     taking the logarithm of the Laplace distribution, commonly used in finance and
     hydrology due to its heavy tails and asymmetry.
 
-    The log-Laplace distribution is parametrized by the scale parameter
-    :math:`\c`, such that the pdf is
+    The log-Laplace distribution is parametrized by the shape parameter
+    :math:`\shape`, such that the pdf is
 
     .. math:: f(x) = \frac{c}{2} x^{c-1}, 0<x<1
     and
     .. math:: f(x) = \frac{c}{2} x^{-c-1}, x >= 1
 
-    The scale parameter :math:`c` is represented by the parameter ``c``.
+    The shape parameter :math:`shape` is represented by the parameter ``c``
 
     Parameters
     ----------
-    scale : float or array of float (1D or 2D), must be positive
+    shape : float or array of float (1D or 2D), must be positive
         scale parameter of the log-Laplace distribution
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
@@ -39,7 +39,7 @@ class LogLaplace(_ScipyAdapter):
     -------
     >>> from skpro.distributions.loglaplace import LogLaplace
 
-    >>> ll = LogLaplace(scale=1)
+    >>> ll = LogLaplace(shape=1)
     """
 
     _tags = {
@@ -50,8 +50,8 @@ class LogLaplace(_ScipyAdapter):
         "broadcast_init": "on",
     }
 
-    def __init__(self, scale, index=None, columns=None):
-        self.scale = scale
+    def __init__(self, shape, index=None, columns=None):
+        self.shape = shape
 
         super().__init__(index=index, columns=columns)
 
@@ -59,19 +59,19 @@ class LogLaplace(_ScipyAdapter):
         return loglaplace
 
     def _get_scipy_param(self):
-        scale = self._bc_params["scale"]
-        return [scale], {}
+        shape = self._bc_params["shape"]
+        return [shape], {}
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Return testing parameter settings for the estimator."""
         # array case examples
-        params1 = {"scale": [[1, 2], [3, 4]]}
+        params1 = {"shape": [[1, 2], [3, 4]]}
         params2 = {
-            "scale": 1,
+            "shape": 1,
             "index": pd.Index([1, 2, 5]),
             "columns": pd.Index(["a", "b"]),
         }
         # scalar case examples
-        params3 = {"scale": 2}
+        params3 = {"shape": 2}
         return [params1, params2, params3]

--- a/skpro/distributions/loglaplace.py
+++ b/skpro/distributions/loglaplace.py
@@ -19,18 +19,18 @@ class LogLaplace(_ScipyAdapter):
     taking the logarithm of the Laplace distribution, commonly used in finance and
     hydrology due to its heavy tails and asymmetry.
 
-    The log-Laplace distribution is parametrized by the shape parameter
-    :math:`\shape`, such that the pdf is
+    The log-Laplace distribution is parametrized by the scale parameter
+    :math:`\c`, such that the pdf is
 
     .. math:: f(x) = \frac{c}{2} x^{c-1}, 0<x<1
     and
     .. math:: f(x) = \frac{c}{2} x^{-c-1}, x >= 1
 
-    The shape parameter :math:`shape` is represented by the parameter ``c``
+    The scale parameter :math:`c` is represented by the parameter ``c``.
 
     Parameters
     ----------
-    shape : float or array of float (1D or 2D), must be positive
+    scale : float or array of float (1D or 2D), must be positive
         scale parameter of the log-Laplace distribution
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
@@ -39,7 +39,7 @@ class LogLaplace(_ScipyAdapter):
     -------
     >>> from skpro.distributions.loglaplace import LogLaplace
 
-    >>> ll = LogLaplace(shape=1)
+    >>> ll = LogLaplace(scale=1)
     """
 
     _tags = {
@@ -50,8 +50,8 @@ class LogLaplace(_ScipyAdapter):
         "broadcast_init": "on",
     }
 
-    def __init__(self, shape, index=None, columns=None):
-        self.shape = shape
+    def __init__(self, scale, index=None, columns=None):
+        self.scale = scale
 
         super().__init__(index=index, columns=columns)
 
@@ -59,19 +59,19 @@ class LogLaplace(_ScipyAdapter):
         return loglaplace
 
     def _get_scipy_param(self):
-        shape = self._bc_params["shape"]
-        return [shape], {}
+        scale = self._bc_params["scale"]
+        return [scale], {}
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Return testing parameter settings for the estimator."""
         # array case examples
-        params1 = {"shape": [[1, 2], [3, 4]]}
+        params1 = {"scale": [[1, 2], [3, 4]]}
         params2 = {
-            "shape": 1,
+            "scale": 1,
             "index": pd.Index([1, 2, 5]),
             "columns": pd.Index(["a", "b"]),
         }
         # scalar case examples
-        params3 = {"shape": 2}
+        params3 = {"scale": 2}
         return [params1, params2, params3]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skpro.readthedocs.io/en/latest/contribute.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
--> #22 


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
--> Implements Log Laplace Distribution

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [x] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [x] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
