### PR TITLE
[DOC] add `scipy` reference to interfaced distributions

### DIFF
--- a/skpro/distributions/alpha.py
+++ b/skpro/distributions/alpha.py
@@ -12,6 +12,8 @@ from skpro.distributions.adapters.scipy import _ScipyAdapter
 class Alpha(_ScipyAdapter):
     r"""Alpha distribution.
 
+    Most methods wrap ``scipy.stats.alpha``.
+
     The alpha distribution is characterized by its shape parameter :math:`\a`,
     which determines its skewness and tail behavior.
     It is often used for modeling data with heavy right tails,
@@ -27,7 +29,6 @@ class Alpha(_ScipyAdapter):
        - :math:`a` is the shape parameter.
        - :math:`Phi` is the cumulative distribution function (CDF) of the
                     standard normal distribution.
-
 
     Parameters
     ----------

--- a/skpro/distributions/beta.py
+++ b/skpro/distributions/beta.py
@@ -12,6 +12,8 @@ from skpro.distributions.adapters.scipy import _ScipyAdapter
 class Beta(_ScipyAdapter):
     r"""Beta distribution.
 
+    Most methods wrap ``scipy.stats.beta``.
+
     The Beta distribution is parametrized by two shape parameters :math:`\alpha`
     and :math:`\beta`, such that the probability density function (PDF) is given by:
 

--- a/skpro/distributions/exponential.py
+++ b/skpro/distributions/exponential.py
@@ -12,6 +12,8 @@ from skpro.distributions.adapters.scipy import _ScipyAdapter
 class Exponential(_ScipyAdapter):
     r"""Exponential Distribution.
 
+    Most methods wrap ``scipy.stats.expon``.
+
     The Exponential distribution is parametrized by mean :math:`\mu` and
     scale :math:`b`, such that the pdf is
 

--- a/skpro/distributions/fisk.py
+++ b/skpro/distributions/fisk.py
@@ -12,6 +12,8 @@ from skpro.distributions.adapters.scipy import _ScipyAdapter
 class Fisk(_ScipyAdapter):
     r"""Fisk distribution, aka log-logistic distribution.
 
+    Most methods wrap ``scipy.stats.fisk``.
+
     The Fisk distribution is parametrized by a scale parameter :math:`\alpha`
     and a shape parameter :math:`\beta`, such that the cumulative distribution
     function (CDF) is given by:

--- a/skpro/distributions/gamma.py
+++ b/skpro/distributions/gamma.py
@@ -12,6 +12,8 @@ from skpro.distributions.adapters.scipy import _ScipyAdapter
 class Gamma(_ScipyAdapter):
     r"""Gamma Distribution.
 
+    Most methods wrap ``scipy.stats.gamma``.
+
     The Gamma Distribution is parameterized by shape :math:`\alpha` and
     rate :math:`\beta`, such that the pdf is
 

--- a/skpro/distributions/halfcauchy.py
+++ b/skpro/distributions/halfcauchy.py
@@ -12,6 +12,8 @@ from skpro.distributions.adapters.scipy import _ScipyAdapter
 class HalfCauchy(_ScipyAdapter):
     r"""Half-Cauchy distribution.
 
+    Most methods wrap ``scipy.stats.halfcauchy``.
+
     This distribution is univariate, without correlation between dimensions
     for the array-valued case.
 

--- a/skpro/distributions/halflogistic.py
+++ b/skpro/distributions/halflogistic.py
@@ -12,6 +12,8 @@ from skpro.distributions.adapters.scipy import _ScipyAdapter
 class HalfLogistic(_ScipyAdapter):
     r"""Half-Logistic distribution.
 
+    Most methods wrap ``scipy.stats.halflogistic``.
+
     This distribution is univariate, without correlation between dimensions
     for the array-valued case.
 

--- a/skpro/distributions/halfnormal.py
+++ b/skpro/distributions/halfnormal.py
@@ -12,6 +12,8 @@ from skpro.distributions.adapters.scipy import _ScipyAdapter
 class HalfNormal(_ScipyAdapter):
     r"""Half-Normal distribution.
 
+    Most methods wrap ``scipy.stats.halfnorm``.
+
     This distribution is univariate, without correlation between dimensions
     for the array-valued case.
 

--- a/skpro/distributions/loglaplace.py
+++ b/skpro/distributions/loglaplace.py
@@ -12,6 +12,8 @@ from skpro.distributions.adapters.scipy import _ScipyAdapter
 class LogLaplace(_ScipyAdapter):
     r"""Log-Laplace distribution.
 
+    Most methods wrap ``scipy.stats.loglaplace``.
+
     This distribution is univariate, without correlation between dimensions
     for the array-valued case.
 

--- a/skpro/distributions/poisson.py
+++ b/skpro/distributions/poisson.py
@@ -12,6 +12,8 @@ from skpro.distributions.adapters.scipy import _ScipyAdapter
 class Poisson(_ScipyAdapter):
     """Poisson distribution.
 
+    Most methods wrap ``scipy.stats.poisson``.
+
     Parameters
     ----------
     mu : float or array of float (1D or 2D)


### PR DESCRIPTION
This PR adds a `scipy` reference in docstrings of interfaced distributions from `scipy`.