### PR TITLE
[BUG] fix `test_methods_p` logic when `shuffle` is `True`

### DIFF
--- a/skpro/distributions/tests/test_all_distrs.py
+++ b/skpro/distributions/tests/test_all_distrs.py
@@ -167,7 +167,7 @@ class TestAllDistributions(PackageConfig, DistributionFixtureGenerator, QuickTes
         else:
             p = np_unif
 
-        res = getattr(object_instance, method)(p)
+        res = getattr(d, method)(p)
 
         _check_output_format(res, d, method)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skpro.readthedocs.io/en/latest/contribute.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
fixes #380 


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
`object_instance` is the distribution before shuffling.
`d` is the one after shuffling so it needs to be used instead 
`res=getattr(object_instance,method)(p)` to be replaced with `res = getattr(d, method)(p)` as this will account for the object_instance after shifting the distribution. This will ensure the outputs are checked with the shifted distribution's instance.
