### PR TITLE
[ENH] `GLM` with multiple `distributions` and `link` function support

### DIFF
--- a/skpro/distributions/tests/test_all_distrs.py
+++ b/skpro/distributions/tests/test_all_distrs.py
@@ -167,7 +167,7 @@ class TestAllDistributions(PackageConfig, DistributionFixtureGenerator, QuickTes
         else:
             p = np_unif
 
-        res = getattr(object_instance, method)(p)
+        res = getattr(d, method)(p)
 
         _check_output_format(res, d, method)
 

--- a/skpro/regression/linear/_glm.py
+++ b/skpro/regression/linear/_glm.py
@@ -301,19 +301,19 @@ class GLMRegressor(BaseProbaRegressor):
 
     def __init__(
         self,
-        missing="4",
-        start_params="5",
-        maxiter="6",
-        method="7",
-        tol="8",
-        scale="9",
-        cov_type="10",
-        cov_kwds="11",
-        use_t="12",
-        full_output="13",
-        disp="14",
-        max_start_irls="15",
-        add_constant="16",
+        missing="none",
+        start_params=None,
+        maxiter=100,
+        method="IRLS",
+        tol=1e-8,
+        scale=None,
+        cov_type="nonrobust",
+        cov_kwds=None,
+        use_t=None,
+        full_output=True,
+        disp=False,
+        max_start_irls=3,
+        add_constant=False,
         family="0",
         link="1",
         offset_var="2",
@@ -359,58 +359,19 @@ class GLMRegressor(BaseProbaRegressor):
             self._exposure_var = None
         else:
             self._exposure_var = exposure_var
-        if missing == "4":
-            self._missing = "none"
-        else:
-            self._missing = missing
-        if start_params == "5":
-            self._start_params = None
-        else:
-            self._start_params = start_params
-        if maxiter == "6":
-            self._maxiter = 100
-        else:
-            self._maxiter = maxiter
-        if method == "7":
-            self._method = "IRLS"
-        else:
-            self._method = method
-        if tol == "8":
-            self._tol = 1e-8
-        else:
-            self._tol = self.tol
-        if scale == "9":
-            self._scale = None
-        else:
-            self._scale = scale
-        if cov_type == "10":
-            self._cov_type = "nonrobust"
-        else:
-            self._cov_type = cov_type
-        if cov_kwds == "11":
-            self._cov_kwds = None
-        else:
-            self._cov_kwds = cov_kwds
-        if use_t == "12":
-            self._use_t = None
-        else:
-            self._use_t = use_t
-        if full_output == "13":
-            self._full_output = True
-        else:
-            self._full_output = full_output
-        if disp == "14":
-            self._disp = False
-        else:
-            self._disp = disp
-        if max_start_irls == "15":
-            self._max_start_irls = 3
-        else:
-            self._max_start_irls = max_start_irls
-        if add_constant == "16":
-            self._add_constant = False
-        else:
-            self._add_constant = add_constant
+        self._missing = self.missing
+        self._start_params = self.start_params
+        self._maxiter = self.maxiter
+        self._method = self.method
+        self._tol = self.tol
+        self._scale = self.scale
+        self._cov_type = self.cov_type
+        self._cov_kwds = self.cov_kwds
+        self._use_t = self.use_t
+        self._full_output = self.full_output
+        self._disp = self.disp
+        self._max_start_irls = self.max_start_irls
+        self._add_constant = self.add_constant
 
         from warnings import warn
 

--- a/skpro/regression/linear/_glm.py
+++ b/skpro/regression/linear/_glm.py
@@ -167,8 +167,20 @@ class GLMRegressor(BaseProbaRegressor):
         "y_inner_mtype": "pd_DataFrame_Table",
     }
 
+    def _str_to_sm_family(self, family):
+        from statsmodels.genmod.families.family import Gamma, Gaussian, Poisson
+
+        sm_fmly = {
+            "Gaussian": Gaussian,
+            "Poisson": Poisson,
+            "Gamma": Gamma,
+        }
+
+        return sm_fmly[family]
+
     def __init__(
         self,
+        family=None,
         missing="none",
         start_params=None,
         maxiter=100,
@@ -184,9 +196,10 @@ class GLMRegressor(BaseProbaRegressor):
         add_constant=False,
     ):
         super().__init__()
-        from statsmodels.genmod.families.family import Gaussian
 
-        self._family = Gaussian()
+        if family is None:
+            family = "Gaussian"
+        self.family = family
         self.missing = missing
         self.start_params = start_params
         self.maxiter = maxiter
@@ -231,10 +244,13 @@ class GLMRegressor(BaseProbaRegressor):
 
         y_col = y.columns
 
+        family = self.family
+        sm_family = self._str_to_sm_family(family)
+
         glm_estimator = GLM(
             endog=y,
             exog=X_,
-            family=self._family,
+            family=sm_family,
             missing=self.missing,
         )
 

--- a/skpro/regression/linear/_glm.py
+++ b/skpro/regression/linear/_glm.py
@@ -368,8 +368,11 @@ class GLMRegressor(BaseProbaRegressor):
             y_mu = y_predictions_df["mean"].rename("mu").to_frame()
             params["mu"] = y_mu
         elif skp_dist == Gamma:
-            y_alpha = y_predictions_df["mean"].rename("alpha").to_frame()
-            y_beta = y_predictions_df["mean_se"].rename("beta").to_frame()
+            y_mean = y_predictions_df["mean"]
+            y_sd = y_predictions_df["mean_se"]
+            y_alpha = (y_mean / y_sd) ** 2
+            y_beta = (y_alpha / y_mean).rename("beta").to_frame()
+            y_alpha = y_alpha.rename("alpha").to_frame()
             params["alpha"] = y_alpha
             params["beta"] = y_beta
 
@@ -457,5 +460,10 @@ class GLMRegressor(BaseProbaRegressor):
         """
         params1 = {}
         params2 = {"add_constant": True}
+        params3 = {
+            "family": "Poisson",
+            "add_constant": True,
+        }
+        params4 = {"family": "Gamma"}
 
-        return [params1, params2]
+        return [params1, params2, params3, params4]

--- a/skpro/regression/linear/_glm.py
+++ b/skpro/regression/linear/_glm.py
@@ -21,7 +21,7 @@ class GLMRegressor(BaseProbaRegressor):
 
     Parameters
     ----------
-    family : str
+    family : str, default : "Normal"
         Available options are
         1.Normal
         2.Poisson
@@ -31,10 +31,6 @@ class GLMRegressor(BaseProbaRegressor):
         Normal : Log, Identity, InversePower
         Poisson : Log, Identity, Sqrt
         Gamma : Log, Identity, InversePower
-    missing : str
-        Available options are 'none', 'drop' and 'raise'. If 'none', no nan
-        checking is done. If 'drop', any observations with nans are dropped.
-        If 'raise', an error is raised. Default = 'none'
     offset_var : pd.Index([str]) or int, default = None
         If ``pd.Index([str])``, then the exog or ``X`` passed while ``fit``-ting
         must have an additional column with column name passed through
@@ -49,6 +45,10 @@ class GLMRegressor(BaseProbaRegressor):
         have additional column with name same as string passed through ``exposure_var``
         in X with all the ``exposure_var`` values stored in the column for each row.
         If ``int`` it corresponding column number will be considered.
+    missing : str
+        Available options are 'none', 'drop' and 'raise'. If 'none', no nan
+        checking is done. If 'drop', any observations with nans are dropped.
+        If 'raise', an error is raised. Default = 'none'
     start_params : array_like (optional)
         Initial guess of the solution for the loglikelihood maximization.
         The default is family-specific and is given by the
@@ -227,30 +227,93 @@ class GLMRegressor(BaseProbaRegressor):
 
         return sm_fmly[family]()
 
+    # TODO (release 2.4.0)
+    # replace the existing definition of `__init__` with
+    # the below definition for `__init__`.
+    # def __init__(
+    #     self,
+    #     family="Normal",
+    #     link=None,
+    #     offset_var=None,
+    #     exposure_var=None,
+    #     missing="none",
+    #     start_params=None,
+    #     maxiter=100,
+    #     method="IRLS",
+    #     tol=1e-8,
+    #     scale=None,
+    #     cov_type="nonrobust",
+    #     cov_kwds=None,
+    #     use_t=None,
+    #     full_output=True,
+    #     disp=False,
+    #     max_start_irls=3,
+    #     add_constant=False,
+    # ):
+    #     super().__init__()
+
+    #     self.family = family
+    #     self.link = link
+    #     self.offset_var = offset_var
+    #     self.exposure_var = exposure_var
+    #     self.missing = missing
+    #     self.start_params = start_params
+    #     self.maxiter = maxiter
+    #     self.method = method
+    #     self.tol = tol
+    #     self.scale = scale
+    #     self.cov_type = cov_type
+    #     self.cov_kwds = cov_kwds
+    #     self.use_t = use_t
+    #     self.full_output = full_output
+    #     self.disp = disp
+    #     self.max_start_irls = max_start_irls
+    #     self.add_constant = add_constant
+
+    #     self._family = self.family
+    #     self._link = self.link
+    #     self._offset_var = self.offset_var
+    #     self._exposure_var = self.exposure_var
+    #     self._missing = self.missing
+    #     self._start_params = self.start_params
+    #     self._maxiter = self.maxiter
+    #     self._method = self.method
+    #     self._tol = self.tol
+    #     self._scale = self.scale
+    #     self._cov_type = self.cov_type
+    #     self._cov_kwds = self.cov_kwds
+    #     self._use_t = self.use_t
+    #     self._full_output = self.full_output
+    #     self._disp = self.disp
+    #     self._max_start_irls = self.max_start_irls
+    #     self._add_constant = self.add_constant
+
     def __init__(
         self,
-        missing="none",
-        start_params=None,
-        maxiter=100,
-        method="IRLS",
-        tol=1e-8,
-        scale=None,
-        cov_type="nonrobust",
-        cov_kwds=None,
-        use_t=None,
-        full_output=True,
-        disp=False,
-        max_start_irls=3,
-        add_constant=False,
-        family="Normal",
-        link=None,
-        offset_var=None,
-        exposure_var=None,
+        missing="4",
+        start_params="5",
+        maxiter="6",
+        method="7",
+        tol="8",
+        scale="9",
+        cov_type="10",
+        cov_kwds="11",
+        use_t="12",
+        full_output="13",
+        disp="14",
+        max_start_irls="15",
+        add_constant="16",
+        family="0",
+        link="1",
+        offset_var="2",
+        exposure_var="3",
     ):
+        # The default values of the parameters
+        # are replaced with the changed sequence
+        # of parameters ranking for each of them
+        # from 0 to 16(total 17 parameters).
         super().__init__()
 
-        if family is None:
-            family = "Normal"
         self.family = family
         self.link = link
         self.offset_var = offset_var
@@ -268,6 +331,88 @@ class GLMRegressor(BaseProbaRegressor):
         self.disp = disp
         self.max_start_irls = max_start_irls
         self.add_constant = add_constant
+
+        if family == "0":
+            self._family = "Normal"
+        else:
+            self._family = family
+        if link == "1":
+            self._link = None
+        else:
+            self._link = link
+        if offset_var == "2":
+            self._offset_var = None
+        else:
+            self._offset_var = offset_var
+        if exposure_var == "3":
+            self._exposure_var = None
+        else:
+            self._exposure_var = exposure_var
+        if missing == "4":
+            self._missing = "none"
+        else:
+            self._missing = missing
+        if start_params == "5":
+            self._start_params = None
+        else:
+            self._start_params = start_params
+        if maxiter == "6":
+            self._maxiter = 100
+        else:
+            self._maxiter = maxiter
+        if method == "7":
+            self._method = "IRLS"
+        else:
+            self._method = method
+        if tol == "8":
+            self._tol = 1e-8
+        else:
+            self._tol = self.tol
+        if scale == "9":
+            self._scale = None
+        else:
+            self._scale = scale
+        if cov_type == "10":
+            self._cov_type = "nonrobust"
+        else:
+            self._cov_type = cov_type
+        if cov_kwds == "11":
+            self._cov_kwds = None
+        else:
+            self._cov_kwds = cov_kwds
+        if use_t == "12":
+            self._use_t = None
+        else:
+            self._use_t = use_t
+        if full_output == "13":
+            self._full_output = True
+        else:
+            self._full_output = full_output
+        if disp == "14":
+            self._disp = False
+        else:
+            self._disp = disp
+        if max_start_irls == "15":
+            self._max_start_irls = 3
+        else:
+            self._max_start_irls = max_start_irls
+        if add_constant == "16":
+            self._add_constant = False
+        else:
+            self._add_constant = add_constant
+
+        from sktime.utils.warnings import warn
+
+        l1 = "Note: in `GLMRegressor`, the sequence of the parameters will change "
+        l2 = "in skpro version 2.4.0. It will be as per the order present in the"
+        l3 = "current docstring with the top one being the first parameter.\n"
+        l4 = "The defaults for the parameters will remain same and "
+        l5 = "there will be no changes.\n"
+        l6 = "Please use the `kwargs` calls instead of positional calls for the"
+        l7 = "parameters until the release of skpro 2.4.0 "
+        l8 = "as this will avoid any discrepancies."
+        warn_msg = l1 + l2 + l3 + l4 + l5 + l6 + l7 + l8
+        warn(warn_msg)
 
     def _fit(self, X, y):
         """Fit regressor to training data.
@@ -297,8 +442,8 @@ class GLMRegressor(BaseProbaRegressor):
 
         # remove the offset and exposure columns which
         # was inserted to maintain the shape
-        offset_var = self.offset_var
-        exposure_var = self.exposure_var
+        offset_var = self._offset_var
+        exposure_var = self._exposure_var
 
         if offset_var is not None:
             if isinstance(offset_var, int):
@@ -317,31 +462,31 @@ class GLMRegressor(BaseProbaRegressor):
 
         y_col = y.columns
 
-        family = self.family
-        link = self.link
+        family = self._family
+        link = self._link
         sm_family = self._str_to_sm_family(family=family, link=link)
 
         glm_estimator = GLM(
             endog=y,
             exog=X_,
             family=sm_family,
-            missing=self.missing,
+            missing=self._missing,
         )
 
         self._estimator = glm_estimator
 
         fitted_glm_model = glm_estimator.fit(
-            self.start_params,
-            self.maxiter,
-            self.method,
-            self.tol,
-            self.scale,
-            self.cov_type,
-            self.cov_kwds,
-            self.use_t,
-            self.full_output,
-            self.disp,
-            self.max_start_irls,
+            self._start_params,
+            self._maxiter,
+            self._method,
+            self._tol,
+            self._scale,
+            self._cov_type,
+            self._cov_kwds,
+            self._use_t,
+            self._full_output,
+            self._disp,
+            self._max_start_irls,
         )
 
         PARAMS_TO_FORWARD = {
@@ -394,8 +539,8 @@ class GLMRegressor(BaseProbaRegressor):
         -------
         y : pandas DataFrame, same length as `X`, with same columns as y in fit
         """
-        offset_var = self.offset_var
-        exposure_var = self.exposure_var
+        offset_var = self._offset_var
+        exposure_var = self._exposure_var
         offset_arr = None
         exposure_arr = None
 
@@ -491,8 +636,8 @@ class GLMRegressor(BaseProbaRegressor):
         """
         # remove the offset and exposure columns
         # which was inserted to maintain the shape
-        offset_var = self.offset_var
-        exposure_var = self.exposure_var
+        offset_var = self._offset_var
+        exposure_var = self._exposure_var
 
         if offset_var is not None:
             if isinstance(offset_var, int):
@@ -516,7 +661,7 @@ class GLMRegressor(BaseProbaRegressor):
         y_predictions_df = self.glm_fit_.get_prediction(X_).summary_frame()
 
         # convert the returned values to skpro equivalent distribution
-        family = self.family
+        family = self._family
         index = X_.index
         columns = y_column
 
@@ -540,7 +685,7 @@ class GLMRegressor(BaseProbaRegressor):
         """
         from statsmodels.tools import add_constant
 
-        if self.add_constant:
+        if self._add_constant:
             X_ = add_constant(X)
             return X_
         else:

--- a/skpro/regression/linear/_glm.py
+++ b/skpro/regression/linear/_glm.py
@@ -35,19 +35,19 @@ class GLMRegressor(BaseProbaRegressor):
         Available options are 'none', 'drop' and 'raise'. If 'none', no nan
         checking is done. If 'drop', any observations with nans are dropped.
         If 'raise', an error is raised. Default = 'none'
-    offset : pd.Index([string]) or int, default = None
-        If ``pd.Index([string])``, then the exog or ``X`` passed while ``fit``ting
+    offset_var : pd.Index([str]) or int, default = None
+        If ``pd.Index([str])``, then the exog or ``X`` passed while ``fit``-ting
         must have an additional column with column name passed through
-        ``offset`` with any values against each row. When ``predict``ing
-        have an additional column with name same as string passed through ``offset``
-        in X with all the ``offset`` values stored in the column for each row.
+        ``offset_var`` with any values against each row. When ``predict``ing
+        have an additional column with name same as string passed through ``offset_var``
+        in X with all the ``offset_var`` values stored in the column for each row.
         If ``int`` it corresponding column number will be considered.
-    exposure : pd.Index([string]) or int, default = None
-        If ```pd.Index([string])``, then the exog or ``X`` passed while ``fit``ting
+    exposure_var : pd.Index([str]) or int, default = None
+        If ```pd.Index([str])``, then the exog or ``X`` passed while ``fit``-ting
         must have an additional column with column name passed through
-        ``exposure`` with any values against each row. When ``predict``ing
-        have an additional column with name same as string passed through ``exposure``
-        in X with all the ``exposure`` values stored in the column for each row.
+        ``exposure_var`` with any values against each row. When ``predict``ing
+        have additional column with name same as string passed through ``exposure_var``
+        in X with all the ``exposure_var`` values stored in the column for each row.
         If ``int`` it corresponding column number will be considered.
     start_params : array_like (optional)
         Initial guess of the solution for the loglikelihood maximization.

--- a/skpro/regression/linear/_glm.py
+++ b/skpro/regression/linear/_glm.py
@@ -34,11 +34,7 @@ class GLMRegressor(BaseProbaRegressor):
         Available options are 'none', 'drop' and 'raise'. If 'none', no nan
         checking is done. If 'drop', any observations with nans are dropped.
         If 'raise', an error is raised. Default = 'none'
-    offset : 1D float array or None (optional)
-        1D array same size as X or exog while ``predict``ing.
-    exposure : 1D float array or None (optional)
-        1D array same size as X or exog while ``predict``ing.
-        used only when link is 'Log'.
+
     start_params : array_like (optional)
         Initial guess of the solution for the loglikelihood maximization.
         The default is family-specific and is given by the
@@ -222,8 +218,6 @@ class GLMRegressor(BaseProbaRegressor):
         family="Normal",
         link=None,
         missing="none",
-        offset=None,
-        exposure=None,
         start_params=None,
         maxiter=100,
         method="IRLS",
@@ -244,8 +238,6 @@ class GLMRegressor(BaseProbaRegressor):
         self.family = family
         self.link = link
         self.missing = missing
-        self.offset = offset
-        self.exposure = exposure
         self.start_params = start_params
         self.maxiter = maxiter
         self.method = method
@@ -368,12 +360,9 @@ class GLMRegressor(BaseProbaRegressor):
         """
         X_ = self._prep_x(X)
 
-        offset = self.offset
-        exposure = self.exposure
-
         index = X_.index
         y_column = self.y_col
-        y_pred_series = self.glm_fit_.predict(X_, offset=offset, exposure=exposure)
+        y_pred_series = self.glm_fit_.predict(X_)
         y_pred = pd.DataFrame(y_pred_series, index=index, columns=y_column)
 
         return y_pred

--- a/skpro/regression/linear/_glm.py
+++ b/skpro/regression/linear/_glm.py
@@ -314,10 +314,10 @@ class GLMRegressor(BaseProbaRegressor):
         disp=False,
         max_start_irls=3,
         add_constant=False,
-        family="0",
-        link="1",
-        offset_var="2",
-        exposure_var="3",
+        family="Normal",
+        link=None,
+        offset_var=None,
+        exposure_var=None,
     ):
         # The default values of the parameters
         # are replaced with the changed sequence
@@ -343,22 +343,10 @@ class GLMRegressor(BaseProbaRegressor):
         self.max_start_irls = max_start_irls
         self.add_constant = add_constant
 
-        if family == "0":
-            self._family = "Normal"
-        else:
-            self._family = family
-        if link == "1":
-            self._link = None
-        else:
-            self._link = link
-        if offset_var == "2":
-            self._offset_var = None
-        else:
-            self._offset_var = offset_var
-        if exposure_var == "3":
-            self._exposure_var = None
-        else:
-            self._exposure_var = exposure_var
+        self._family = self.family
+        self._link = self.link
+        self._offset_var = self.offset_var
+        self._exposure_var = self.exposure_var
         self._missing = self.missing
         self._start_params = self.start_params
         self._maxiter = self.maxiter
@@ -377,12 +365,12 @@ class GLMRegressor(BaseProbaRegressor):
 
         warn(
             "Note: in `GLMRegressor`, the sequence of the parameters will change "
-            "in skpro version 2.4.0. It will be as per the order present in the"
+            "in skpro version 2.5.0. It will be as per the order present in the"
             "current docstring with the top one being the first parameter.\n"
             "The defaults for the parameters will remain same and "
             "there will be no changes.\n"
             "Please use the `kwargs` calls instead of positional calls for the"
-            "parameters until the release of skpro 2.4.0 "
+            "parameters until the release of skpro 2.5.0 "
             "as this will avoid any discrepancies."
         )
 

--- a/skpro/regression/linear/_glm.py
+++ b/skpro/regression/linear/_glm.py
@@ -192,7 +192,7 @@ class GLMRegressor(BaseProbaRegressor):
 
     def __init__(
         self,
-        family=None,
+        family="Normal",
         missing="none",
         start_params=None,
         maxiter=100,

--- a/skpro/regression/linear/_glm.py
+++ b/skpro/regression/linear/_glm.py
@@ -3,7 +3,6 @@
 
 __author__ = ["ShreeshaM07", "julian-fong"]
 
-import numpy as np
 import pandas as pd
 
 from skpro.regression.base import BaseProbaRegressor
@@ -35,16 +34,11 @@ class GLMRegressor(BaseProbaRegressor):
         Available options are 'none', 'drop' and 'raise'. If 'none', no nan
         checking is done. If 'drop', any observations with nans are dropped.
         If 'raise', an error is raised. Default = 'none'
-    offset : bool, default = False
-        If True, then the exog or ``X`` passed while ``fit``ting must have an additional
-        column with column name ``offset`` with any values against each row.
-        When ``predict``ing have an additional column with name ``offset``
-        in X with all the ``offset`` values stored in the column for each row.
-    exposure : bool, default = False
-        If True, then the exog or ``X`` passed while ``fit``ting must have an additional
-        column with column name ``exposure`` with any values against each row.
-        When ``predict``ing have an additional column with name ``exposure``
-        in X with all the ``exposure`` values stored in the column for each row.
+    offset : 1D float array or None (optional)
+        1D array same size as X or exog while ``predict``ing.
+    exposure : 1D float array or None (optional)
+        1D array same size as X or exog while ``predict``ing.
+        used only when link is 'Log'.
     start_params : array_like (optional)
         Initial guess of the solution for the loglikelihood maximization.
         The default is family-specific and is given by the
@@ -228,8 +222,8 @@ class GLMRegressor(BaseProbaRegressor):
         family="Normal",
         link=None,
         missing="none",
-        offset=False,
-        exposure=False,
+        offset=None,
+        exposure=None,
         start_params=None,
         maxiter=100,
         method="IRLS",
@@ -290,15 +284,6 @@ class GLMRegressor(BaseProbaRegressor):
         self : reference to self
         """
         from statsmodels.genmod.generalized_linear_model import GLM
-
-        # remove the offset and exposure columns which
-        # was inserted to maintain the shape
-        offset = self.offset
-        exposure = self.exposure
-        if offset is True:
-            X = X.drop(["offset"], axis=1)
-        if exposure is True:
-            X = X.drop(["exposure"], axis=1)
 
         X_ = self._prep_x(X)
 
@@ -381,23 +366,14 @@ class GLMRegressor(BaseProbaRegressor):
         -------
         y : pandas DataFrame, same length as `X`, with same columns as y in fit
         """
+        X_ = self._prep_x(X)
+
         offset = self.offset
         exposure = self.exposure
-        offset_arr = None
-        exposure_arr = None
-        if offset is True:
-            offset_arr = np.array(X["offset"])
-            X = X.drop(["offset"], axis=1)
-        if exposure is True:
-            exposure_arr = np.array(X["exposure"])
-            X = X.drop(["exposure"], axis=1)
-        X_ = self._prep_x(X)
 
         index = X_.index
         y_column = self.y_col
-        y_pred_series = self.glm_fit_.predict(
-            X_, offset=offset_arr, exposure=exposure_arr
-        )
+        y_pred_series = self.glm_fit_.predict(X_, offset=offset, exposure=exposure)
         y_pred = pd.DataFrame(y_pred_series, index=index, columns=y_column)
 
         return y_pred
@@ -462,15 +438,6 @@ class GLMRegressor(BaseProbaRegressor):
         y_pred : skpro BaseDistribution, same length as `X`
             labels predicted for `X`
         """
-        # remove the offset and exposure columns
-        # which was inserted to maintain the shape
-        offset = self.offset
-        exposure = self.exposure
-        if offset is True:
-            X = X.drop(["offset"], axis=1)
-        if exposure is True:
-            X = X.drop(["exposure"], axis=1)
-
         X_ = self._prep_x(X)
 
         # instead of using the conventional predict() method, we use statsmodels

--- a/skpro/regression/linear/_glm.py
+++ b/skpro/regression/linear/_glm.py
@@ -401,7 +401,7 @@ class GLMRegressor(BaseProbaRegressor):
         else:
             self._add_constant = add_constant
 
-        from sktime.utils.warnings import warn
+        from warnings import warn
 
         l1 = "Note: in `GLMRegressor`, the sequence of the parameters will change "
         l2 = "in skpro version 2.4.0. It will be as per the order present in the"

--- a/skpro/regression/linear/_glm.py
+++ b/skpro/regression/linear/_glm.py
@@ -229,11 +229,7 @@ class GLMRegressor(BaseProbaRegressor):
 
     def __init__(
         self,
-        family="Normal",
-        link=None,
         missing="none",
-        offset_var=None,
-        exposure_var=None,
         start_params=None,
         maxiter=100,
         method="IRLS",
@@ -246,6 +242,10 @@ class GLMRegressor(BaseProbaRegressor):
         disp=False,
         max_start_irls=3,
         add_constant=False,
+        family="Normal",
+        link=None,
+        offset_var=None,
+        exposure_var=None,
     ):
         super().__init__()
 

--- a/skpro/regression/linear/_glm.py
+++ b/skpro/regression/linear/_glm.py
@@ -3,6 +3,7 @@
 
 __author__ = ["ShreeshaM07", "julian-fong"]
 
+import numpy as np
 import pandas as pd
 
 from skpro.regression.base import BaseProbaRegressor
@@ -34,7 +35,16 @@ class GLMRegressor(BaseProbaRegressor):
         Available options are 'none', 'drop' and 'raise'. If 'none', no nan
         checking is done. If 'drop', any observations with nans are dropped.
         If 'raise', an error is raised. Default = 'none'
-
+    offset : bool, default = False
+        If True, then the exog or ``X`` passed while ``fit``ting must have an additional
+        column with column name ``offset`` with any values against each row.
+        When ``predict``ing have an additional column with name ``offset``
+        in X with all the ``offset`` values stored in the column for each row.
+    exposure : bool, default = False
+        If True, then the exog or ``X`` passed while ``fit``ting must have an additional
+        column with column name ``exposure`` with any values against each row.
+        When ``predict``ing have an additional column with name ``exposure``
+        in X with all the ``exposure`` values stored in the column for each row.
     start_params : array_like (optional)
         Initial guess of the solution for the loglikelihood maximization.
         The default is family-specific and is given by the
@@ -218,6 +228,8 @@ class GLMRegressor(BaseProbaRegressor):
         family="Normal",
         link=None,
         missing="none",
+        offset=False,
+        exposure=False,
         start_params=None,
         maxiter=100,
         method="IRLS",
@@ -276,6 +288,15 @@ class GLMRegressor(BaseProbaRegressor):
         self : reference to self
         """
         from statsmodels.genmod.generalized_linear_model import GLM
+
+        # remove the offset and exposure columns which
+        # was inserted to maintain the shape
+        offset = self.offset
+        exposure = self.exposure
+        if offset is True:
+            X = X.drop(["offset"], axis=1)
+        if exposure is True:
+            X = X.drop(["exposure"], axis=1)
 
         X_ = self._prep_x(X)
 
@@ -358,11 +379,23 @@ class GLMRegressor(BaseProbaRegressor):
         -------
         y : pandas DataFrame, same length as `X`, with same columns as y in fit
         """
+        offset = self.offset
+        exposure = self.exposure
+        offset_arr = None
+        exposure_arr = None
+        if offset is True:
+            offset_arr = np.array(X["offset"])
+            X = X.drop(["offset"], axis=1)
+        if exposure is True:
+            exposure_arr = np.array(X["exposure"])
+            X = X.drop(["exposure"], axis=1)
         X_ = self._prep_x(X)
 
         index = X_.index
         y_column = self.y_col
-        y_pred_series = self.glm_fit_.predict(X_)
+        y_pred_series = self.glm_fit_.predict(
+            X_, offset=offset_arr, exposure=exposure_arr
+        )
         y_pred = pd.DataFrame(y_pred_series, index=index, columns=y_column)
 
         return y_pred
@@ -427,6 +460,15 @@ class GLMRegressor(BaseProbaRegressor):
         y_pred : skpro BaseDistribution, same length as `X`
             labels predicted for `X`
         """
+        # remove the offset and exposure columns
+        # which was inserted to maintain the shape
+        offset = self.offset
+        exposure = self.exposure
+        if offset is True:
+            X = X.drop(["offset"], axis=1)
+        if exposure is True:
+            X = X.drop(["exposure"], axis=1)
+
         X_ = self._prep_x(X)
 
         # instead of using the conventional predict() method, we use statsmodels

--- a/skpro/regression/tests/test_glm.py
+++ b/skpro/regression/tests/test_glm.py
@@ -1,0 +1,60 @@
+"""Tests Generalized Linear Model regressor."""
+
+import pandas as pd
+import pytest
+
+from skpro.regression.linear import GLMRegressor
+from skpro.tests.test_switch import run_test_for_class
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(GLMRegressor),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_glm_simple_use():
+    """Test simple use of GLM regressor."""
+    from sklearn.datasets import load_diabetes
+    from sklearn.model_selection import train_test_split
+
+    X, y = load_diabetes(return_X_y=True, as_frame=True)
+    y = pd.DataFrame(y)
+    X = X.iloc[:200]
+    y = y.iloc[:200]
+    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+
+    glm_reg = GLMRegressor()
+    glm_reg.fit(X_train, y_train)
+    y_pred = glm_reg.predict(X_test)
+    y_pred_proba = glm_reg.predict_proba(X_test)
+
+    assert y_pred.shape == y_test.shape
+    assert y_pred_proba.shape == y_test.shape
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(GLMRegressor),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_glm_with_offset_exposure():
+    """Test GLM with offset_var and exposure_var parameters."""
+    import numpy as np
+    from sklearn.datasets import load_diabetes
+    from sklearn.model_selection import train_test_split
+
+    X, y = load_diabetes(return_X_y=True, as_frame=True)
+    y = pd.DataFrame(y)
+    X = X.iloc[:200]
+    y = y.iloc[:200]
+    X["off"] = np.ones(X.shape[0]) * 2.1
+    X["exp"] = np.arange(1, X.shape[0] + 1)
+    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+
+    glm_reg = GLMRegressor(
+        family="Normal", link="Log", offset_var=pd.Index(["off"]), exposure_var=-1
+    )
+    glm_reg.fit(X_train, y_train)
+    y_pred = glm_reg.predict(X_test)
+    y_pred_proba = glm_reg.predict_proba(X_test)
+
+    assert y_pred.shape == y_test.shape
+    assert y_pred_proba.shape == y_test.shape

--- a/skpro/regression/tests/test_glm.py
+++ b/skpro/regression/tests/test_glm.py
@@ -50,7 +50,7 @@ def test_glm_with_offset_exposure():
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
 
     glm_reg = GLMRegressor(
-        family="Normal", link="Log", offset_var=pd.Index(["off"]), exposure_var=-1
+        family="Normal", link="Log", offset_var="off", exposure_var=-1
     )
     glm_reg.fit(X_train, y_train)
     y_pred = glm_reg.predict(X_test)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skpro.readthedocs.io/en/latest/contribute.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
fixes #383 and closes #230

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
This creates an adapter converting the statsmodels GLM families to skpro equivalent giving `GLM`s a broader capability of distributions and link functions.
#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new core dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core skpro package to a minimum.
-->
No

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->
Yes

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
