### PR TITLE
[BUG] - bugfix when `None` was specified for `max_iter` parameter in sklearn regressors

### DIFF
--- a/skpro/regression/linear/_sklearn.py
+++ b/skpro/regression/linear/_sklearn.py
@@ -19,8 +19,8 @@ class ARDRegression(_DelegateWithFittedParamForwarding):
 
     Parameters
     ----------
-    max_iter : int, default=None
-        Maximum number of iterations. If `None`, it corresponds to `max_iter=300`.
+    max_iter : int, default= 300
+        Maximum number of iterations.
 
     tol : float, default=1e-3
         Stop the algorithm if w has converged.
@@ -90,7 +90,7 @@ class ARDRegression(_DelegateWithFittedParamForwarding):
 
     def __init__(
         self,
-        max_iter=None,
+        max_iter=300,
         tol=1e-3,
         alpha_1=1e-6,
         alpha_2=1e-6,
@@ -188,10 +188,9 @@ class BayesianRidge(_DelegateWithFittedParamForwarding):
 
     Parameters
     ----------
-    max_iter : int, default=None
+    max_iter : int, default= 300
         Maximum number of iterations over the complete dataset before
-        stopping independently of any early stopping criterion. If `None`, it
-        corresponds to `max_iter=300`.
+        stopping independently of any early stopping criterion.
 
     tol : float, default=1e-3
         Stop the algorithm if w has converged.
@@ -272,7 +271,7 @@ class BayesianRidge(_DelegateWithFittedParamForwarding):
 
     def __init__(
         self,
-        max_iter=None,
+        max_iter=300,
         tol=1e-3,
         alpha_1=1e-6,
         alpha_2=1e-6,

--- a/skpro/regression/linear/_sklearn.py
+++ b/skpro/regression/linear/_sklearn.py
@@ -188,7 +188,7 @@ class BayesianRidge(_DelegateWithFittedParamForwarding):
 
     Parameters
     ----------
-    max_iter : int, default= 300
+    max_iter : int, default=300
         Maximum number of iterations over the complete dataset before
         stopping independently of any early stopping criterion.
 

--- a/skpro/regression/linear/_sklearn.py
+++ b/skpro/regression/linear/_sklearn.py
@@ -19,7 +19,7 @@ class ARDRegression(_DelegateWithFittedParamForwarding):
 
     Parameters
     ----------
-    max_iter : int, default= 300
+    max_iter : int, default=300
         Maximum number of iterations.
 
     tol : float, default=1e-3


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #385 . 

@fkiraly I couldn't specify `inf` as a `max_iter` since the allowed values range between [1, inf) with inf as an open interval. Instead I chose 300 because thats what the docstring said previously. Let me know if you want something else set as the default value.
