### PR TITLE
[ENH] interval width and area under calibration curve metrics

### DIFF
--- a/docs/source/api_reference/metrics.rst
+++ b/docs/source/api_reference/metrics.rst
@@ -31,6 +31,7 @@ Quantile and interval prediction metrics
     PinballLoss
     EmpiricalCoverage
     ConstraintViolation
+    IntervalWidth
 
 Distribution prediction metrics
 -------------------------------
@@ -46,9 +47,9 @@ Distribution predictions are also known as conditional distribution predictions.
 
     CRPS
     LogLoss
-    SquaredDistrLoss
     LinearizedLogLoss
     SquaredDistrLoss
+    AUCalibration
 
 Survival prediction metrics
 ---------------------------

--- a/skpro/metrics/__init__.py
+++ b/skpro/metrics/__init__.py
@@ -5,21 +5,26 @@
 __author__ = ["fkiraly", "euanenticott-shell"]
 
 __all__ = [
-    "PinballLoss",
-    "EmpiricalCoverage",
-    "ConstraintViolation",
     "CRPS",
+    "AUCalibration",
+    "ConstraintViolation",
+    "EmpiricalCoverage",
+    "IntervalWidth",
     "LogLoss",
     "LinearizedLogLoss",
+    "PinballLoss",
     "SquaredDistrLoss",
+    # survival metrics
     "ConcordanceHarrell",
     "SPLL",
 ]
 
 from skpro.metrics._classes import (
     CRPS,
+    AUCalibration,
     ConstraintViolation,
     EmpiricalCoverage,
+    IntervalWidth,
     LinearizedLogLoss,
     LogLoss,
     PinballLoss,

--- a/skpro/metrics/_classes.py
+++ b/skpro/metrics/_classes.py
@@ -181,7 +181,7 @@ class IntervalWidth(BaseProbaMetric):
         self.multioutput = multioutput
         super().__init__(score_average=score_average, multioutput=multioutput)
 
-    def _evaluate_by_index(self, y_true, y_pred, multioutput, **kwargs):
+    def _evaluate_by_index(self, y_true, y_pred, **kwargs):
         """Logic for finding the metric evaluated at each index.
 
         y_true : pd.Series, pd.DataFrame or np.array of shape (fh,) or \

--- a/skpro/metrics/_classes.py
+++ b/skpro/metrics/_classes.py
@@ -566,6 +566,9 @@ class AUCalibration(BaseDistrMetric):
         diagonal = np.arange(1, n + 1).reshape(-1, 1) / n
 
         res = (cdfs_ranked - diagonal).abs()
+
+        if self.multivariate:
+            return pd.DataFrame(res.mean(axis=1), columns=["score"])
         return res
 
     @classmethod

--- a/skpro/metrics/_classes.py
+++ b/skpro/metrics/_classes.py
@@ -159,6 +159,70 @@ class EmpiricalCoverage(BaseProbaMetric):
         return [params1]
 
 
+class IntervalWidth(BaseProbaMetric):
+    """Interval width for interval predictions, sometimes also known as sharpness.
+
+    Parameters
+    ----------
+    multioutput : string "uniform_average" or "raw_values" determines how\
+        multioutput results will be treated.
+
+    score_average : bool, optional, default = True
+        specifies whether scores for each quantile should be averaged.
+    """
+
+    _tags = {
+        "scitype:y_pred": "pred_interval",
+        "lower_is_better": True,
+    }
+
+    def __init__(self, multioutput="uniform_average", score_average=True):
+        self.score_average = score_average
+        self.multioutput = multioutput
+        super().__init__(score_average=score_average, multioutput=multioutput)
+
+    def _evaluate_by_index(self, y_true, y_pred, multioutput, **kwargs):
+        """Logic for finding the metric evaluated at each index.
+
+        y_true : pd.Series, pd.DataFrame or np.array of shape (fh,) or \
+            (fh, n_outputs) where fh is the forecasting horizon
+            Ground truth (correct) target values.
+
+        y_pred : pd.Series, pd.DataFrame or np.array of shape (fh,) or  \
+            (fh, n_outputs)  where fh is the forecasting horizon
+            Forecasted values.
+
+        multioutput : string "uniform_average" or "raw_values" determines how \
+            multioutput results will be treated.
+        """
+        lower = y_pred.iloc[:, y_pred.columns.get_level_values(2) == "lower"].to_numpy()
+        upper = y_pred.iloc[:, y_pred.columns.get_level_values(2) == "upper"].to_numpy()
+
+        if not isinstance(y_true, np.ndarray):
+            y_true_np = y_true.to_numpy()
+        else:
+            y_true_np = y_true
+        if y_true_np.ndim == 1:
+            y_true_np = y_true.reshape(-1, 1)
+
+        scores = np.unique(np.round(y_pred.columns.get_level_values(1), 7))
+        vars = np.unique(y_pred.columns.get_level_values(0))
+
+        metric_array = upper - lower
+
+        out_df = pd.DataFrame(
+            metric_array, columns=pd.MultiIndex.from_product([vars, scores])
+        )
+
+        return out_df
+
+    @classmethod
+    def get_test_params(self):
+        """Retrieve test parameters."""
+        params1 = {}
+        return [params1]
+
+
 class ConstraintViolation(BaseProbaMetric):
     """Evaluate the pinball loss at all quantiles given in data.
 
@@ -433,6 +497,76 @@ class CRPS(BaseDistrMetric):
     def _evaluate_by_index(self, y_true, y_pred, **kwargs):
         # CRPS(d, y) = E_X,Y as d [abs(Y-y) - 0.5 abs(X-Y)]
         return y_pred.energy(y_true) - y_pred.energy() / 2
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Retrieve test parameters."""
+        params1 = {}
+        params2 = {"multivariate": True}
+        return [params1, params2]
+
+
+class AUCalibration(BaseDistrMetric):
+    r"""Area under the calibration curve for distributional predictions.
+
+    Computes the unsigned area between the calibration curve and the diagonal.
+
+    The calibration curve is the cumulative curve of the sample of
+    predictive cumulative distibution functions evaluated at the true values.
+
+    Mathematically, let :math:`d_1, \dots, d_N` be the predictive distributions,
+    let :math:`y_1, \dots, y_N` be the true values, and let :math:`F_i` be the
+    cumulative distribution function of :math:`d_i`.
+
+    Define the calibration sample as :math:`c_i := F_i(y_i)`, for
+    :math:`i = 1, \dots, N`. For perfect predictions, the sample of :math:`c_i` will be
+    uniformly distributed on [0, 1], and i.i.d. from that uniform distribution.
+
+    Let :math:`c_{(i)}` be the :math:`i`-th order statistic of the sample of
+    :math:`c_i`, i.e., the :math:`i`-th smallest value in the sample.
+
+    The (unsigned) area under the calibration curve - or, more precisely,
+    between the diagonal and the calibration curve - is defined as
+
+    .. math:: \frac{1}{N} \sum_{i=1}^N \left| c_{(i)} - \frac{i}{N} \right|.
+
+    * ``evaluate`` returns the unsigned area between the calibration curve
+      and the diagonal, i.e., the above quantity.
+    * ``evaluate_by_index`` returns, for the :math:`i`-th test sample, the value
+      :math:`\left| c_i - \frac{r_i}{N} \right|`,
+      where :math:`r_i` is the rank of :math:`c_i`
+      in the sample of :math:`c_i`. In case of ties, tied ranks are averaged.
+    * ``multivariate`` controls averaging over variables.
+
+    Parameters
+    ----------
+    multioutput : {'raw_values', 'uniform_average'} or array-like of shape \
+            (n_outputs,), default='uniform_average'
+        Defines whether and how to aggregate metric for across variables.
+        If 'uniform_average' (default), errors are mean-averaged across variables.
+        If array-like, errors are weighted averaged across variables, values as weights.
+        If 'raw_values', does not average errors across variables, columns are retained.
+    multivariate : bool, optional, default=False
+        if True, behaves as multivariate metric (sum of scores)
+        The metric is computed for entire row, results one score per row
+        if False, returns univariate metric, per variable
+        The metric is computed per variable marginal, results in many scores per row
+    """  # noqa: E501
+
+    def __init__(self, multioutput="uniform_average", multivariate=False):
+        self.multivariate = multivariate
+        super().__init__(multioutput=multioutput)
+
+    def _evaluate_by_index(self, y_true, y_pred, multioutput, **kwargs):
+        cdfs = y_pred.cdf(y_true)
+        # using the average in case of ranks is fine
+        # because the absolute sums in the metric average out
+        cdfs_ranked = cdfs.rank(axis=0, method="average", pct=True)
+        n = cdfs.shape[0]
+        diagonal = np.arange(1, n + 1).reshape(-1, 1) / n
+
+        res = (cdfs_ranked - diagonal).abs()
+        return res
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/skpro/metrics/tests/test_probabilistic_metrics.py
+++ b/skpro/metrics/tests/test_probabilistic_metrics.py
@@ -4,7 +4,12 @@ import pytest
 from sklearn.datasets import load_diabetes
 from sklearn.model_selection import train_test_split
 
-from skpro.metrics._classes import ConstraintViolation, EmpiricalCoverage, PinballLoss
+from skpro.metrics._classes import (
+    ConstraintViolation,
+    EmpiricalCoverage,
+    IntervalWidth,
+    PinballLoss,
+)
 from skpro.regression.residual import ResidualDouble
 
 quantile_metrics = [
@@ -14,6 +19,7 @@ quantile_metrics = [
 interval_metrics = [
     EmpiricalCoverage,
     ConstraintViolation,
+    IntervalWidth,
 ]
 
 all_metrics = quantile_metrics + interval_metrics


### PR DESCRIPTION
This PR adds interval width and area under calibration curve metrics from `sktime`. Until refactor, the metrics modules should be kept in sync.