### PR TITLE
[MNT] increase `numpy` bound to `numpy < 2.1`, `numpy 2` compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
 ]
 requires-python = ">=3.8,<3.13"
 dependencies = [
-    "numpy>=1.21.0,<1.27",
+    "numpy>=1.21.0,<2.1",
     "pandas>=1.1.0,<2.3.0",
     "packaging",
     "scikit-base>=0.6.1,<0.9.0",


### PR DESCRIPTION
This PR bumps the bound for `numpy` to `<2.1`.