### PR TITLE
DIAGNOSTIC - `numpy 2`, test all estimators

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
 ]
 requires-python = ">=3.8,<3.13"
 dependencies = [
-    "numpy>=1.21.0,<1.27",
+    "numpy>=1.21.0,<2.1",
     "pandas>=1.1.0,<2.3.0",
     "packaging",
     "scikit-base>=0.6.1,<0.9.0",

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ addopts =
     --cov-report xml
     --cov-report html
     --showlocals
-    --only_changed_modules True
+    --only_changed_modules False
     -n auto
 filterwarnings =
     ignore::UserWarning


### PR DESCRIPTION
Diagnostic - do not merge

Diagnostic PR to test all estimators with `numpy 2`. 
For https://github.com/sktime/skpro/issues/394