### PR TITLE
[MNT] make `BaseArrayDistribution` private

### DIFF
--- a/docs/source/api_reference/distributions.rst
+++ b/docs/source/api_reference/distributions.rst
@@ -22,7 +22,6 @@ Base
     :template: class.rst
 
     BaseDistribution
-    BaseArrayDistribution
 
 Parametric distributions
 ------------------------

--- a/skpro/distributions/base/__init__.py
+++ b/skpro/distributions/base/__init__.py
@@ -2,8 +2,8 @@
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 # adapted from sktime
 
-__all__ = ["BaseDistribution", "_DelegatedDistribution", "BaseArrayDistribution"]
+__all__ = ["BaseDistribution", "_DelegatedDistribution", "_BaseArrayDistribution"]
 
 from skpro.distributions.base._base import BaseDistribution
-from skpro.distributions.base._base_array import BaseArrayDistribution
+from skpro.distributions.base._base_array import _BaseArrayDistribution
 from skpro.distributions.base._delegate import _DelegatedDistribution

--- a/skpro/distributions/base/_base_array.py
+++ b/skpro/distributions/base/_base_array.py
@@ -3,7 +3,7 @@
 
 __author__ = ["ShreeshaM07"]
 
-__all__ = ["BaseArrayDistribution"]
+__all__ = ["_BaseArrayDistribution"]
 
 import numpy as np
 import pandas as pd
@@ -16,7 +16,7 @@ from skpro.distributions.base._base import (
 )
 
 
-class BaseArrayDistribution(BaseDistribution, BaseObject):
+class _BaseArrayDistribution(BaseDistribution, BaseObject):
     """Base Array probability distribution."""
 
     def __init__(self, index=None, columns=None):

--- a/skpro/distributions/histogram.py
+++ b/skpro/distributions/histogram.py
@@ -6,10 +6,10 @@ __author__ = ["ShreeshaM07"]
 import numpy as np
 import pandas as pd
 
-from skpro.distributions.base import BaseArrayDistribution
+from skpro.distributions.base import _BaseArrayDistribution
 
 
-class Histogram(BaseArrayDistribution):
+class Histogram(_BaseArrayDistribution):
     """Histogram Probability Distribution.
 
     The histogram probability distribution is parameterized


### PR DESCRIPTION
This PR makes `BaesArrayDistribution` private.

This is due to the imminent release - if it is private, we can change interfaces later without having to go through the deprecation process. This includes changes such as merging into the base class.

FYI @ShreeshaM07.