### PR TITLE
[BUG] ensure `index` and `columns` are taken into account in broadcasting if `bc_params` are set

### DIFF
--- a/skpro/distributions/base/_base.py
+++ b/skpro/distributions/base/_base.py
@@ -559,6 +559,12 @@ class BaseDistribution(BaseObject):
         bc_params = self.get_tags()["broadcast_params"]
         if bc_params is None:
             bc_params = kwargs_as_np.keys()
+        else:
+            bc_params = bc_params.copy()
+            if "index" in kwargs_as_np:
+                bc_params.append("index")
+            if "columns" in kwargs_as_np:
+                bc_params.append("columns")
 
         args_as_np = [kwargs_as_np[k] for k in bc_params]
         bc = np.broadcast_arrays(*args_as_np)


### PR DESCRIPTION
This PR fixes an unreported bug in the `BaseDistribution`, it ensures that `index` and `columns` are taken into account in boilerplate broadcasting if the `bc_params` tag is set.