### PR TITLE
[BUG] Histogram Distribution: address `np.broadcast_arrays` deprecation of writable return in `numpy 2.0.0`

### DIFF
--- a/skpro/distributions/base/_base_array.py
+++ b/skpro/distributions/base/_base_array.py
@@ -229,7 +229,7 @@ class _BaseArrayDistribution(BaseDistribution, BaseObject):
         index_column_broadcast.append(kwargs_as_np["index"])
         index_column_broadcast.append(kwargs_as_np["columns"])
 
-        bc = np.broadcast_arrays(*index_column_broadcast)
+        bc = list(np.broadcast_arrays(*index_column_broadcast))
         if dtype is not None:
             bc = [array.astype(dtype) for array in bc]
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skpro.readthedocs.io/en/latest/contribute.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
fixes #412 


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
The error is due to the deprecation of the np.broadcast_arrays. https://numpy.org/doc/stable/reference/generated/numpy.broadcast_arrays.html
So the bc is actually a tuple with broadcasted arrays whose values are getting reassigned.


#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
