### PR TITLE
[ENH] Truncated Normal distribution

### DIFF
--- a/docs/source/api_reference/distributions.rst
+++ b/docs/source/api_reference/distributions.rst
@@ -77,6 +77,16 @@ Integer support
     Binomial
     Poisson
 
+Continuous support - truncated distributions
+--------------------------------------------
+
+.. currentmodule:: skpro.distributions
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    TruncatedNormal
 
 Non-parametric and empirical distributions
 ------------------------------------------

--- a/docs/source/api_reference/distributions.rst
+++ b/docs/source/api_reference/distributions.rst
@@ -39,6 +39,7 @@ Continuous support - full reals
     Logistic
     Normal
     TDistribution
+    TruncatedNormal
 
 
 Continuous support - non-negative reals
@@ -76,17 +77,6 @@ Integer support
 
     Binomial
     Poisson
-
-Continuous support - truncated distributions
---------------------------------------------
-
-.. currentmodule:: skpro.distributions
-
-.. autosummary::
-    :toctree: auto_generated/
-    :template: class.rst
-
-    TruncatedNormal
 
 Non-parametric and empirical distributions
 ------------------------------------------

--- a/skpro/distributions/__init__.py
+++ b/skpro/distributions/__init__.py
@@ -34,6 +34,7 @@ __all__ = [
     "QPD_U",
     "QPD_Johnson",
     "TDistribution",
+    "TruncatedNormal",
     "Uniform",
     "Weibull",
 ]
@@ -65,5 +66,6 @@ from skpro.distributions.poisson import Poisson
 from skpro.distributions.qpd import QPD_B, QPD_S, QPD_U, QPD_Johnson
 from skpro.distributions.qpd_empirical import QPD_Empirical
 from skpro.distributions.t import TDistribution
+from skpro.distributions.truncated_normal import TruncatedNormal
 from skpro.distributions.uniform import Uniform
 from skpro.distributions.weibull import Weibull

--- a/skpro/distributions/truncated_normal.py
+++ b/skpro/distributions/truncated_normal.py
@@ -37,11 +37,11 @@ class TruncatedNormal(_ScipyAdapter):
     -------
     >>> from skpro.distributions.truncated_normal import TruncatedNormal
 
-    >>> d = TruncatedNormal(
-            mu=[[0, 1], [2, 3], [4, 5]],
-            sigma= 1,
-            l_trunc= [[-0.1,0.5],[1.5,2.4],[4.1,5]],
-            r_trunc= [[0.8,2],[4,5],[5,7]]
+    >>> d = TruncatedNormal(\
+            mu=[[0, 1], [2, 3], [4, 5]],\
+            sigma= 1,\
+            l_trunc= [[-0.1,0.5],[1.5,2.4],[4.1,5]],\
+            r_trunc= [[0.8,2],[4,5],[5,7]]\
         )
     """
 

--- a/skpro/distributions/truncated_normal.py
+++ b/skpro/distributions/truncated_normal.py
@@ -13,6 +13,12 @@ class TruncatedNormal(_ScipyAdapter):
     """A truncated normal probability distribution.
 
     Most methods wrap ``scipy.stats.truncnorm``.
+    It truncates the normal distribution at
+    the abscissa ``l_trunc`` and ``r_trunc``.
+
+    Note: The truncation parameters passed
+    is internally shifted to be centred at
+    mean and scaled by sigma.
 
     Parameters
     ----------

--- a/skpro/distributions/truncated_normal.py
+++ b/skpro/distributions/truncated_normal.py
@@ -1,0 +1,98 @@
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+"""Truncated Normal probability distribution."""
+
+__author__ = ["ShreeshaM07"]
+
+import pandas as pd
+from scipy.stats import rv_continuous, truncnorm
+
+from skpro.distributions.adapters.scipy import _ScipyAdapter
+
+
+class TruncatedNormal(_ScipyAdapter):
+    """A truncated normal probability distribution.
+
+    Most methods wrap ``scipy.stats.truncnorm``.
+
+    Parameters
+    ----------
+    mu : float or array of float (1D or 2D)
+        mean of the normal distribution
+    sigma : float or array of float (1D or 2D), must be positive
+        standard deviation of the normal distribution
+    l_trunc : float or array of float (1D or 2D)
+        Left truncation abscissa.
+    r_trunc : float or array of float (1D or 2D)
+        Right truncation abscissa.
+    index : pd.Index, optional, default = RangeIndex
+    columns : pd.Index, optional, default = RangeIndex
+
+    Example
+    -------
+    >>> from skpro.distributions.truncated_normal import TruncatedNormal
+
+    >>> d = TruncatedNormal(
+            mu=[[0, 1], [2, 3], [4, 5]],
+            sigma= 1,
+            l_trunc= [[-0.1,0.5],[1.5,2.4],[4.1,5]],
+            r_trunc= [[0.8,2],[4,5],[5,7]]
+        )
+    """
+
+    _tags = {
+        "capabilities:approx": ["energy", "pdfnorm"],
+        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
+        "distr:measuretype": "continuous",
+        "distr:paramtype": "parametric",
+        "broadcast_init": "on",
+    }
+
+    def __init__(self, mu, sigma, l_trunc, r_trunc, index=None, columns=None):
+        self.mu = mu
+        self.sigma = sigma
+        self.l_trunc = l_trunc
+        self.r_trunc = r_trunc
+
+        super().__init__(index=index, columns=columns)
+
+    def _get_scipy_object(self) -> rv_continuous:
+        return truncnorm
+
+    def _get_scipy_param(self):
+        mu = self._bc_params["mu"]
+        sigma = self._bc_params["sigma"]
+        l_trunc = self._bc_params["l_trunc"]
+        r_trunc = self._bc_params["r_trunc"]
+
+        # shift it to be centred at mu and sigma
+        a = (l_trunc - mu) / sigma
+        b = (r_trunc - mu) / sigma
+
+        return [], {
+            "loc": mu,
+            "scale": sigma,
+            "a": a,
+            "b": b,
+        }
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator."""
+        # array case examples
+        params1 = {
+            "mu": [[0, 1], [2, 3], [4, 5]],
+            "sigma": 1,
+            "l_trunc": [[-0.1, 0.5], [1.5, 2.4], [4.1, 5]],
+            "r_trunc": [[0.8, 2], [4, 5], [5, 7]],
+        }
+        params2 = {
+            "mu": 0,
+            "sigma": 1,
+            "l_trunc": [-10, -5],
+            "r_trunc": [5, 10],
+            "index": pd.Index([1, 2, 5]),
+            "columns": pd.Index(["a", "b"]),
+        }
+        # scalar case examples
+        params3 = {"mu": 1, "sigma": 2, "l_trunc": -3, "r_trunc": 5}
+        return [params1, params2, params3]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skpro.readthedocs.io/en/latest/contribute.html
-->


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
Interfaces truncated normal distribution from scipy.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new core dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core skpro package to a minimum.
-->
No

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->
Yes
#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
