### PR TITLE
[ENH] Syncing datatypes module `_check.py` and `_convert.py` with `sktime`

### DIFF
--- a/skpro/datatypes/_check.py
+++ b/skpro/datatypes/_check.py
@@ -100,13 +100,18 @@ def check_is_mtype(
         if str, list of str, metadata return dict is subset to keys in return_metadata
     var_name: str, optional, default="obj"
         name of input in error messages
-
     msg_return_dict: str, one of ``"list"`` or ``"dict"``, optional, default="dict"
         whether returned msg, if returned, is a str, dict or list
 
-        *  if "list", msg is str if mtype is str, list of str if mtype is list
+        * if ``msg_return_dict="list"``,
+          returned ``msg`` is ``str`` if ``mtype`` is ``str``,
+          returned ``msg`` is ``list`` of ``str`` if ``mtype`` is ``list``
 
-        *  if "dict", msg is str if mtype is str, dict of str if mtype is list,
+        * if ``msg_return_dict="dict"``,
+          returned ``msg`` is ``str`` if ``mtype`` is ``str``,
+          returned ``msg`` is ``dict`` of ``str`` if ``mtype`` is ``list``.
+          If ``dict``, has str in ``mtype`` as key,
+          and error message for mtype as value.
 
     Returns
     -------
@@ -260,7 +265,7 @@ def check_raise(obj, mtype: str, scitype: str = None, var_name: str = "input"):
 
 def mtype(
     obj,
-    as_scitype,
+    as_scitype=None,
     exclude_mtypes=AMBIGUOUS_MTYPES,
 ):
     """Infer the mtype of an object considered as a specific scitype.

--- a/skpro/datatypes/_check.py
+++ b/skpro/datatypes/_check.py
@@ -22,7 +22,6 @@ __all__ = [
     "check_raise",
     "mtype",
 ]
-from typing import Union
 
 import numpy as np
 
@@ -79,7 +78,7 @@ def _coerce_list_of_str(obj, var_name="obj"):
 
 def check_is_mtype(
     obj,
-    mtype: Union[str, list[str]],
+    mtype,
     scitype: str = None,
     return_metadata=False,
     var_name="obj",
@@ -261,7 +260,7 @@ def check_raise(obj, mtype: str, scitype: str = None, var_name: str = "input"):
 
 def mtype(
     obj,
-    as_scitype: Union[str, list[str]] = None,
+    as_scitype,
     exclude_mtypes=AMBIGUOUS_MTYPES,
 ):
     """Infer the mtype of an object considered as a specific scitype.
@@ -343,7 +342,7 @@ def mtype(
 
 def check_is_scitype(
     obj,
-    scitype: Union[str, list[str]],
+    scitype,
     return_metadata=False,
     var_name="obj",
     exclude_mtypes=AMBIGUOUS_MTYPES,

--- a/skpro/datatypes/_check.py
+++ b/skpro/datatypes/_check.py
@@ -22,6 +22,7 @@ __all__ = [
     "check_raise",
     "mtype",
 ]
+from typing import Union
 
 import numpy as np
 
@@ -78,7 +79,7 @@ def _coerce_list_of_str(obj, var_name="obj"):
 
 def check_is_mtype(
     obj,
-    mtype,
+    mtype: Union[str, list[str]],
     scitype: str = None,
     return_metadata=False,
     var_name="obj",
@@ -104,15 +105,9 @@ def check_is_mtype(
     msg_return_dict: str, one of ``"list"`` or ``"dict"``, optional, default="dict"
         whether returned msg, if returned, is a str, dict or list
 
-        * if ``msg_return_dict="list"``,
-          returned ``msg`` is ``str`` if ``mtype`` is ``str``,
-          returned ``msg`` is ``list`` of ``str`` if ``mtype`` is ``list``
+        *  if "list", msg is str if mtype is str, list of str if mtype is list
 
-        * if ``msg_return_dict="dict"``,
-          returned ``msg`` is ``str`` if ``mtype`` is ``str``,
-          returned ``msg`` is ``dict`` of ``str`` if ``mtype`` is ``list``.
-          If ``dict``, has str in ``mtype`` as key,
-          and error message for mtype as value.
+        *  if "dict", msg is str if mtype is str, dict of str if mtype is list,
 
     Returns
     -------
@@ -158,15 +153,13 @@ def check_is_mtype(
 
     # we loop through individual mtypes in mtype and see whether they pass the check
     #  for each check we remember whether it passed and what it returned
-    if msg_return_dict == "list":
+    if msg_return_dict is None:
+        msg_return_dict = "dict"
+        msg = dict()
+    elif msg_return_dict == "list":
         msg = []
     elif msg_return_dict == "dict":
         msg = dict()
-    else:
-        raise ValueError(
-            f"Error in check_is_mtype, msg_return_dict argument "
-            f"must be 'list' or 'dict', found {msg_return_dict}"
-        )
 
     found_mtype = []
     found_scitype = []
@@ -263,7 +256,11 @@ def check_raise(obj, mtype: str, scitype: str = None, var_name: str = "input"):
         raise TypeError(msg)
 
 
-def mtype(obj, as_scitype=None, exclude_mtypes=AMBIGUOUS_MTYPES):
+def mtype(
+    obj,
+    as_scitype: Union[str, list[str]] = None,
+    exclude_mtypes=AMBIGUOUS_MTYPES,
+):
     """Infer the mtype of an object considered as a specific scitype.
 
     Parameters
@@ -343,7 +340,7 @@ def mtype(obj, as_scitype=None, exclude_mtypes=AMBIGUOUS_MTYPES):
 
 def check_is_scitype(
     obj,
-    scitype,
+    scitype: Union[str, list[str]],
     return_metadata=False,
     var_name="obj",
     exclude_mtypes=AMBIGUOUS_MTYPES,
@@ -533,7 +530,7 @@ def scitype(obj, candidate_scitypes=SCITYPE_LIST, exclude_mtypes=AMBIGUOUS_MTYPE
     if len(valid_scitypes) > 1:
         raise TypeError(
             "Error in function scitype, more than one valid scitype identified:"
-            f"{ valid_scitypes}"
+            f"{valid_scitypes}"
         )
     if len(valid_scitypes) == 0:
         raise TypeError(

--- a/skpro/datatypes/_check.py
+++ b/skpro/datatypes/_check.py
@@ -210,7 +210,10 @@ def check_is_mtype(
     # c. no mtype is found - then return False and all error messages if requested
     else:
         if len(msg) == 1:
-            msg = msg[0]
+            if msg_return_dict == "list":
+                msg = msg[0]
+            else:
+                msg = list(msg.values())[0]
 
         return _ret(False, msg, None, return_metadata)
 

--- a/skpro/datatypes/_convert.py
+++ b/skpro/datatypes/_convert.py
@@ -87,6 +87,7 @@ def convert(
     as_scitype: str = None,
     store=None,
     store_behaviour: str = None,
+    return_to_mtype: bool = False,
 ):
     """Convert objects between different machine representations, subject to scitype.
 
@@ -95,7 +96,9 @@ def convert(
     obj : object to convert - any type, should comply with mtype spec for as_scitype
     from_type : str - the type to convert "obj" to, a valid mtype string
         valid mtype strings, with explanation, are in datatypes.MTYPE_REGISTER
-    to_type : str - the type to convert "obj" to, a valid mtype string
+    to_type : str - the mtype to convert "obj" to, a valid mtype string
+        or list of str, this specifies admissible types for conversion to;
+        if list, will convert to first mtype of the same scitype as from_mtype
         valid mtype strings, with explanation, are in datatypes.MTYPE_REGISTER
     as_scitype : str, optional - name of scitype the object "obj" is considered as
         default = inferred from from_type
@@ -107,11 +110,15 @@ def convert(
         "freeze" - store is read-only, may be read/used by conversion but not changed
         "update" - store is updated from conversion and retains previous contents
         None - automatic: "update" if store is empty and not None; "freeze", otherwise
+    return_to_mtype: bool, optional (default=False)
+        if True, also returns the str of the mtype converted to
 
     Returns
     -------
     converted_obj : to_type - object obj converted to to_type
                     if obj was None, returns None
+    to_type : str, only returned if ``return_to_mtype=True``
+        mtype of ``converted_obj`` - useful of ``to_type`` was a list
 
     Raises
     ------
@@ -121,9 +128,14 @@ def convert(
     if obj is None:
         return None
 
+    # if to_type is a list, we do the following:
+    # if on the list, then don't do a conversion (convert to from_type)
+    # if not on the list, we find and convert to first mtype that has same scitype
+    to_type = _get_first_mtype_of_same_scitype(
+        from_mtype=from_type, to_mtypes=to_type, varname="to_type"
+    )
+
     # input type checks
-    if not isinstance(to_type, str):
-        raise TypeError("to_type must be a str")
     if not isinstance(from_type, str):
         raise TypeError("from_type must be a str")
     if as_scitype is None:
@@ -158,13 +170,16 @@ def convert(
         # this "elif" is here for clarity, to cover all three values
         pass
     else:
-        raise ValueError(
+        raise RuntimeError(
             "bug: unreachable condition error, store_behaviour has unexpected value"
         )
 
     converted_obj = convert_dict[key](obj, store=store)
 
-    return converted_obj
+    if return_to_mtype:
+        return converted_obj, to_type
+    else:
+        return converted_obj
 
 
 # conversion based on queryable type to specified target
@@ -174,14 +189,16 @@ def convert_to(
     as_scitype: str = None,
     store=None,
     store_behaviour: str = None,
+    return_to_mtype: bool = False,
 ):
     """Convert object to a different machine representation, subject to scitype.
 
     Parameters
     ----------
     obj : object to convert - any type, should comply with mtype spec for as_scitype
-    to_type : str - the type to convert "obj" to, a valid mtype string
-            or list of str, this specifies admissible types for conversion to
+    to_type : str - the mtype to convert "obj" to, a valid mtype string
+            or list of str, this specifies admissible types for conversion to;
+            if list, will convert to first mtype of the same scitype as obj
         valid mtype strings, with explanation, are in datatypes.MTYPE_REGISTER
     as_scitype : str, optional - name of scitype the object "obj" is considered as
         pre-specifying the scitype reduces the number of checks done in type inference
@@ -194,7 +211,8 @@ def convert_to(
         "freeze" - store is read-only, may be read/used by conversion but not changed
         "update" - store is updated from conversion and retains previous contents
         None - automatic: "update" if store is empty and not None; "freeze", otherwise
-
+    return_to_mtype: bool, optional (default=False)
+        if True, also returns the str of the mtype converted to
     Returns
     -------
     converted_obj : to_type - object obj, or obj converted to target mtype as follows:
@@ -206,6 +224,8 @@ def convert_to(
             converted_obj is converted to the first mtype in to_type
                 that is of same scitype as obj
         case 4: if obj was None, converted_obj is also None
+    to_type : str, only returned if ``return_to_mtype=True``
+        mtype of ``converted_obj`` - useful of ``to_type`` was a list
 
     Raises
     ------
@@ -234,24 +254,24 @@ def convert_to(
     from_type = infer_mtype(obj=obj, as_scitype=as_scitype)
     as_scitype = mtype_to_scitype(from_type)
 
-    # if to_type is a list, we do the following:
-    # if on the list, then don't do a conversion (convert to from_type)
-    # if not on the list, we find and convert to first mtype that has same scitype
-    if isinstance(to_type, list):
-        # no conversion of from_type is in the list
-        if from_type in to_type:
-            to_type = from_type
-        # otherwise convert to first element of same scitype
-        else:
-            same_scitype_mtypes = [
-                mtype for mtype in to_type if mtype_to_scitype(mtype) == as_scitype
-            ]
-            if len(same_scitype_mtypes) == 0:
-                raise TypeError(
-                    "to_type contains no mtype compatible with the scitype of obj,"
-                    f"which is {as_scitype}"
-                )
-            to_type = same_scitype_mtypes[0]
+    # # if to_type is a list, we do the following:
+    # # if on the list, then don't do a conversion (convert to from_type)
+    # # if not on the list, we find and convert to first mtype that has same scitype
+    # if isinstance(to_type, list):
+    #     # no conversion of from_type is in the list
+    #     if from_type in to_type:
+    #         to_type = from_type
+    #     # otherwise convert to first element of same scitype
+    #     else:
+    #         same_scitype_mtypes = [
+    #             mtype for mtype in to_type if mtype_to_scitype(mtype) == as_scitype
+    #         ]
+    #         if len(same_scitype_mtypes) == 0:
+    #             raise TypeError(
+    #                 "to_type contains no mtype compatible with the scitype of obj,"
+    #                 f"which is {as_scitype}"
+    #             )
+    #         to_type = same_scitype_mtypes[0]
 
     converted_obj = convert(
         obj=obj,
@@ -260,9 +280,43 @@ def convert_to(
         as_scitype=as_scitype,
         store=store,
         store_behaviour=store_behaviour,
+        return_to_mtype=return_to_mtype,
     )
 
     return converted_obj
+
+
+def _get_first_mtype_of_same_scitype(from_mtype, to_mtypes, varname="to_mtypes"):
+    """Return first mtype in list mtypes that has same scitype as from_mtype.
+
+    Parameters
+    ----------
+    from_mtype : str - mtype of object to convert from
+    to_mtypes : list of str - mtypes to convert to
+    varname : str - name of variable to_mtypes, for error message
+
+    Returns
+    -------
+    to_type : str - first mtype in to_mtypes that has same scitype as from_mtype
+    """
+    to_mtypes = _check_str_or_list_of_str(to_mtypes, obj_name=varname)
+    if not isinstance(to_mtypes, list):
+        raise TypeError(f"{varname} must be a str or a list of str")
+    # no conversion of from_type is in the list
+    if from_mtype in to_mtypes:
+        return from_mtype
+    # otherwise convert to first element of same scitype
+    scitype = mtype_to_scitype(from_mtype)
+    same_scitype_mtypes = [
+        mtype for mtype in to_mtypes if mtype_to_scitype(mtype) == scitype
+    ]
+    if len(same_scitype_mtypes) == 0:
+        raise TypeError(
+            f"{varname} contains no mtype compatible with the scitype of obj, "
+            f"which is {scitype}. Value of {varname} is: {to_mtypes}"
+        )
+    to_type = same_scitype_mtypes[0]
+    return to_type
 
 
 def _conversions_defined(scitype: str):

--- a/skpro/datatypes/_convert.py
+++ b/skpro/datatypes/_convert.py
@@ -136,6 +136,10 @@ def convert(
     )
 
     # input type checks
+    if not (
+        isinstance(to_type, list) and all(isinstance(item, str) for item in to_type)
+    ) and not isinstance(to_type, str):
+        raise TypeError("to_type must be a str or list of str")
     if not isinstance(from_type, str):
         raise TypeError("from_type must be a str")
     if as_scitype is None:
@@ -253,25 +257,6 @@ def convert_to(
     # now further narrow down as_scitype by inference from the obj
     from_type = infer_mtype(obj=obj, as_scitype=as_scitype)
     as_scitype = mtype_to_scitype(from_type)
-
-    # # if to_type is a list, we do the following:
-    # # if on the list, then don't do a conversion (convert to from_type)
-    # # if not on the list, we find and convert to first mtype that has same scitype
-    # if isinstance(to_type, list):
-    #     # no conversion of from_type is in the list
-    #     if from_type in to_type:
-    #         to_type = from_type
-    #     # otherwise convert to first element of same scitype
-    #     else:
-    #         same_scitype_mtypes = [
-    #             mtype for mtype in to_type if mtype_to_scitype(mtype) == as_scitype
-    #         ]
-    #         if len(same_scitype_mtypes) == 0:
-    #             raise TypeError(
-    #                 "to_type contains no mtype compatible with the scitype of obj,"
-    #                 f"which is {as_scitype}"
-    #             )
-    #         to_type = same_scitype_mtypes[0]
 
     converted_obj = convert(
         obj=obj,


### PR DESCRIPTION
As per requested by @fkiraly, we are updating the files `_check.py` and `_convert.py` to match functionality with the `sktime` library. Note that `_common.py` is exactly the same for both libraries, so no changes were needed. 

This pr also should allow list of strings to be accepted as valid `X_inner_mtype` and `y_inner_mtype`.

@fkiraly Could you please do a review to ensure that the code is correct?

Thanks!