### PR TITLE
[MNT] 2.5.0 deprecations and change actions

### DIFF
--- a/skpro/distributions/qpd.py
+++ b/skpro/distributions/qpd.py
@@ -89,9 +89,7 @@ class QPD_Johnson(_DelegatedDistribution):
         qv_high: float | Sequence,
         lower: float | None = None,
         upper: float | None = None,
-        version: str = "deprecated",
         base_dist: str | None = "normal",
-        dist_shape: float = 0.0,
         index=None,
         columns=None,
     ):
@@ -101,37 +99,13 @@ class QPD_Johnson(_DelegatedDistribution):
         self.qv_high = qv_high
         self.lower = lower
         self.upper = upper
-        self.version = version
         self.base_dist = base_dist
-        self.dist_shape = dist_shape
         self.index = index
         self.columns = columns
 
-        # TODO <2.5.0>: rename parameter 'version' to 'base_dist
-        # TODO <2.5.0>: remove parameter 'dist_shape'
-        # TODO <2.5.0>: update docstring, and remove warning
-        message = (
-            "In QPD_Johnson, parameter 'dist_shape' will be removed in version 2.5.0."
-            "To retain the current behavior, set parameters in the base_dist "
-            "argument."
-        )
-        if self.dist_shape != 0.0:
-            warnings.warn(message, DeprecationWarning, stacklevel=2)
-
-        message = (
-            "In QPD_Johnson, parameter 'version' will be renamed to 'base_dist' "
-            "in version 2.5.0. To retain the current behavior, pass the base_dist "
-            "argument instead."
-        )
-        if self.version != "deprecated":
-            warnings.warn(message, DeprecationWarning, stacklevel=2)
-            self._base_dist = self.version
-        else:
-            self._base_dist = self.base_dist
-
         if lower is None:
             delegate_cls = QPD_U
-            extra_params = {"dist_shape": dist_shape}
+            extra_params = {}
         elif upper is None:
             delegate_cls = QPD_S
             extra_params = {"lower": lower}
@@ -144,7 +118,7 @@ class QPD_Johnson(_DelegatedDistribution):
             "qv_low": qv_low,
             "qv_median": qv_median,
             "qv_high": qv_high,
-            "version": self._base_dist,
+            "base_dist": base_dist,
             "index": index,
             "columns": columns,
             **extra_params,
@@ -162,14 +136,14 @@ class QPD_Johnson(_DelegatedDistribution):
         """Return testing parameter settings for the estimator."""
         params1 = {
             "alpha": 0.2,
-            "version": "normal",
+            "base_dist": "normal",
             "qv_low": 0.2,
             "qv_median": 0.5,
             "qv_high": 0.8,
         }
         params2 = {
             "alpha": 0.1,
-            "version": "normal",
+            "base_dist": "normal",
             "qv_low": [[-0.3], [-0.2], [-0.1]],
             "qv_median": [[-0.1], [0.0], [0.1]],
             "qv_high": [[0.2], [0.3], [0.4]],
@@ -178,7 +152,7 @@ class QPD_Johnson(_DelegatedDistribution):
         }
         params3 = {
             "alpha": 0.1,
-            "version": "normal",
+            "base_dist": "normal",
             "qv_low": [0.1, 0.2, 0.3],
             "qv_median": [0.4, 0.5, 0.6],
             "qv_high": [0.7, 0.8, 0.9],
@@ -186,7 +160,7 @@ class QPD_Johnson(_DelegatedDistribution):
         }
         params4 = {
             "alpha": 0.12,
-            "version": "logistic",
+            "base_dist": "logistic",
             "qv_low": [0.15, 0.1, 0.15],
             "qv_median": [0.45, 0.51, 0.54],
             "qv_high": [0.85, 0.83, 0.81],
@@ -252,7 +226,6 @@ class QPD_S(BaseDistribution):
             "qv_median",
             "qv_high",
             "lower",
-            "upper",
         ],
     }
 
@@ -263,8 +236,6 @@ class QPD_S(BaseDistribution):
         qv_median: float | Sequence,
         qv_high: float | Sequence,
         lower: float,
-        upper: float = 1e3,
-        version: str = "deprecated",
         base_dist: str | None = "normal",
         index=None,
         columns=None,
@@ -274,38 +245,14 @@ class QPD_S(BaseDistribution):
         self.qv_median = qv_median
         self.qv_high = qv_high
         self.lower = lower
-        self.upper = upper
-        self.version = version
         self.base_dist = base_dist
         self.index = index
         self.columns = columns
 
-        # TODO <2.5.0>: rename parameter 'version' to 'base_dist
-        # TODO <2.5.0>: remove parameter 'upper'
-        # TODO <2.5.0>: update docstring, and remove warning
-        message = (
-            "In QPD_S, parameter 'version' will be renamed to 'base_dist' "
-            "in version 2.5.0. To retain the current behavior, pass the base_dist "
-            "argument instead."
-        )
-        if self.version != "deprecated":
-            warnings.warn(message, DeprecationWarning, stacklevel=2)
-            self._base_dist = self.version
-        else:
-            self._base_dist = self.base_dist
-
-        message = (
-            "In QPD_S, parameter 'upper' will be removed "
-            "in version 2.5.0. The parameter has no effect in the current version, "
-            "and should be removed entirely."
-        )
-        if self.upper != 1e3:
-            warnings.warn(message, DeprecationWarning, stacklevel=2)
-
         super().__init__(index=index, columns=columns)
 
         # precompute parameters for methods
-        phi = _resolve_phi(self._base_dist)
+        phi = _resolve_phi(self.base_dist)
         self.phi = phi
 
         qpd_params = _prep_qpd_vars(phi=phi, mode="S", **self._bc_params)
@@ -380,7 +327,7 @@ class QPD_S(BaseDistribution):
         """Return testing parameter settings for the estimator."""
         params1 = {
             "alpha": 0.2,
-            "version": "normal",
+            "base_dist": "normal",
             "qv_low": -0.3,
             "qv_median": 0.0,
             "qv_high": 0.3,
@@ -390,7 +337,7 @@ class QPD_S(BaseDistribution):
         }
         params2 = {
             "alpha": 0.2,
-            "version": "normal",
+            "base_dist": "normal",
             "qv_low": [[-0.3], [-0.2], [-0.1]],
             "qv_median": [[-0.1], [0.0], [0.1]],
             "qv_high": [[0.2], [0.3], [0.4]],
@@ -470,7 +417,6 @@ class QPD_B(BaseDistribution):
         qv_high: float | Sequence,
         lower: float,
         upper: float,
-        version: str = "deprecated",
         base_dist: str | None = "normal",
         index=None,
         columns=None,
@@ -481,28 +427,14 @@ class QPD_B(BaseDistribution):
         self.qv_high = qv_high
         self.lower = lower
         self.upper = upper
-        self.version = version
         self.base_dist = base_dist
         self.index = index
         self.columns = columns
 
-        # TODO <2.5.0>: rename parameter 'version' to 'base_dist
-        # TODO <2.5.0>: update docstring, and remove warning
-        message = (
-            "In QPD_B, parameter 'version' will be renamed to 'base_dist' "
-            "in version 2.5.0. To retain the current behavior, pass the base_dist "
-            "argument instead."
-        )
-        if self.version != "deprecated":
-            warnings.warn(message, DeprecationWarning, stacklevel=2)
-            self._base_dist = self.version
-        else:
-            self._base_dist = self.base_dist
-
         super().__init__(index=index, columns=columns)
 
         # precompute parameters for methods
-        phi = _resolve_phi(self._base_dist)
+        phi = _resolve_phi(self.base_dist)
         self.phi = phi
 
         qpd_params = _prep_qpd_vars(phi=phi, mode="B", **self._bc_params)
@@ -579,7 +511,7 @@ class QPD_B(BaseDistribution):
         """Return testing parameter settings for the estimator."""
         params1 = {
             "alpha": 0.2,
-            "version": "normal",
+            "base_dist": "normal",
             "qv_low": -0.3,
             "qv_median": 0.0,
             "qv_high": 0.3,
@@ -590,7 +522,7 @@ class QPD_B(BaseDistribution):
         }
         params2 = {
             "alpha": 0.2,
-            "version": "normal",
+            "base_dist": "normal",
             "qv_low": [[-0.3], [-0.2], [-0.1]],
             "qv_median": [[-0.1], [0.0], [0.1]],
             "qv_high": [[0.2], [0.3], [0.4]],
@@ -654,8 +586,6 @@ class QPD_U(BaseDistribution):
             "qv_low",
             "qv_median",
             "qv_high",
-            "lower",
-            "upper",
         ],
     }
 
@@ -665,11 +595,7 @@ class QPD_U(BaseDistribution):
         qv_low: float | Sequence,
         qv_median: float | Sequence,
         qv_high: float | Sequence,
-        lower: float = -1e3,
-        upper: float = 1e3,
-        version: str = "deprecated",
         base_dist: str | None = "normal",
-        dist_shape: float = 0.0,
         index=None,
         columns=None,
     ):
@@ -678,58 +604,14 @@ class QPD_U(BaseDistribution):
         self.qv_low = qv_low
         self.qv_median = qv_median
         self.qv_high = qv_high
-        self.lower = lower
-        self.upper = upper
-        self.version = version
         self.base_dist = base_dist
-        self.dist_shape = dist_shape
         self.index = index
         self.columns = columns
-
-        # TODO <2.5.0>: rename parameter 'version' to 'base_dist
-        # TODO <2.5.0>: remove parameter 'dist_shape'
-        # TODO <2.5.0>: remove parameter 'upper'
-        # TODO <2.5.0>: remove parameter 'lower'
-        # TODO <2.5.0>: update docstring, and remove warning
-        message = (
-            "In QPD_U, parameter 'dist_shape' will be removed in version 2.5.0."
-            "To retain the current behavior, set parameters in the base_dist "
-            "argument."
-        )
-        if self.dist_shape != 0.0:
-            warnings.warn(message, DeprecationWarning, stacklevel=2)
-
-        message = (
-            "In QPD_U, parameter 'version' will be renamed to 'base_dist' "
-            "in version 2.5.0. To retain the current behavior, pass the base_dist "
-            "argument instead."
-        )
-        if self.version != "deprecated":
-            warnings.warn(message, DeprecationWarning, stacklevel=2)
-            self._base_dist = self.version
-        else:
-            self._base_dist = self.base_dist
-
-        message = (
-            "In QPD_U, parameter 'upper' will be removed "
-            "in version 2.5.0. The parameter has no effect in the current version, "
-            "and should be removed entirely."
-        )
-        if self.upper != 1e3:
-            warnings.warn(message, DeprecationWarning, stacklevel=2)
-
-        message = (
-            "In QPD_U, parameter 'lower' will be removed "
-            "in version 2.5.0. The parameter has no effect in the current version, "
-            "and should be removed entirely."
-        )
-        if self.lower != -1e3:
-            warnings.warn(message, DeprecationWarning, stacklevel=2)
 
         super().__init__(index=index, columns=columns)
 
         # precompute parameters for methods
-        phi = _resolve_phi(self._base_dist)
+        phi = _resolve_phi(self.base_dist)
         self.phi = phi
 
         qpd_params = _prep_qpd_vars(phi=phi, mode="U", **self._bc_params)
@@ -791,7 +673,7 @@ class QPD_U(BaseDistribution):
         """Return testing parameter settings for the estimator."""
         params1 = {
             "alpha": 0.2,
-            "version": "normal",
+            "base_dist": "normal",
             "qv_low": -0.3,
             "qv_median": 0.0,
             "qv_high": 0.3,
@@ -800,7 +682,7 @@ class QPD_U(BaseDistribution):
         }
         params2 = {
             "alpha": 0.2,
-            "version": "normal",
+            "base_dist": "normal",
             "qv_low": [[-0.3], [-0.2], [-0.1]],
             "qv_median": [[-0.1], [0.0], [0.1]],
             "qv_high": [[0.2], [0.3], [0.4]],

--- a/skpro/distributions/qpd.py
+++ b/skpro/distributions/qpd.py
@@ -9,7 +9,6 @@ __author__ = [
     "setoguchi-naoki",
 ]  # interface only. Cyclic boosting authors in cyclic_boosting package
 
-import warnings
 from typing import Sequence
 
 import numpy as np

--- a/skpro/distributions/qpd.py
+++ b/skpro/distributions/qpd.py
@@ -706,10 +706,10 @@ def _prep_qpd_vars(
     qv_low,
     qv_median,
     qv_high,
-    lower,
-    upper,
     phi,
     mode="B",
+    lower=None,
+    upper=None,
     **kwargs,
 ):
     """Prepare parameters for Johnson Quantile-Parameterized Distributions.

--- a/skpro/model_selection/_tuning.py
+++ b/skpro/model_selection/_tuning.py
@@ -22,13 +22,10 @@ class BaseGridSearch(_DelegatedProbaRegressor):
         "capability:missing": True,
     }
 
-    # todo 2.5.0: remove pre_dispatch and n_jobs params
     def __init__(
         self,
         estimator,
         cv,
-        n_jobs=None,
-        pre_dispatch=None,
         backend="loky",
         refit=True,
         scoring=None,
@@ -39,8 +36,6 @@ class BaseGridSearch(_DelegatedProbaRegressor):
     ):
         self.estimator = estimator
         self.cv = cv
-        self.n_jobs = n_jobs
-        self.pre_dispatch = pre_dispatch
         self.backend = backend
         self.refit = refit
         self.scoring = scoring
@@ -117,23 +112,8 @@ class BaseGridSearch(_DelegatedProbaRegressor):
         scoring = self.scoring
         scoring_name = f"test_{scoring.name}"
 
-        # todo 2.5.0: remove this logic and only use backend_params
         backend = self.backend
         backend_params = self.backend_params if self.backend_params else {}
-        if backend in ["threading", "multiprocessing", "loky"]:
-            n_jobs = self.n_jobs
-            pre_dispatch = self.pre_dispatch
-            backend_params["n_jobs"] = n_jobs
-            backend_params["pre_dispatch"] = pre_dispatch
-            if n_jobs is not None or pre_dispatch is not None:
-                warn(
-                    f"in {self.__class__.__name__}, n_jobs and pre_dispatch "
-                    "parameters in skpro GridSearchCV and RandomizedSearchCV "
-                    "are deprecated and will be removed in skpro 2.5.0. "
-                    "Please use n_jobs and pre_dispatch directly in the backend_params "
-                    "argument instead.",
-                    stacklevel=2,
-                )
 
         def _fit_and_score(params, meta):
             # Clone estimator.
@@ -256,7 +236,6 @@ class BaseGridSearch(_DelegatedProbaRegressor):
         return getattr(self, self._delegate_name)
 
 
-# todo 2.5.0: remove pre_dispatch and n_jobs params
 class GridSearchCV(BaseGridSearch):
     """Perform grid-search cross-validation to find optimal model parameters.
 
@@ -302,22 +281,21 @@ class GridSearchCV(BaseGridSearch):
 
         * If None, defaults to CRPS()
 
-    n_jobs: int, optional (default=None)
-        Number of jobs to run in parallel.
-        None means 1 unless in a joblib.parallel_backend context.
-        -1 means using all processors.
     refit : bool, optional (default=True)
         True = refit the estimator with the best parameters on the entire data in fit
         False = no refitting takes place. The estimator cannot be used to predict.
         This is to be used to tune the hyperparameters, and then use the estimator
         as a parameter estimator, e.g., via get_fitted_params or PluginParamsestimator.
+
     verbose: int, optional (default=0)
+
     return_n_best_estimators : int, default=1
         In case the n best estimator should be returned, this value can be set
         and the n best estimators will be assigned to n_best_estimators_
-    pre_dispatch : str, optional (default='2*n_jobs')
+
     error_score : numeric value or the str 'raise', optional (default=np.nan)
         The test score returned when a estimator fails to be fitted.
+
     return_train_score : bool, optional (default=False)
 
     backend : {"dask", "loky", "multiprocessing", "threading"}, by default "loky".
@@ -416,11 +394,9 @@ class GridSearchCV(BaseGridSearch):
         cv,
         param_grid,
         scoring=None,
-        n_jobs=None,
         refit=True,
         verbose=0,
         return_n_best_estimators=1,
-        pre_dispatch="2*n_jobs",
         backend="loky",
         error_score=np.nan,
         backend_params=None,
@@ -428,12 +404,10 @@ class GridSearchCV(BaseGridSearch):
         super().__init__(
             estimator=estimator,
             scoring=scoring,
-            n_jobs=n_jobs,
             refit=refit,
             cv=cv,
             verbose=verbose,
             return_n_best_estimators=return_n_best_estimators,
-            pre_dispatch=pre_dispatch,
             backend=backend,
             error_score=error_score,
             backend_params=backend_params,
@@ -521,7 +495,6 @@ class GridSearchCV(BaseGridSearch):
         return params
 
 
-# todo 2.5.0: remove pre_dispatch and n_jobs params
 class RandomizedSearchCV(BaseGridSearch):
     """Perform randomized-search cross-validation to find optimal model parameters.
 
@@ -576,26 +549,23 @@ class RandomizedSearchCV(BaseGridSearch):
 
         * If None, defaults to CRPS()
 
-    n_jobs : int, optional (default=None)
-        Number of jobs to run in parallel.
-        None means 1 unless in a joblib.parallel_backend context.
-        -1 means using all processors.
     refit : bool, optional (default=True)
         True = refit the estimator with the best parameters on the entire data in fit
         False = no refitting takes place. The estimator cannot be used to predict.
         This is to be used to tune the hyperparameters, and then use the estimator
         as a parameter estimator, e.g., via get_fitted_params or PluginParamsestimator.
+
     verbose : int, optional (default=0)
+
     return_n_best_estimators: int, default=1
         In case the n best estimator should be returned, this value can be set
         and the n best estimators will be assigned to n_best_estimators_
-    pre_dispatch : str, optional (default='2*n_jobs')
+
     random_state : int, RandomState instance or None, default=None
         Pseudo random number generator state used for random uniform sampling
         from lists of possible values instead of scipy.stats distributions.
         Pass an int for reproducible output across multiple
         function calls.
-    pre_dispatch : str, optional (default='2*n_jobs')
 
     backend : {"dask", "loky", "multiprocessing", "threading"}, by default "loky".
         Runs parallel evaluate if specified and `strategy` is set as "refit".
@@ -688,26 +658,20 @@ class RandomizedSearchCV(BaseGridSearch):
         param_distributions,
         n_iter=10,
         scoring=None,
-        n_jobs=None,
         refit=True,
         verbose=0,
         return_n_best_estimators=1,
         random_state=None,
-        pre_dispatch="2*n_jobs",
-        backend="loky",
         error_score=np.nan,
         backend_params=None,
     ):
         super().__init__(
             estimator=estimator,
             scoring=scoring,
-            n_jobs=n_jobs,
             refit=refit,
             cv=cv,
             verbose=verbose,
             return_n_best_estimators=return_n_best_estimators,
-            pre_dispatch=pre_dispatch,
-            backend=backend,
             error_score=error_score,
             backend_params=backend_params,
         )

--- a/skpro/model_selection/_tuning.py
+++ b/skpro/model_selection/_tuning.py
@@ -4,8 +4,6 @@
 __author__ = ["fkiraly"]
 __all__ = ["GridSearchCV", "RandomizedSearchCV"]
 
-from warnings import warn
-
 import numpy as np
 import pandas as pd
 from sklearn.model_selection import ParameterGrid, ParameterSampler, check_cv

--- a/skpro/regression/linear/_glm.py
+++ b/skpro/regression/linear/_glm.py
@@ -238,69 +238,12 @@ class GLMRegressor(BaseProbaRegressor):
 
         return sm_fmly[family]()
 
-    # TODO (release 2.5.0)
-    # replace the existing definition of `__init__` with
-    # the below definition for `__init__`.
-    # def __init__(
-    #     self,
-    #     family="Normal",
-    #     link=None,
-    #     offset_var=None,
-    #     exposure_var=None,
-    #     missing="none",
-    #     start_params=None,
-    #     maxiter=100,
-    #     method="IRLS",
-    #     tol=1e-8,
-    #     scale=None,
-    #     cov_type="nonrobust",
-    #     cov_kwds=None,
-    #     use_t=None,
-    #     full_output=True,
-    #     disp=False,
-    #     max_start_irls=3,
-    #     add_constant=False,
-    # ):
-    #     super().__init__()
-
-    #     self.family = family
-    #     self.link = link
-    #     self.offset_var = offset_var
-    #     self.exposure_var = exposure_var
-    #     self.missing = missing
-    #     self.start_params = start_params
-    #     self.maxiter = maxiter
-    #     self.method = method
-    #     self.tol = tol
-    #     self.scale = scale
-    #     self.cov_type = cov_type
-    #     self.cov_kwds = cov_kwds
-    #     self.use_t = use_t
-    #     self.full_output = full_output
-    #     self.disp = disp
-    #     self.max_start_irls = max_start_irls
-    #     self.add_constant = add_constant
-
-    #     self._family = self.family
-    #     self._link = self.link
-    #     self._offset_var = self.offset_var
-    #     self._exposure_var = self.exposure_var
-    #     self._missing = self.missing
-    #     self._start_params = self.start_params
-    #     self._maxiter = self.maxiter
-    #     self._method = self.method
-    #     self._tol = self.tol
-    #     self._scale = self.scale
-    #     self._cov_type = self.cov_type
-    #     self._cov_kwds = self.cov_kwds
-    #     self._use_t = self.use_t
-    #     self._full_output = self.full_output
-    #     self._disp = self.disp
-    #     self._max_start_irls = self.max_start_irls
-    #     self._add_constant = self.add_constant
-
     def __init__(
         self,
+        family="Normal",
+        link=None,
+        offset_var=None,
+        exposure_var=None,
         missing="none",
         start_params=None,
         maxiter=100,
@@ -314,15 +257,7 @@ class GLMRegressor(BaseProbaRegressor):
         disp=False,
         max_start_irls=3,
         add_constant=False,
-        family="Normal",
-        link=None,
-        offset_var=None,
-        exposure_var=None,
     ):
-        # The default values of the parameters
-        # are replaced with the changed sequence
-        # of parameters ranking for each of them
-        # from 0 to 16(total 17 parameters).
         super().__init__()
 
         self.family = family
@@ -360,19 +295,6 @@ class GLMRegressor(BaseProbaRegressor):
         self._disp = self.disp
         self._max_start_irls = self.max_start_irls
         self._add_constant = self.add_constant
-
-        from warnings import warn
-
-        warn(
-            "Note: in `GLMRegressor`, the sequence of the parameters will change "
-            "in skpro version 2.5.0. It will be as per the order present in the"
-            "current docstring with the top one being the first parameter.\n"
-            "The defaults for the parameters will remain same and "
-            "there will be no changes.\n"
-            "Please use the `kwargs` calls instead of positional calls for the"
-            "parameters until the release of skpro 2.5.0 "
-            "as this will avoid any discrepancies."
-        )
 
     def _fit(self, X, y):
         """Fit regressor to training data.


### PR DESCRIPTION
Carries out deprecations and change actions scheduled for 2.5.0.

* in QPD distributions, remove `version` and `dist_shape` parameters
* in QPD distributions, remove `lower` and `upper` parameters where not used
* in `GLMRegressor`, reorder parameters as announced in warning
* in probabilistic regression tuners, remove `n_jobs` and `pre_dispatch` in favour of `backend` and `backend_params` parameters