### PR TITLE
[ENH] Polars adapter enhancements

### DIFF
--- a/skpro/datatypes/_adapter/polars.py
+++ b/skpro/datatypes/_adapter/polars.py
@@ -123,14 +123,22 @@ def convert_pandas_to_polars_with_index(
         index from pandas DataFrame will be returned as a polars column
         named __index__.
     """
+    import pandas as pd
     from polars import from_pandas
 
-    obj_index_name = obj.index.name
-    obj = obj.reset_index()
-    if obj_index_name is not None:
-        obj = obj.rename(columns={obj_index_name: f"__index__{obj_index_name}"})
-    else:
-        obj = obj.rename(columns={"index": "__index__"})
+    # if the index of the dataframe is the trivial index (i.e RangeIndex(0,numrows))
+    # we do not return an __index__ column
+    if not (
+        isinstance(obj.index, pd.RangeIndex)
+        and obj.index.start == 0
+        and obj.index.stop == len(obj)
+    ):
+        obj_index_name = obj.index.name
+        obj = obj.reset_index()
+        if obj_index_name is not None:
+            obj = obj.rename(columns={obj_index_name: f"__index__{obj_index_name}"})
+        else:
+            obj = obj.rename(columns={"index": "__index__"})
 
     pl_df = from_pandas(
         data=obj,

--- a/skpro/datatypes/_adapter/polars.py
+++ b/skpro/datatypes/_adapter/polars.py
@@ -72,6 +72,7 @@ def convert_polars_to_pandas_with_index(obj):
     for col in obj.columns:
         if col.startswith("__index__"):
             pd_df = pd_df.set_index(col, drop=True)
+            pd_df.index.name = col.split("__index__")[1]
 
     return pd_df
 

--- a/skpro/datatypes/_adapter/polars.py
+++ b/skpro/datatypes/_adapter/polars.py
@@ -34,7 +34,10 @@ def check_polars_frame(obj, return_metadata=False, var_name="obj", lazy=False):
     if _req("n_features", return_metadata):
         metadata["n_features"] = obj.width
     if _req("feature_names", return_metadata):
-        metadata["feature_names"] = obj.columns
+        if lazy:
+            metadata["feature_names"] = obj.collect_schema().names()
+        else:
+            metadata["feature_names"] = obj.columns
 
     # check if there are any nans
     #   compute only if needed

--- a/skpro/datatypes/_adapter/polars.py
+++ b/skpro/datatypes/_adapter/polars.py
@@ -69,8 +69,9 @@ def convert_polars_to_pandas_with_index(obj):
         obj = obj.collect()
 
     pd_df = obj.to_pandas()
-    if "__index__" in obj.columns:
-        pd_df = pd_df.set_index("__index__", drop=True)
+    for col in obj.columns:
+        if col.startswith("__index__"):
+            pd_df = pd_df.set_index(col, drop=True)
 
     return pd_df
 
@@ -104,8 +105,9 @@ def convert_pandas_to_polars_with_index(
     """
     from polars import from_pandas
 
+    obj_index_name = obj.index.name
     obj.reset_index()
-    obj.rename(columns={"index": "__index__"})
+    obj.rename(columns={obj_index_name: f"__index__{obj_index_name}"})
 
     pl_df = from_pandas(
         data=obj,

--- a/skpro/datatypes/_adapter/polars.py
+++ b/skpro/datatypes/_adapter/polars.py
@@ -36,7 +36,11 @@ def check_polars_frame(obj, return_metadata=False, var_name="obj", lazy=False):
         else:
             metadata["n_instances"] = "NA"
     if _req("n_features", return_metadata):
-        metadata["n_features"] = obj.width
+        obj_width = obj.width
+        for col in obj.columns:
+            if "__index__" in col:
+                obj_width -= 1
+        metadata["n_features"] = obj_width
     if _req("feature_names", return_metadata):
         if lazy:
             obj_columns = obj.collect_schema().names()

--- a/skpro/datatypes/_adapter/polars.py
+++ b/skpro/datatypes/_adapter/polars.py
@@ -107,8 +107,11 @@ def convert_pandas_to_polars_with_index(
     from polars import from_pandas
 
     obj_index_name = obj.index.name
-    obj.reset_index()
-    obj.rename(columns={obj_index_name: f"__index__{obj_index_name}"})
+    obj = obj.reset_index()
+    if obj_index_name is not None:
+        obj = obj.rename(columns={obj_index_name: f"__index__{obj_index_name}"})
+    else:
+        obj = obj.rename(columns={"index": "__index__"})
 
     pl_df = from_pandas(
         data=obj,

--- a/skpro/datatypes/_adapter/polars.py
+++ b/skpro/datatypes/_adapter/polars.py
@@ -107,7 +107,12 @@ def convert_pandas_to_polars_with_index(
     obj.reset_index()
     obj.rename(columns={"index": "__index__"})
 
-    pl_df = from_pandas(obj, schema_overrides, rechunk, nan_to_null)
+    pl_df = from_pandas(
+        data=obj,
+        schema_overrides=schema_overrides,
+        rechunk=rechunk,
+        nan_to_null=nan_to_null,
+    )
 
     if lazy:
         pl_df = pl_df.lazy()

--- a/skpro/datatypes/_adapter/polars.py
+++ b/skpro/datatypes/_adapter/polars.py
@@ -27,7 +27,7 @@ def check_polars_frame(obj, return_metadata=False, var_name="obj", lazy=False):
     if _req("is_univariate", return_metadata):
         obj_width = obj.width
         for col in obj.columns:
-            if col.startswith("__index__"):
+            if "__index__" in col:
                 obj_width -= 1
         metadata["is_univariate"] = obj_width == 1
     if _req("n_instances", return_metadata):

--- a/skpro/datatypes/_adapter/polars.py
+++ b/skpro/datatypes/_adapter/polars.py
@@ -46,3 +46,13 @@ def check_polars_frame(obj, return_metadata=False, var_name="obj", lazy=False):
             metadata["has_nans"] = hasnan
 
     return ret(True, None, metadata, return_metadata)
+
+
+def convert_polars_to_pandas():
+    """Convert function from polars to pandas."""
+    pass
+
+
+def convert_pandas_to_polars_eager():
+    """Convert function from pandas to polars eager."""
+    pass

--- a/skpro/datatypes/_table/_convert.py
+++ b/skpro/datatypes/_table/_convert.py
@@ -249,9 +249,6 @@ if _check_soft_dependencies(["polars", "pyarrow"], severity="none"):
         if not isinstance(obj, (pl.LazyFrame, pl.DataFrame)):
             raise TypeError("input is not a polars frame")
 
-        # if isinstance(obj, pl.LazyFrame):
-        #     obj = obj.collect().to_pandas()
-        # elif isinstance(obj, pl.DataFrame):
         obj = convert_polars_to_pandas_with_index(obj)
 
         return obj

--- a/skpro/datatypes/_table/_convert.py
+++ b/skpro/datatypes/_table/_convert.py
@@ -249,23 +249,24 @@ if _check_soft_dependencies(["polars", "pyarrow"], severity="none"):
         if not isinstance(obj, (pl.LazyFrame, pl.DataFrame)):
             raise TypeError("input is not a polars frame")
 
-        if isinstance(obj, pl.LazyFrame):
-            obj = obj.collect().to_pandas()
-        elif isinstance(obj, pl.DataFrame):
-            obj = convert_polars_to_pandas_with_index
+        # if isinstance(obj, pl.LazyFrame):
+        #     obj = obj.collect().to_pandas()
+        # elif isinstance(obj, pl.DataFrame):
+        obj = convert_polars_to_pandas_with_index(obj)
 
         return obj
 
     def convert_pandas_to_polars_eager(obj: pd.DataFrame, store=None):
         if not isinstance(obj, pd.DataFrame):
             raise TypeError("input is not a pd.DataFrame")
-        obj = convert_pandas_to_polars_with_index
+        obj = convert_pandas_to_polars_with_index(obj)
 
         return obj
 
     def convert_pandas_to_polars_lazy(obj: pd.DataFrame, store=None):
         if not isinstance(obj, pd.DataFrame):
             raise TypeError("input is not a pd.DataFrame")
+        obj = convert_pandas_to_polars_with_index(obj, lazy=True)
 
         return pl.LazyFrame(obj)
 

--- a/skpro/datatypes/_table/_convert.py
+++ b/skpro/datatypes/_table/_convert.py
@@ -240,20 +240,10 @@ _extend_conversions(
 if _check_soft_dependencies(["polars", "pyarrow"], severity="none"):
     import polars as pl
 
-    def convert_polars_to_pandas(obj, store=None):
-        if not isinstance(obj, (pl.LazyFrame, pl.DataFrame)):
-            raise TypeError("input is not a polars frame")
-
-        if isinstance(obj, pl.LazyFrame):
-            obj = obj.collect()
-
-        return obj.to_pandas()
-
-    def convert_pandas_to_polars_eager(obj: pd.DataFrame, store=None):
-        if not isinstance(obj, pd.DataFrame):
-            raise TypeError("input is not a pd.DataFrame")
-
-        return pl.DataFrame(obj)
+    from skpro.datatypes._adapter.polars import (
+        convert_pandas_to_polars_eager,
+        convert_polars_to_pandas,
+    )
 
     def convert_pandas_to_polars_lazy(obj: pd.DataFrame, store=None):
         if not isinstance(obj, pd.DataFrame):

--- a/skpro/datatypes/_table/_convert.py
+++ b/skpro/datatypes/_table/_convert.py
@@ -241,9 +241,27 @@ if _check_soft_dependencies(["polars", "pyarrow"], severity="none"):
     import polars as pl
 
     from skpro.datatypes._adapter.polars import (
-        convert_pandas_to_polars_eager,
-        convert_polars_to_pandas,
+        convert_pandas_to_polars_with_index,
+        convert_polars_to_pandas_with_index,
     )
+
+    def convert_polars_to_pandas(obj, store=None):
+        if not isinstance(obj, (pl.LazyFrame, pl.DataFrame)):
+            raise TypeError("input is not a polars frame")
+
+        if isinstance(obj, pl.LazyFrame):
+            obj = obj.collect().to_pandas()
+        elif isinstance(obj, pl.DataFrame):
+            obj = convert_polars_to_pandas_with_index
+
+        return obj
+
+    def convert_pandas_to_polars_eager(obj: pd.DataFrame, store=None):
+        if not isinstance(obj, pd.DataFrame):
+            raise TypeError("input is not a pd.DataFrame")
+        obj = convert_pandas_to_polars_with_index
+
+        return obj
 
     def convert_pandas_to_polars_lazy(obj: pd.DataFrame, store=None):
         if not isinstance(obj, pd.DataFrame):

--- a/skpro/datatypes/_table/_convert.py
+++ b/skpro/datatypes/_table/_convert.py
@@ -268,7 +268,7 @@ if _check_soft_dependencies(["polars", "pyarrow"], severity="none"):
             raise TypeError("input is not a pd.DataFrame")
         obj = convert_pandas_to_polars_with_index(obj, lazy=True)
 
-        return pl.LazyFrame(obj)
+        return obj
 
     def convert_polars_eager_to_lazy(obj: pl.DataFrame, store=None) -> pl.LazyFrame:
         if not isinstance(obj, pl.DataFrame):

--- a/skpro/datatypes/_table/_examples.py
+++ b/skpro/datatypes/_table/_examples.py
@@ -110,12 +110,16 @@ example_dict[("list_of_dict", "Table", 1)] = list_of_dict
 example_dict_lossy[("list_of_dict", "Table", 1)] = False
 
 if _check_soft_dependencies(["polars", "pyarrow"], severity="none"):
-    import polars as pl
+    from skpro.datatypes._adapter.polars import convert_pandas_to_polars_with_index
 
-    example_dict[("polars_eager_table", "Table", 1)] = pl.DataFrame(df)
+    example_dict[
+        ("polars_eager_table", "Table", 1)
+    ] = convert_pandas_to_polars_with_index(df)
     example_dict_lossy[("polars_eager_table", "Table", 1)] = False
 
-    example_dict[("polars_lazy_table", "Table", 1)] = pl.LazyFrame(df)
+    example_dict[
+        ("polars_lazy_table", "Table", 1)
+    ] = convert_pandas_to_polars_with_index(df, lazy=True)
     example_dict_lossy[("polars_lazy_table", "Table", 1)] = False
 
 example_dict_metadata[("Table", 1)] = {

--- a/skpro/datatypes/_table/_examples.py
+++ b/skpro/datatypes/_table/_examples.py
@@ -59,12 +59,16 @@ example_dict[("list_of_dict", "Table", 0)] = list_of_dict
 example_dict_lossy[("list_of_dict", "Table", 0)] = False
 
 if _check_soft_dependencies(["polars", "pyarrow"], severity="none"):
-    import polars as pl
+    from skpro.datatypes._adapter.polars import convert_pandas_to_polars_with_index
 
-    example_dict[("polars_eager_table", "Table", 0)] = pl.DataFrame(df)
+    example_dict[
+        ("polars_eager_table", "Table", 0)
+    ] = convert_pandas_to_polars_with_index(df)
     example_dict_lossy[("polars_eager_table", "Table", 0)] = False
 
-    example_dict[("polars_lazy_table", "Table", 0)] = pl.LazyFrame(df)
+    example_dict[
+        ("polars_lazy_table", "Table", 0)
+    ] = convert_pandas_to_polars_with_index(df, lazy=True)
     example_dict_lossy[("polars_lazy_table", "Table", 0)] = False
 
 example_dict_metadata[("Table", 0)] = {

--- a/skpro/datatypes/tests/test_polars.py
+++ b/skpro/datatypes/tests/test_polars.py
@@ -50,6 +50,20 @@ def polars_load_diabetes_polars(polars_load_diabetes_pandas):
     X_test_pl = convert_pandas_to_polars_eager(X_test)
     y_train_pl = convert_pandas_to_polars_eager(y_train)
 
+    # drop the index in the polars frame
+    X_train_pl = X_train_pl.drop(["__index__"])
+    X_test_pl = X_test_pl.drop(["__index__"])
+    y_train_pl = y_train_pl.drop(["__index__"])
+
+    return [X_train_pl, X_test_pl, y_train_pl]
+
+
+def polars_load_diabetes_polars_with_index(polars_load_diabetes_pandas):
+    X_train, X_test, y_train = polars_load_diabetes_pandas
+    X_train_pl = convert_pandas_to_polars_eager(X_train)
+    X_test_pl = convert_pandas_to_polars_eager(X_test)
+    y_train_pl = convert_pandas_to_polars_eager(y_train)
+
     return [X_train_pl, X_test_pl, y_train_pl]
 
 
@@ -72,6 +86,7 @@ def test_polars_eager_conversion_methods(
     assert check_polars_table(X_train_pl)
     assert check_polars_table(X_test_pl)
     assert check_polars_table(y_train_pl)
+
     assert (X_train.values == X_train_pl.to_numpy()).all()
     assert (X_test.values == X_test_pl.to_numpy()).all()
     assert (y_train.values == y_train_pl.to_numpy()).all()
@@ -103,6 +118,7 @@ def test_polars_eager_regressor_in_fit_predict(
 
     estimator.fit(X_train_pl, y_train_pl)
     y_pred = estimator.predict(X_test_pl)
+    y_pred = y_pred.drop(["__index__"])
 
     assert isinstance(y_pred, pl.DataFrame)
     assert y_pred.columns == y_train_pl.columns

--- a/skpro/datatypes/tests/test_polars.py
+++ b/skpro/datatypes/tests/test_polars.py
@@ -118,7 +118,6 @@ def test_polars_eager_regressor_in_fit_predict(
 
     estimator.fit(X_train_pl, y_train_pl)
     y_pred = estimator.predict(X_test_pl)
-    y_pred = y_pred.drop(["__index__"])
 
     assert isinstance(y_pred, pl.DataFrame)
     assert y_pred.columns == y_train_pl.columns


### PR DESCRIPTION
adds index support as part of #440 and is used to sync up polars conversion utilities between skpro and sktime.

Correponding sktime pr for polars conversion utilities is https://github.com/sktime/sktime/pull/6455/.

In this pr:

If a pandas Dataframe is a `from_type` and polars frame is a `to_type` then during the conversion, we will save the index (assumed never to be in multi-index format) and insert it as an individual column with column name `__index__`. Then the resulting pandas dataframe will be converted to a polars dataframe.

In the inverse function, if we are converting from polars dataframe to pandas dataframe, if the column `__index__` exists in the pandas dataframe post-conversion, then we will map that column to the index before returning the pandas Dataframe

After this is merged, #447 will be implemented as a `polars` only estimator. tests will also be written to check polars input end to end and pandas input and output through the polars estimator (i.e pandas input into polars estimator -> polars predictions -> pandas output)