### PR TITLE
[ENH] refactor `datatypes` mtypes - example fixtures

### DIFF
--- a/skpro/datatypes/_base/__init__.py
+++ b/skpro/datatypes/_base/__init__.py
@@ -1,5 +1,5 @@
 """Base module for datatypes."""
 
-from skpro.datatypes._base._base import BaseConverter, BaseDatatype
+from skpro.datatypes._base._base import BaseConverter, BaseDatatype, BaseExample
 
-__all__ = ["BaseConverter", "BaseDatatype"]
+__all__ = ["BaseConverter", "BaseDatatype", "BaseExample"]

--- a/skpro/datatypes/_base/_base.py
+++ b/skpro/datatypes/_base/_base.py
@@ -328,6 +328,43 @@ class BaseConverter(BaseObject):
         return (mtype_from, mtype_to, scitype)
 
 
+class BaseExample(BaseObject):
+    """Base class for Example fixtures used in tests and get_examples."""
+
+    _tags = {
+        "object_type": "datatype_example",
+        "scitype": None,
+        "mtype": None,
+        "python_version": None,
+        "python_dependencies": None,
+        "index": None,  # integer index of the example to match with other mtypes
+        "lossy": False,  # whether the example is lossy
+    }
+
+    def __init__(self):
+        super().__init__()
+
+    def _get_key(self):
+        """Get unique dictionary key corresponding to self.
+
+        Private function, used in collecting a dictionary of examples.
+        """
+        mtype = self.get_class_tag("mtype")
+        scitype = self.get_class_tag("scitype")
+        index = self.get_class_tag("index")
+        return (mtype, scitype, index)
+
+    def build(self):
+        """Build example.
+
+        Returns
+        -------
+        obj : any
+            Example object.
+        """
+        raise NotImplementedError
+
+
 def _coerce_str_to_cls(cls_or_str):
     """Get class from string.
 

--- a/skpro/datatypes/_examples.py
+++ b/skpro/datatypes/_examples.py
@@ -23,12 +23,6 @@ __all__ = [
     "get_examples",
 ]
 
-from skpro.datatypes._proba import (
-    example_dict_lossy_Proba,
-    example_dict_metadata_Proba,
-    example_dict_Proba,
-)
-
 
 @lru_cache(maxsize=1)
 def generate_example_dicts(soft_deps="present"):

--- a/skpro/datatypes/_examples.py
+++ b/skpro/datatypes/_examples.py
@@ -13,8 +13,6 @@ the representation is considered "lossy" if the representation is incomplete
     e.g., metadata such as column names are missing
 """
 
-from functools import lru_cache
-
 from skpro.datatypes._registry import mtype_to_scitype
 
 __author__ = ["fkiraly"]
@@ -24,7 +22,6 @@ __all__ = [
 ]
 
 
-@lru_cache(maxsize=1)
 def generate_example_dicts(soft_deps="present"):
     """Generate example dicts using lookup."""
     from skbase.utils.dependencies import _check_estimator_deps

--- a/skpro/datatypes/_examples.py
+++ b/skpro/datatypes/_examples.py
@@ -48,7 +48,7 @@ def generate_example_dicts(soft_deps="present"):
         k = cls()
         key = k._get_key()
         key_meta = (key[1], key[2])
-        example_dict[key] = k
+        example_dict[key] = k.build()
         example_dict_lossy[key] = k.get_class_tags().get("lossy", False)
         example_dict_metadata[key_meta] = k.get_class_tags().get("metadata", {})
 

--- a/skpro/datatypes/_examples.py
+++ b/skpro/datatypes/_examples.py
@@ -58,11 +58,6 @@ def generate_example_dicts(soft_deps="present"):
         example_dict_lossy[key] = k.get_class_tags().get("lossy", False)
         example_dict_metadata[key_meta] = k.get_class_tags().get("metadata", {})
 
-    # temporary while refactoring
-    example_dict.update(example_dict_Proba)
-    example_dict_lossy.update(example_dict_lossy_Proba)
-    example_dict_metadata.update(example_dict_metadata_Proba)
-
     return example_dict, example_dict_lossy, example_dict_metadata
 
 

--- a/skpro/datatypes/_examples.py
+++ b/skpro/datatypes/_examples.py
@@ -13,6 +13,8 @@ the representation is considered "lossy" if the representation is incomplete
     e.g., metadata such as column names are missing
 """
 
+from functools import lru_cache
+
 from skpro.datatypes._registry import mtype_to_scitype
 
 __author__ = ["fkiraly"]
@@ -22,6 +24,7 @@ __all__ = [
 ]
 
 
+@lru_cache(maxsize=1)
 def generate_example_dicts(soft_deps="present"):
     """Generate example dicts using lookup."""
     from skbase.utils.dependencies import _check_estimator_deps
@@ -45,7 +48,7 @@ def generate_example_dicts(soft_deps="present"):
         k = cls()
         key = k._get_key()
         key_meta = (key[1], key[2])
-        example_dict[key] = k.build()
+        example_dict[key] = k
         example_dict_lossy[key] = k.get_class_tags().get("lossy", False)
         example_dict_metadata[key_meta] = k.get_class_tags().get("metadata", {})
 
@@ -96,14 +99,14 @@ def get_examples(
 
     for k in keys:
         if return_lossy:
-            fixtures[k[2]] = (example_dict.get(k), example_dict_lossy.get(k))
+            fixtures[k[2]] = (example_dict.get(k).build(), example_dict_lossy.get(k))
         elif return_metadata:
             fixtures[k[2]] = (
-                example_dict.get(k),
+                example_dict.get(k).build(),
                 example_dict_lossy.get(k),
                 example_dict_metadata.get((k[1], k[2])),
             )
         else:
-            fixtures[k[2]] = example_dict.get(k)
+            fixtures[k[2]] = example_dict.get(k).build()
 
     return fixtures

--- a/skpro/datatypes/_proba/__init__.py
+++ b/skpro/datatypes/_proba/__init__.py
@@ -2,13 +2,6 @@
 
 from skpro.datatypes._proba._check import check_dict as check_dict_Proba
 from skpro.datatypes._proba._convert import convert_dict as convert_dict_Proba
-from skpro.datatypes._proba._examples import example_dict as example_dict_Proba
-from skpro.datatypes._proba._examples import (
-    example_dict_lossy as example_dict_lossy_Proba,
-)
-from skpro.datatypes._proba._examples import (
-    example_dict_metadata as example_dict_metadata_Proba,
-)
 from skpro.datatypes._proba._registry import MTYPE_LIST_PROBA, MTYPE_REGISTER_PROBA
 
 __all__ = [
@@ -16,7 +9,4 @@ __all__ = [
     "convert_dict_Proba",
     "MTYPE_LIST_PROBA",
     "MTYPE_REGISTER_PROBA",
-    "example_dict_Proba",
-    "example_dict_lossy_Proba",
-    "example_dict_metadata_Proba",
 ]

--- a/skpro/datatypes/_proba/_examples.py
+++ b/skpro/datatypes/_proba/_examples.py
@@ -98,19 +98,19 @@ class ProbaMulti(BaseExample):
 
 
 class ProbaMultiPredQ(ProbaMulti):
-        _tags = {
-            "mtype": "pred_quantiles",
-            "python_dependencies": None,
-            "lossy": False,
-        }
-    
-        def build(self):
-            pred_q = pd.DataFrame(
-                {0.2: [1, 2, 3], 0.6: [2, 3, 4], 42: [5, 3, -1], 46: [5, 3, -1]}
-            )
-            pred_q.columns = pd.MultiIndex.from_product([["foo", "bar"], [0.2, 0.6]])
-    
-            return pred_q
+    _tags = {
+        "mtype": "pred_quantiles",
+        "python_dependencies": None,
+        "lossy": False,
+    }
+
+    def build(self):
+        pred_q = pd.DataFrame(
+            {0.2: [1, 2, 3], 0.6: [2, 3, 4], 42: [5, 3, -1], 46: [5, 3, -1]}
+        )
+        pred_q.columns = pd.MultiIndex.from_product([["foo", "bar"], [0.2, 0.6]])
+
+        return pred_q
 
 
 class ProbaMultiPredInt(ProbaMulti):

--- a/skpro/datatypes/_proba/_examples.py
+++ b/skpro/datatypes/_proba/_examples.py
@@ -36,7 +36,8 @@ from skpro.datatypes._base import BaseExample
 ###
 # example 0: univariate
 
-class ProbaUniv(BaseExample):
+
+class _ProbaUniv(BaseExample):
     _tags = {
         "scitype": "Proba",
         "index": 0,
@@ -48,7 +49,7 @@ class ProbaUniv(BaseExample):
     }
 
 
-class ProbaUnivPredQ(ProbaUniv):
+class _ProbaUnivPredQ(_ProbaUniv):
     _tags = {
         "mtype": "pred_quantiles",
         "python_dependencies": None,
@@ -62,7 +63,7 @@ class ProbaUnivPredQ(ProbaUniv):
         return pred_q
 
 
-class ProbaUnivPredInt(ProbaUniv):
+class _ProbaUnivPredInt(_ProbaUniv):
     _tags = {
         "mtype": "pred_interval",
         "python_dependencies": None,
@@ -85,7 +86,8 @@ class ProbaUnivPredInt(ProbaUniv):
 ###
 # example 1: multi
 
-class ProbaMulti(BaseExample):
+
+class _ProbaMulti(BaseExample):
     _tags = {
         "scitype": "Proba",
         "index": 1,
@@ -97,7 +99,7 @@ class ProbaMulti(BaseExample):
     }
 
 
-class ProbaMultiPredQ(ProbaMulti):
+class _ProbaMultiPredQ(_ProbaMulti):
     _tags = {
         "mtype": "pred_quantiles",
         "python_dependencies": None,
@@ -113,7 +115,7 @@ class ProbaMultiPredQ(ProbaMulti):
         return pred_q
 
 
-class ProbaMultiPredInt(ProbaMulti):
+class _ProbaMultiPredInt(_ProbaMulti):
     _tags = {
         "mtype": "pred_interval",
         "python_dependencies": None,

--- a/skpro/datatypes/_proba/_examples.py
+++ b/skpro/datatypes/_proba/_examples.py
@@ -37,7 +37,6 @@ from skpro.datatypes._base import BaseExample
 # example 0: univariate
 
 class ProbaUniv(BaseExample):
-
     _tags = {
         "scitype": "Proba",
         "index": 0,
@@ -50,7 +49,6 @@ class ProbaUniv(BaseExample):
 
 
 class ProbaUnivPredQ(ProbaUniv):
-
     _tags = {
         "mtype": "pred_quantiles",
         "python_dependencies": None,
@@ -65,7 +63,6 @@ class ProbaUnivPredQ(ProbaUniv):
 
 
 class ProbaUnivPredInt(ProbaUniv):
-
     _tags = {
         "mtype": "pred_interval",
         "python_dependencies": None,
@@ -89,7 +86,6 @@ class ProbaUnivPredInt(ProbaUniv):
 # example 1: multi
 
 class ProbaMulti(BaseExample):
-
     _tags = {
         "scitype": "Proba",
         "index": 1,
@@ -102,7 +98,6 @@ class ProbaMulti(BaseExample):
 
 
 class ProbaMultiPredQ(ProbaMulti):
-    
         _tags = {
             "mtype": "pred_quantiles",
             "python_dependencies": None,
@@ -119,7 +114,6 @@ class ProbaMultiPredQ(ProbaMulti):
 
 
 class ProbaMultiPredInt(ProbaMulti):
-
     _tags = {
         "mtype": "pred_interval",
         "python_dependencies": None,

--- a/skpro/datatypes/_proba/_examples.py
+++ b/skpro/datatypes/_proba/_examples.py
@@ -31,64 +31,116 @@ overall, conversions from non-lossy representations to any other ones
 import numpy as np
 import pandas as pd
 
-example_dict = dict()
-example_dict_lossy = dict()
-example_dict_metadata = dict()
+from skpro.datatypes._base import BaseExample
 
 ###
 # example 0: univariate
 
-pred_q = pd.DataFrame({0.2: [1, 2, 3], 0.6: [2, 3, 4]})
-pred_q.columns = pd.MultiIndex.from_product([["foo"], [0.2, 0.6]])
+class ProbaUniv(BaseExample):
 
-# we need to use this due to numerical inaccuracies from the binary based representation
-pseudo_0_2 = 2 * np.abs(0.6 - 0.5)
-
-example_dict[("pred_quantiles", "Proba", 0)] = pred_q
-example_dict_lossy[("pred_quantiles", "Proba", 0)] = False
-
-pred_int = pd.DataFrame({0.2: [1, 2, 3], 0.6: [2, 3, 4]})
-pred_int.columns = pd.MultiIndex.from_tuples(
-    [("foo", 0.6, "lower"), ("foo", pseudo_0_2, "upper")]
-)
-
-example_dict[("pred_interval", "Proba", 0)] = pred_int
-example_dict_lossy[("pred_interval", "Proba", 0)] = False
+    _tags = {
+        "scitype": "Proba",
+        "index": 0,
+        "metadata": {
+            "is_univariate": True,
+            "is_empty": False,
+            "has_nans": False,
+        },
+    }
 
 
-example_dict_metadata[("Proba", 0)] = {
-    "is_univariate": True,
-    "is_empty": False,
-    "has_nans": False,
-}
+class ProbaUnivPredQ(ProbaUniv):
+
+    _tags = {
+        "mtype": "pred_quantiles",
+        "python_dependencies": None,
+        "lossy": False,
+    }
+
+    def build(self):
+        pred_q = pd.DataFrame({0.2: [1, 2, 3], 0.6: [2, 3, 4]})
+        pred_q.columns = pd.MultiIndex.from_product([["foo"], [0.2, 0.6]])
+
+        return pred_q
+
+
+class ProbaUnivPredInt(ProbaUniv):
+
+    _tags = {
+        "mtype": "pred_interval",
+        "python_dependencies": None,
+        "lossy": False,
+    }
+
+    def build(self):
+        # we need to use this due to numerical inaccuracies
+        # from the binary based representation
+        pseudo_0_2 = 2 * np.abs(0.6 - 0.5)
+
+        pred_int = pd.DataFrame({0.2: [1, 2, 3], 0.6: [2, 3, 4]})
+        pred_int.columns = pd.MultiIndex.from_tuples(
+            [("foo", 0.6, "lower"), ("foo", pseudo_0_2, "upper")]
+        )
+
+        return pred_int
+
 
 ###
 # example 1: multi
 
-pred_q = pd.DataFrame({0.2: [1, 2, 3], 0.6: [2, 3, 4], 42: [5, 3, -1], 46: [5, 3, -1]})
-pred_q.columns = pd.MultiIndex.from_product([["foo", "bar"], [0.2, 0.6]])
+class ProbaMulti(BaseExample):
 
-example_dict[("pred_quantiles", "Proba", 1)] = pred_q
-example_dict_lossy[("pred_quantiles", "Proba", 1)] = False
-
-pred_int = pd.DataFrame(
-    {0.2: [1, 2, 3], 0.6: [2, 3, 4], 42: [5, 3, -1], 46: [5, 3, -1]}
-)
-pred_int.columns = pd.MultiIndex.from_tuples(
-    [
-        ("foo", 0.6, "lower"),
-        ("foo", pseudo_0_2, "upper"),
-        ("bar", 0.6, "lower"),
-        ("bar", pseudo_0_2, "upper"),
-    ]
-)
-
-example_dict[("pred_interval", "Proba", 1)] = pred_int
-example_dict_lossy[("pred_interval", "Proba", 1)] = False
+    _tags = {
+        "scitype": "Proba",
+        "index": 1,
+        "metadata": {
+            "is_univariate": False,
+            "is_empty": False,
+            "has_nans": False,
+        },
+    }
 
 
-example_dict_metadata[("Proba", 1)] = {
-    "is_univariate": False,
-    "is_empty": False,
-    "has_nans": False,
-}
+class ProbaMultiPredQ(ProbaMulti):
+    
+        _tags = {
+            "mtype": "pred_quantiles",
+            "python_dependencies": None,
+            "lossy": False,
+        }
+    
+        def build(self):
+            pred_q = pd.DataFrame(
+                {0.2: [1, 2, 3], 0.6: [2, 3, 4], 42: [5, 3, -1], 46: [5, 3, -1]}
+            )
+            pred_q.columns = pd.MultiIndex.from_product([["foo", "bar"], [0.2, 0.6]])
+    
+            return pred_q
+
+
+class ProbaMultiPredInt(ProbaMulti):
+
+    _tags = {
+        "mtype": "pred_interval",
+        "python_dependencies": None,
+        "lossy": False,
+    }
+
+    def build(self):
+        # we need to use this due to numerical inaccuracies
+        # from the binary based representation
+        pseudo_0_2 = 2 * np.abs(0.6 - 0.5)
+
+        pred_int = pd.DataFrame(
+            {0.2: [1, 2, 3], 0.6: [2, 3, 4], 42: [5, 3, -1], 46: [5, 3, -1]}
+        )
+        pred_int.columns = pd.MultiIndex.from_tuples(
+            [
+                ("foo", 0.6, "lower"),
+                ("foo", pseudo_0_2, "upper"),
+                ("bar", 0.6, "lower"),
+                ("bar", pseudo_0_2, "upper"),
+            ]
+        )
+
+        return pred_int

--- a/skpro/datatypes/_table/__init__.py
+++ b/skpro/datatypes/_table/__init__.py
@@ -1,20 +1,10 @@
 """Module exports: Series type checkers, converters and mtype inference."""
 
 from skpro.datatypes._table._convert import convert_dict as convert_dict_Table
-from skpro.datatypes._table._examples import example_dict as example_dict_Table
-from skpro.datatypes._table._examples import (
-    example_dict_lossy as example_dict_lossy_Table,
-)
-from skpro.datatypes._table._examples import (
-    example_dict_metadata as example_dict_metadata_Table,
-)
 from skpro.datatypes._table._registry import MTYPE_LIST_TABLE, MTYPE_REGISTER_TABLE
 
 __all__ = [
     "convert_dict_Table",
     "MTYPE_LIST_TABLE",
     "MTYPE_REGISTER_TABLE",
-    "example_dict_Table",
-    "example_dict_lossy_Table",
-    "example_dict_metadata_Table",
 ]

--- a/skpro/datatypes/_table/_examples.py
+++ b/skpro/datatypes/_table/_examples.py
@@ -25,7 +25,6 @@ import numpy as np
 import pandas as pd
 
 from skpro.datatypes._base import BaseExample
-from skpro.utils.validation._dependencies import _check_soft_dependencies
 
 example_dict = dict()
 example_dict_lossy = dict()
@@ -33,7 +32,6 @@ example_dict_metadata = dict()
 
 ###
 # example 0: univariate
-
 
 class UnivTable(BaseExample):
 

--- a/skpro/datatypes/_table/_examples.py
+++ b/skpro/datatypes/_table/_examples.py
@@ -33,7 +33,8 @@ example_dict_metadata = dict()
 ###
 # example 0: univariate
 
-class UnivTable(BaseExample):
+
+class _UnivTable(BaseExample):
     _tags = {
         "scitype": "Table",
         "index": 0,
@@ -48,7 +49,7 @@ class UnivTable(BaseExample):
     }
 
 
-class UnivTableDf(UnivTable):
+class _UnivTableDf(_UnivTable):
     _tags = {
         "mtype": "pd_DataFrame_Table",
         "python_dependencies": None,
@@ -59,7 +60,7 @@ class UnivTableDf(UnivTable):
         return pd.DataFrame({"a": [1, 4, 0.5, -3]})
 
 
-class UnivTableNumpy2D(UnivTable):
+class _UnivTableNumpy2D(_UnivTable):
     _tags = {
         "mtype": "numpy2D",
         "python_dependencies": None,
@@ -70,7 +71,7 @@ class UnivTableNumpy2D(UnivTable):
         return np.array([[1], [4], [0.5], [-3]])
 
 
-class UnivTableNumpy1D(UnivTable):
+class _UnivTableNumpy1D(_UnivTable):
     _tags = {
         "mtype": "numpy1D",
         "python_dependencies": None,
@@ -81,7 +82,7 @@ class UnivTableNumpy1D(UnivTable):
         return np.array([1, 4, 0.5, -3])
 
 
-class UnivTableSeries(UnivTable):
+class _UnivTableSeries(_UnivTable):
     _tags = {
         "mtype": "pd_Series_Table",
         "python_dependencies": None,
@@ -92,7 +93,7 @@ class UnivTableSeries(UnivTable):
         return pd.Series([1, 4, 0.5, -3])
 
 
-class UnivTableListOfDict(UnivTable):
+class _UnivTableListOfDict(_UnivTable):
     _tags = {
         "mtype": "list_of_dict",
         "python_dependencies": None,
@@ -103,7 +104,7 @@ class UnivTableListOfDict(UnivTable):
         return [{"a": 1.0}, {"a": 4.0}, {"a": 0.5}, {"a": -3.0}]
 
 
-class UnivTablePolarsEager(UnivTable):
+class _UnivTablePolarsEager(_UnivTable):
     _tags = {
         "mtype": "polars_eager_table",
         "python_dependencies": ["polars", "pyarrow"],
@@ -117,7 +118,7 @@ class UnivTablePolarsEager(UnivTable):
         return convert_pandas_to_polars_with_index(df)
 
 
-class UnivTablePolarsLazy(UnivTable):
+class _UnivTablePolarsLazy(_UnivTable):
     _tags = {
         "mtype": "polars_lazy_table",
         "python_dependencies": ["polars", "pyarrow"],
@@ -134,7 +135,8 @@ class UnivTablePolarsLazy(UnivTable):
 ###
 # example 1: multivariate
 
-class MultivTable(BaseExample):
+
+class _MultivTable(BaseExample):
     _tags = {
         "scitype": "Table",
         "index": 1,
@@ -149,7 +151,7 @@ class MultivTable(BaseExample):
     }
 
 
-class MultivTableDf(MultivTable):
+class _MultivTableDf(_MultivTable):
     _tags = {
         "mtype": "pd_DataFrame_Table",
         "python_dependencies": None,
@@ -160,7 +162,7 @@ class MultivTableDf(MultivTable):
         return pd.DataFrame({"a": [1, 4, 0.5, -3], "b": [3, 7, 2, -3 / 7]})
 
 
-class MultivTableNumpy2D(MultivTable):
+class _MultivTableNumpy2D(_MultivTable):
     _tags = {
         "mtype": "numpy2D",
         "python_dependencies": None,
@@ -171,7 +173,7 @@ class MultivTableNumpy2D(MultivTable):
         return np.array([[1, 3], [4, 7], [0.5, 2], [-3, -3 / 7]])
 
 
-class MultivTableNumpy1D(MultivTable):
+class _MultivTableNumpy1D(_MultivTable):
     _tags = {
         "mtype": "numpy1D",
         "python_dependencies": None,
@@ -182,7 +184,7 @@ class MultivTableNumpy1D(MultivTable):
         return None
 
 
-class MultivTableSeries(MultivTable):
+class _MultivTableSeries(_MultivTable):
     _tags = {
         "mtype": "pd_Series_Table",
         "python_dependencies": None,
@@ -193,7 +195,7 @@ class MultivTableSeries(MultivTable):
         return None
 
 
-class MultivTableListOfDict(MultivTable):
+class _MultivTableListOfDict(_MultivTable):
     _tags = {
         "mtype": "list_of_dict",
         "python_dependencies": None,
@@ -209,7 +211,7 @@ class MultivTableListOfDict(MultivTable):
         ]
 
 
-class MultivTablePolarsEager(MultivTable):
+class _MultivTablePolarsEager(_MultivTable):
     _tags = {
         "mtype": "polars_eager_table",
         "python_dependencies": ["polars", "pyarrow"],
@@ -223,7 +225,7 @@ class MultivTablePolarsEager(MultivTable):
         return convert_pandas_to_polars_with_index(df)
 
 
-class MultivTablePolarsLazy(MultivTable):
+class _MultivTablePolarsLazy(_MultivTable):
     _tags = {
         "mtype": "polars_lazy_table",
         "python_dependencies": ["polars", "pyarrow"],

--- a/skpro/datatypes/_table/_examples.py
+++ b/skpro/datatypes/_table/_examples.py
@@ -34,7 +34,6 @@ example_dict_metadata = dict()
 # example 0: univariate
 
 class UnivTable(BaseExample):
-
     _tags = {
         "scitype": "Table",
         "index": 0,
@@ -50,7 +49,6 @@ class UnivTable(BaseExample):
 
 
 class UnivTableDf(UnivTable):
-
     _tags = {
         "mtype": "pd_DataFrame_Table",
         "python_dependencies": None,
@@ -62,7 +60,6 @@ class UnivTableDf(UnivTable):
 
 
 class UnivTableNumpy2D(UnivTable):
-
     _tags = {
         "mtype": "numpy2D",
         "python_dependencies": None,
@@ -74,7 +71,6 @@ class UnivTableNumpy2D(UnivTable):
 
 
 class UnivTableNumpy1D(UnivTable):
-
     _tags = {
         "mtype": "numpy1D",
         "python_dependencies": None,
@@ -86,7 +82,6 @@ class UnivTableNumpy1D(UnivTable):
 
 
 class UnivTableSeries(UnivTable):
-
     _tags = {
         "mtype": "pd_Series_Table",
         "python_dependencies": None,
@@ -98,7 +93,6 @@ class UnivTableSeries(UnivTable):
 
 
 class UnivTableListOfDict(UnivTable):
-
     _tags = {
         "mtype": "list_of_dict",
         "python_dependencies": None,
@@ -110,7 +104,6 @@ class UnivTableListOfDict(UnivTable):
 
 
 class UnivTablePolarsEager(UnivTable):
-
     _tags = {
         "mtype": "polars_eager_table",
         "python_dependencies": ["polars", "pyarrow"],
@@ -125,7 +118,6 @@ class UnivTablePolarsEager(UnivTable):
 
 
 class UnivTablePolarsLazy(UnivTable):
-
     _tags = {
         "mtype": "polars_lazy_table",
         "python_dependencies": ["polars", "pyarrow"],
@@ -143,7 +135,6 @@ class UnivTablePolarsLazy(UnivTable):
 # example 1: multivariate
 
 class MultivTable(BaseExample):
-
     _tags = {
         "scitype": "Table",
         "index": 1,
@@ -159,7 +150,6 @@ class MultivTable(BaseExample):
 
 
 class MultivTableDf(MultivTable):
-
     _tags = {
         "mtype": "pd_DataFrame_Table",
         "python_dependencies": None,
@@ -171,7 +161,6 @@ class MultivTableDf(MultivTable):
 
 
 class MultivTableNumpy2D(MultivTable):
-
     _tags = {
         "mtype": "numpy2D",
         "python_dependencies": None,
@@ -183,19 +172,17 @@ class MultivTableNumpy2D(MultivTable):
 
 
 class MultivTableNumpy1D(MultivTable):
-    
-        _tags = {
-            "mtype": "numpy1D",
-            "python_dependencies": None,
-            "lossy": None,
-        }
-    
-        def build(self):
-            return None
+    _tags = {
+        "mtype": "numpy1D",
+        "python_dependencies": None,
+        "lossy": None,
+    }
+
+    def build(self):
+        return None
 
 
 class MultivTableSeries(MultivTable):
-
     _tags = {
         "mtype": "pd_Series_Table",
         "python_dependencies": None,
@@ -207,7 +194,6 @@ class MultivTableSeries(MultivTable):
 
 
 class MultivTableListOfDict(MultivTable):
-
     _tags = {
         "mtype": "list_of_dict",
         "python_dependencies": None,
@@ -224,7 +210,6 @@ class MultivTableListOfDict(MultivTable):
 
 
 class MultivTablePolarsEager(MultivTable):
-
     _tags = {
         "mtype": "polars_eager_table",
         "python_dependencies": ["polars", "pyarrow"],
@@ -239,7 +224,6 @@ class MultivTablePolarsEager(MultivTable):
 
 
 class MultivTablePolarsLazy(MultivTable):
-
     _tags = {
         "mtype": "polars_lazy_table",
         "python_dependencies": ["polars", "pyarrow"],

--- a/skpro/datatypes/_table/_examples.py
+++ b/skpro/datatypes/_table/_examples.py
@@ -24,6 +24,7 @@ overall, conversions from non-lossy representations to any other ones
 import numpy as np
 import pandas as pd
 
+from skpro.datatypes._base import BaseExample
 from skpro.utils.validation._dependencies import _check_soft_dependencies
 
 example_dict = dict()
@@ -33,100 +34,222 @@ example_dict_metadata = dict()
 ###
 # example 0: univariate
 
-df = pd.DataFrame({"a": [1, 4, 0.5, -3]})
 
-example_dict[("pd_DataFrame_Table", "Table", 0)] = df
-example_dict_lossy[("pd_DataFrame_Table", "Table", 0)] = False
+class UnivTable(BaseExample):
 
-arr = np.array([[1], [4], [0.5], [-3]])
+    _tags = {
+        "scitype": "Table",
+        "index": 0,
+        "metadata": {
+            "is_univariate": True,
+            "is_empty": False,
+            "has_nans": False,
+            "n_instances": 4,
+            "n_features": 1,
+            "feature_names": ["a"],
+        },
+    }
 
-example_dict[("numpy2D", "Table", 0)] = arr
-example_dict_lossy[("numpy2D", "Table", 0)] = True
 
-arr = np.array([1, 4, 0.5, -3])
+class UnivTableDf(UnivTable):
 
-example_dict[("numpy1D", "Table", 0)] = arr
-example_dict_lossy[("numpy1D", "Table", 0)] = True
+    _tags = {
+        "mtype": "pd_DataFrame_Table",
+        "python_dependencies": None,
+        "lossy": False,
+    }
 
-series = pd.Series([1, 4, 0.5, -3])
+    def build(self):
+        return pd.DataFrame({"a": [1, 4, 0.5, -3]})
 
-example_dict[("pd_Series_Table", "Table", 0)] = series
-example_dict_lossy[("pd_Series_Table", "Table", 0)] = True
 
-list_of_dict = [{"a": 1.0}, {"a": 4.0}, {"a": 0.5}, {"a": -3.0}]
+class UnivTableNumpy2D(UnivTable):
 
-example_dict[("list_of_dict", "Table", 0)] = list_of_dict
-example_dict_lossy[("list_of_dict", "Table", 0)] = False
+    _tags = {
+        "mtype": "numpy2D",
+        "python_dependencies": None,
+        "lossy": True,
+    }
 
-if _check_soft_dependencies(["polars", "pyarrow"], severity="none"):
-    from skpro.datatypes._adapter.polars import convert_pandas_to_polars_with_index
+    def build(self):
+        return np.array([[1], [4], [0.5], [-3]])
 
-    example_dict[
-        ("polars_eager_table", "Table", 0)
-    ] = convert_pandas_to_polars_with_index(df)
-    example_dict_lossy[("polars_eager_table", "Table", 0)] = False
 
-    example_dict[
-        ("polars_lazy_table", "Table", 0)
-    ] = convert_pandas_to_polars_with_index(df, lazy=True)
-    example_dict_lossy[("polars_lazy_table", "Table", 0)] = False
+class UnivTableNumpy1D(UnivTable):
 
-example_dict_metadata[("Table", 0)] = {
-    "is_univariate": True,
-    "is_empty": False,
-    "has_nans": False,
-    "n_instances": 4,
-    "n_features": 1,
-    "feature_names": ["a"],
-}
+    _tags = {
+        "mtype": "numpy1D",
+        "python_dependencies": None,
+        "lossy": True,
+    }
+
+    def build(self):
+        return np.array([1, 4, 0.5, -3])
+
+
+class UnivTableSeries(UnivTable):
+
+    _tags = {
+        "mtype": "pd_Series_Table",
+        "python_dependencies": None,
+        "lossy": True,
+    }
+
+    def build(self):
+        return pd.Series([1, 4, 0.5, -3])
+
+
+class UnivTableListOfDict(UnivTable):
+
+    _tags = {
+        "mtype": "list_of_dict",
+        "python_dependencies": None,
+        "lossy": False,
+    }
+
+    def build(self):
+        return [{"a": 1.0}, {"a": 4.0}, {"a": 0.5}, {"a": -3.0}]
+
+
+class UnivTablePolarsEager(UnivTable):
+
+    _tags = {
+        "mtype": "polars_eager_table",
+        "python_dependencies": ["polars", "pyarrow"],
+        "lossy": False,
+    }
+
+    def build(self):
+        from skpro.datatypes._adapter.polars import convert_pandas_to_polars_with_index
+
+        df = pd.DataFrame({"a": [1, 4, 0.5, -3]})
+        return convert_pandas_to_polars_with_index(df)
+
+
+class UnivTablePolarsLazy(UnivTable):
+
+    _tags = {
+        "mtype": "polars_lazy_table",
+        "python_dependencies": ["polars", "pyarrow"],
+        "lossy": False,
+    }
+
+    def build(self):
+        from skpro.datatypes._adapter.polars import convert_pandas_to_polars_with_index
+
+        df = pd.DataFrame({"a": [1, 4, 0.5, -3]})
+        return convert_pandas_to_polars_with_index(df, lazy=True)
+
 
 ###
 # example 1: multivariate
 
-example_dict[("numpy1D", "Table", 1)] = None
-example_dict_lossy[("numpy1D", "Table", 1)] = None
+class MultivTable(BaseExample):
 
-df = pd.DataFrame({"a": [1, 4, 0.5, -3], "b": [3, 7, 2, -3 / 7]})
+    _tags = {
+        "scitype": "Table",
+        "index": 1,
+        "metadata": {
+            "is_univariate": False,
+            "is_empty": False,
+            "has_nans": False,
+            "n_instances": 4,
+            "n_features": 2,
+            "feature_names": ["a", "b"],
+        },
+    }
 
-example_dict[("d_DataFrame_Table", "Table", 1)] = df
-example_dict_lossy[("pd_DataFrame_Table", "Table", 1)] = False
 
-arr = np.array([[1, 3], [4, 7], [0.5, 2], [-3, -3 / 7]])
+class MultivTableDf(MultivTable):
 
-example_dict[("numpy2D", "Table", 1)] = arr
-example_dict_lossy[("numpy2D", "Table", 1)] = True
+    _tags = {
+        "mtype": "pd_DataFrame_Table",
+        "python_dependencies": None,
+        "lossy": False,
+    }
 
-example_dict[("pd_Series_Table", "Table", 1)] = None
-example_dict_lossy[("pd_Series_Table", "Table", 1)] = None
+    def build(self):
+        return pd.DataFrame({"a": [1, 4, 0.5, -3], "b": [3, 7, 2, -3 / 7]})
 
-list_of_dict = [
-    {"a": 1.0, "b": 3.0},
-    {"a": 4.0, "b": 7.0},
-    {"a": 0.5, "b": 2.0},
-    {"a": -3.0, "b": -3 / 7},
-]
 
-example_dict[("list_of_dict", "Table", 1)] = list_of_dict
-example_dict_lossy[("list_of_dict", "Table", 1)] = False
+class MultivTableNumpy2D(MultivTable):
 
-if _check_soft_dependencies(["polars", "pyarrow"], severity="none"):
-    from skpro.datatypes._adapter.polars import convert_pandas_to_polars_with_index
+    _tags = {
+        "mtype": "numpy2D",
+        "python_dependencies": None,
+        "lossy": True,
+    }
 
-    example_dict[
-        ("polars_eager_table", "Table", 1)
-    ] = convert_pandas_to_polars_with_index(df)
-    example_dict_lossy[("polars_eager_table", "Table", 1)] = False
+    def build(self):
+        return np.array([[1, 3], [4, 7], [0.5, 2], [-3, -3 / 7]])
 
-    example_dict[
-        ("polars_lazy_table", "Table", 1)
-    ] = convert_pandas_to_polars_with_index(df, lazy=True)
-    example_dict_lossy[("polars_lazy_table", "Table", 1)] = False
 
-example_dict_metadata[("Table", 1)] = {
-    "is_univariate": False,
-    "is_empty": False,
-    "has_nans": False,
-    "n_instances": 4,
-    "n_features": 2,
-    "feature_names": ["a", "b"],
-}
+class MultivTableNumpy1D(MultivTable):
+    
+        _tags = {
+            "mtype": "numpy1D",
+            "python_dependencies": None,
+            "lossy": None,
+        }
+    
+        def build(self):
+            return None
+
+
+class MultivTableSeries(MultivTable):
+
+    _tags = {
+        "mtype": "pd_Series_Table",
+        "python_dependencies": None,
+        "lossy": None,
+    }
+
+    def build(self):
+        return None
+
+
+class MultivTableListOfDict(MultivTable):
+
+    _tags = {
+        "mtype": "list_of_dict",
+        "python_dependencies": None,
+        "lossy": False,
+    }
+
+    def build(self):
+        return [
+            {"a": 1.0, "b": 3.0},
+            {"a": 4.0, "b": 7.0},
+            {"a": 0.5, "b": 2.0},
+            {"a": -3.0, "b": -3 / 7},
+        ]
+
+
+class MultivTablePolarsEager(MultivTable):
+
+    _tags = {
+        "mtype": "polars_eager_table",
+        "python_dependencies": ["polars", "pyarrow"],
+        "lossy": False,
+    }
+
+    def build(self):
+        from skpro.datatypes._adapter.polars import convert_pandas_to_polars_with_index
+
+        df = pd.DataFrame({"a": [1, 4, 0.5, -3], "b": [3, 7, 2, -3 / 7]})
+        return convert_pandas_to_polars_with_index(df)
+
+
+class MultivTablePolarsLazy(MultivTable):
+
+    _tags = {
+        "mtype": "polars_lazy_table",
+        "python_dependencies": ["polars", "pyarrow"],
+        "lossy": False,
+    }
+
+    def build(self):
+        from skpro.datatypes._adapter.polars import convert_pandas_to_polars_with_index
+
+        df = pd.DataFrame({"a": [1, 4, 0.5, -3], "b": [3, 7, 2, -3 / 7]})
+        return convert_pandas_to_polars_with_index(df, lazy=True)


### PR DESCRIPTION
This PR refactors the data type specifications and converters to classes.

Related: https://github.com/sktime/sktime/issues/3512, related to https://github.com/sktime/sktime/issues/2957.

Contains:

* a base class for datatype examples, `BaseExample`, to replace the more ad-hoc dictionary design
* a complete refactor of the `Table` and `Proba` mtype submodules to this interface
* a full refactor of the public framework module with `get_example` logic, in `datatypes`, to allow extensibility with this design

Partial mirror in `skpro` of https://github.com/sktime/sktime/pull/6033