### PR TITLE
[ENH] `datatypes` examples - docstrings, deepcopy

### DIFF
--- a/skpro/datatypes/_examples.py
+++ b/skpro/datatypes/_examples.py
@@ -13,6 +13,7 @@ the representation is considered "lossy" if the representation is incomplete
     e.g., metadata such as column names are missing
 """
 
+from copy import deepcopy
 from functools import lru_cache
 
 from skpro.datatypes._registry import mtype_to_scitype
@@ -109,4 +110,5 @@ def get_examples(
         else:
             fixtures[k[2]] = example_dict.get(k).build()
 
-    return fixtures
+    # deepcopy to avoid side effects
+    return deepcopy(fixtures)

--- a/skpro/datatypes/_proba/_examples.py
+++ b/skpro/datatypes/_proba/_examples.py
@@ -1,31 +1,25 @@
 """Example generation for testing.
 
-Exports dict of examples, useful for testing as fixtures.
+Exports examples of in-memory data containers, useful for testing as fixtures.
 
-example_dict: dict indexed by triple
-  1st element = mtype - str
-  2nd element = considered as this scitype - str
-  3rd element = int - index of example
-elements are data objects, considered examples for the mtype
-    all examples with same index are considered "same" on scitype content
-    if None, indicates that representation is not possible
+Examples come in clusters, tagged by scitype: str, index: int, and metadata: dict.
 
-example_lossy: dict of bool indexed by triple
-  1st element = mtype - str
-  2nd element = considered as this scitype - str
-  3rd element = int - index of example
-elements are bool, indicate whether representation has information removed
-    all examples with same index are considered "same" on scitype content
+All examples with the same index are considered "content-wise the same", i.e.,
+representing the same abstract data object. They differ by mtype, i.e.,
+machine type, which is the specific in-memory representation.
 
-example_metadata: dict of metadata dict, indexed by pair
-  1st element = considered as this scitype - str
-  2nd element = int - index of example
-  (there is no "mtype" element, as properties are equal for all mtypes)
-elements are metadata dict, as returned by check_is_mtype
-    used as expected return of check_is_mtype in tests
+If an example returns None, it indicates that representation
+with that specific mtype is not possible.
 
-overall, conversions from non-lossy representations to any other ones
-    should yield the element exactly, identidally (given same index)
+If the tag "lossy" is True, the representation is considered incomplete,
+e.g., metadata such as column names are missing.
+
+Types of tests that can be performed with these examples:
+
+* the mtype and scitype of the example should be correctly inferred by checkers.
+* the metadata of hte example should be correctly inferred by checkers.
+* conversions from non-lossy representations to any other ones
+  should yield the element exactly, identically, for examples of the same index.
 """
 
 import numpy as np

--- a/skpro/datatypes/_table/_examples.py
+++ b/skpro/datatypes/_table/_examples.py
@@ -1,34 +1,31 @@
 """Example generation for testing.
 
-Exports dict of examples, useful for testing as fixtures.
+Exports examples of in-memory data containers, useful for testing as fixtures.
 
-example_dict: dict indexed by triple
-  1st element = mtype - str
-  2nd element = considered as this scitype - str
-  3rd element = int - index of example
-elements are data objects, considered examples for the mtype
-    all examples with same index are considered "same" on scitype content
-    if None, indicates that representation is not possible
+Examples come in clusters, tagged by scitype: str, index: int, and metadata: dict.
 
-example_lossy: dict of bool indexed by pairs of str
-  1st element = mtype - str
-  2nd element = considered as this scitype - str
-  3rd element = int - index of example
-elements are bool, indicate whether representation has information removed
-    all examples with same index are considered "same" on scitype content
+All examples with the same index are considered "content-wise the same", i.e.,
+representing the same abstract data object. They differ by mtype, i.e.,
+machine type, which is the specific in-memory representation.
 
-overall, conversions from non-lossy representations to any other ones
-    should yield the element exactly, identidally (given same index)
+If an example returns None, it indicates that representation
+with that specific mtype is not possible.
+
+If the tag "lossy" is True, the representation is considered incomplete,
+e.g., metadata such as column names are missing.
+
+Types of tests that can be performed with these examples:
+
+* the mtype and scitype of the example should be correctly inferred by checkers.
+* the metadata of hte example should be correctly inferred by checkers.
+* conversions from non-lossy representations to any other ones
+  should yield the element exactly, identically, for examples of the same index.
 """
 
 import numpy as np
 import pandas as pd
 
 from skpro.datatypes._base import BaseExample
-
-example_dict = dict()
-example_dict_lossy = dict()
-example_dict_metadata = dict()
 
 ###
 # example 0: univariate
@@ -112,10 +109,10 @@ class _UnivTablePolarsEager(_UnivTable):
     }
 
     def build(self):
-        from skpro.datatypes._adapter.polars import convert_pandas_to_polars_with_index
+        import polars as pl
 
         df = pd.DataFrame({"a": [1, 4, 0.5, -3]})
-        return convert_pandas_to_polars_with_index(df)
+        return pl.DataFrame(df)
 
 
 class _UnivTablePolarsLazy(_UnivTable):
@@ -126,10 +123,10 @@ class _UnivTablePolarsLazy(_UnivTable):
     }
 
     def build(self):
-        from skpro.datatypes._adapter.polars import convert_pandas_to_polars_with_index
+        import polars as pl
 
         df = pd.DataFrame({"a": [1, 4, 0.5, -3]})
-        return convert_pandas_to_polars_with_index(df, lazy=True)
+        return pl.LazyFrame(df)
 
 
 ###
@@ -219,10 +216,10 @@ class _MultivTablePolarsEager(_MultivTable):
     }
 
     def build(self):
-        from skpro.datatypes._adapter.polars import convert_pandas_to_polars_with_index
+        import polars as pl
 
         df = pd.DataFrame({"a": [1, 4, 0.5, -3], "b": [3, 7, 2, -3 / 7]})
-        return convert_pandas_to_polars_with_index(df)
+        return pl.DataFrame(df)
 
 
 class _MultivTablePolarsLazy(_MultivTable):
@@ -233,7 +230,7 @@ class _MultivTablePolarsLazy(_MultivTable):
     }
 
     def build(self):
-        from skpro.datatypes._adapter.polars import convert_pandas_to_polars_with_index
+        import polars as pl
 
         df = pd.DataFrame({"a": [1, 4, 0.5, -3], "b": [3, 7, 2, -3 / 7]})
-        return convert_pandas_to_polars_with_index(df, lazy=True)
+        return pl.LazyFrame(df)


### PR DESCRIPTION
This syncs the `datatypes` examples module with `sktime`:

* update the docstrings to the class based architecture
* ensure examples are deepcopied before returned