### PR TITLE
[MNT] python 3.13 support, add 3.13 to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13.0-rc.2"]
         os: [ubuntu-latest, windows-latest, macOS-13]
     runs-on: ${{ matrix.os }}
     steps:
@@ -107,7 +107,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13.0-rc.2"]
         os: [ubuntu-latest, windows-latest, macOS-13]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13.0-rc.2"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13.0-rc.3"]
         os: [ubuntu-latest, windows-latest, macOS-13]
     runs-on: ${{ matrix.os }}
     steps:
@@ -107,7 +107,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13.0-rc.2"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13.0-rc32"]
         os: [ubuntu-latest, windows-latest, macOS-13]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13.0-rc.2"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13.0-rc.2"]
         os: [ubuntu-latest, windows-latest, macOS-13]
     runs-on: ${{ matrix.os }}
     steps:
@@ -107,7 +107,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13.0-rc.2"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13.0-rc.2"]
         os: [ubuntu-latest, windows-latest, macOS-13]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,7 +107,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13.0-rc32"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13.0-rc.3"]
         os: [ubuntu-latest, windows-latest, macOS-13]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13.0-rc.3"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, windows-latest, macOS-13]
     runs-on: ${{ matrix.os }}
     steps:
@@ -107,7 +107,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13.0-rc.3"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, windows-latest, macOS-13]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false  # to not fail all combinations if just one fail
       matrix:
         os: [ubuntu-latest, macOS-13]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4
@@ -66,7 +66,7 @@ jobs:
       fail-fast: false  # to not fail all combinations if just one fail
       matrix:
         os: [windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,11 +50,11 @@ dependencies = [
 [project.optional-dependencies]
 all_extras = [
     "cyclic-boosting>=1.4.0; python_version < '3.12'",
-    "distfit",
-    "lifelines<0.30.0",
-    "mapie",
+    "distfit; python_version < '3.13'",
+    "lifelines<0.30.0; python_version < '3.13'",
+    "mapie; python_version < '3.13'",
     "matplotlib>=3.3.2",
-    "ngboost<0.6.0",
+    "ngboost<0.6.0; python_version < '3.13'",
     "polars<1.10.0",
     "pyarrow<14.0.0; python_version < '3.12'",
     "scikit-survival<0.24.0; python_version < '3.13'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,13 +35,14 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.9,<3.14"
 dependencies = [
     "numpy>=1.21.0,<2.2",
     "pandas>=1.1.0,<2.3.0",
     "packaging",
-    "scikit-base>=0.6.1,<0.10.0",
+    "scikit-base>=0.6.1,<0.11.0",
     "scikit-learn>=0.24.0,<1.6.0",
     "scipy<2.0.0,>=1.2.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ dependencies = [
 
 [project.optional-dependencies]
 all_extras = [
-    "attrs",
     "cyclic-boosting>=1.4.0; python_version < '3.12'",
     "distfit",
     "lifelines<0.30.0",
@@ -58,10 +57,8 @@ all_extras = [
     "ngboost<0.6.0",
     "polars<1.10.0",
     "pyarrow<14.0.0; python_version < '3.12'",
-    "scikit-survival<0.24.0",
+    "scikit-survival<0.24.0; python_version < '3.13'",
     "statsmodels>=0.12.1",
-    "tabulate",
-    "uncertainties",
 ]
 
 dev = [


### PR DESCRIPTION
Extends the bounds in `pyproject.toml` to add experimental support for python 3.13, and adds testing on 3.13 to the test matrix.

Full 3.13 support to be added with 2.7.0.