### PR TITLE
[ENH] rename `capability:online` tag to `capability:update`

### DIFF
--- a/skpro/registry/_tags.py
+++ b/skpro/registry/_tags.py
@@ -123,7 +123,7 @@ OBJECT_TAG_REGISTER = [
         "whether estimator supports missing values",
     ),
     (
-        "capability:online",
+        "capability:update",
         "regressor_proba",
         "bool",
         "whether estimator supports online updates via update",

--- a/skpro/regression/base/_base.py
+++ b/skpro/regression/base/_base.py
@@ -33,7 +33,7 @@ class BaseProbaRegressor(BaseEstimator):
         "capability:survival": False,
         "capability:multioutput": False,
         "capability:missing": True,
-        "capability:online": False,
+        "capability:update": False,
         "X_inner_mtype": "pd_DataFrame_Table",
         "y_inner_mtype": "pd_DataFrame_Table",
         "C_inner_mtype": "pd_DataFrame_Table",
@@ -140,7 +140,7 @@ class BaseProbaRegressor(BaseEstimator):
     def update(self, X, y, C=None):
         """Update regressor with a new batch of training data.
 
-        Only estimators with the ``capability:online`` tag (value ``True``)
+        Only estimators with the ``capability:update`` tag (value ``True``)
         provide this method, otherwise the method ignores the call and
         discards the data passed.
 
@@ -164,7 +164,7 @@ class BaseProbaRegressor(BaseEstimator):
         -------
         self : reference to self
         """
-        capa_online = self.get_tag("capability:online")
+        capa_online = self.get_tag("capability:update")
         capa_surv = self.get_tag("capability:survival")
 
         if not capa_online:

--- a/skpro/regression/compose/_pipeline.py
+++ b/skpro/regression/compose/_pipeline.py
@@ -339,7 +339,7 @@ class Pipeline(_Pipeline):
         tags_to_clone = [
             "capability:multioutput",
             "capability:survival",
-            "capability:online",
+            "capability:update",
         ]
         self.clone_tags(self.regressor_, tags_to_clone)
 

--- a/skpro/regression/online/_dont_refit.py
+++ b/skpro/regression/online/_dont_refit.py
@@ -26,7 +26,7 @@ class OnlineDontRefit(_DelegatedProbaRegressor):
         clone of the regressor passed in the constructor, fitted on all data
     """
 
-    _tags = {"capability:online": False}
+    _tags = {"capability:update": False}
 
     def __init__(self, estimator):
         self.estimator = estimator

--- a/skpro/regression/online/_refit.py
+++ b/skpro/regression/online/_refit.py
@@ -28,7 +28,7 @@ class OnlineRefit(_DelegatedProbaRegressor):
         clone of the regressor passed in the constructor, fitted on all data
     """
 
-    _tags = {"capability:online": True}
+    _tags = {"capability:update": True}
 
     def __init__(self, estimator):
         self.estimator = estimator

--- a/skpro/regression/online/_refit_every.py
+++ b/skpro/regression/online/_refit_every.py
@@ -33,7 +33,7 @@ class OnlineRefitEveryN(_DelegatedProbaRegressor):
         clone of the regressor passed in the constructor, fitted on all data
     """
 
-    _tags = {"capability:online": True}
+    _tags = {"capability:update": True}
 
     def __init__(self, estimator, N=1):
         self.estimator = estimator

--- a/skpro/survival/base.py
+++ b/skpro/survival/base.py
@@ -51,7 +51,7 @@ class BaseSurvReg(BaseProbaRegressor):
     def update(self, X, y, C=None):
         """Update regressor with a new batch of training data.
 
-        Only estimators with the ``capability:online`` tag (value ``True``)
+        Only estimators with the ``capability:update`` tag (value ``True``)
         provide this method, otherwise the method ignores the call and
         discards the data passed.
 


### PR DESCRIPTION
This PR renames the `capability:online` tag to `capability:update`.

This is more in line with tags that describe whether methods are present, most being called `capability:methodname`.

No deprecation is necessary, as the online update API has not been released yet.