### PR TITLE
[MNT] fix failing `code-quality` CI step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,9 +39,10 @@ jobs:
           output: " "
       - name: List changed files
         run: echo '${{ steps.file_changes.outputs.files}}'
-      - uses: pre-commit/action@v3.0.1
-        with:
-          extra_args: --files ${{ steps.file_changes.outputs.files}}
+      - name: install pre-commit
+        run: python3 -m pip install pre-commit
+      - name: run pre-commit hooks on modified files
+        run: pre-commit run --color always --files ${{ steps.changed-files.outputs.all_changed_files }} --show-diff-on-failure
       - name: Check for missing init files
         run: build_tools/fail_on_missing_init_files.sh
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,21 +29,23 @@ concurrency:
 
 jobs:
   code-quality:
+    name: code-quality
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-      - id: file_changes
-        uses: trilom/file-changes-action@v1.2.4
+      - name: repository checkout step
+        uses: actions/checkout@v4
+      - name: python environment step
+        uses: actions/setup-python@v5
         with:
-          output: " "
-      - name: List changed files
-        run: echo '${{ steps.file_changes.outputs.files}}'
+          python-version: "3.11"
       - name: install pre-commit
         run: python3 -m pip install pre-commit
+      - id: changed-files
+        name: identify modified files
+        uses: tj-actions/changed-files@v45
       - name: run pre-commit hooks on modified files
         run: pre-commit run --color always --files ${{ steps.changed-files.outputs.all_changed_files }} --show-diff-on-failure
-      - name: Check for missing init files
+      - name: check missing __init__ files
         run: build_tools/fail_on_missing_init_files.sh
         shell: bash
 


### PR DESCRIPTION
This PR fixes the failing `code-quality` CI step, by replacing the deprecated `pre-commit` action.