### PR TITLE
[DOC] in docstring, rename `Example`  to `Examples` sections

### DIFF
--- a/skpro/distributions/alpha.py
+++ b/skpro/distributions/alpha.py
@@ -38,8 +38,8 @@ class Alpha(_ScipyAdapter):
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
 
-    Example
-    -------
+    Examples
+    --------
     >>> from skpro.distributions import Alpha
 
     >>> distr = Alpha(a=[[1, 2], [3, 4]])

--- a/skpro/distributions/beta.py
+++ b/skpro/distributions/beta.py
@@ -29,8 +29,8 @@ class Beta(_ScipyAdapter):
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
 
-    Example
-    -------
+    Examples
+    --------
     >>> from skpro.distributions.beta import Beta
 
     >>> d = Beta(beta=[[1, 1], [2, 3], [4, 5]], alpha=2)

--- a/skpro/distributions/binomial.py
+++ b/skpro/distributions/binomial.py
@@ -26,8 +26,8 @@ class Binomial(_ScipyAdapter):
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
 
-    Example
-    -------
+    Examples
+    --------
     >>> from skpro.distributions.binomial import Binomial
 
     >>> d = Binomial(n=[[10, 10], [20, 30], [40, 50]], p=0.5)

--- a/skpro/distributions/chi_squared.py
+++ b/skpro/distributions/chi_squared.py
@@ -19,8 +19,8 @@ class ChiSquared(BaseDistribution):
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
 
-    Example
-    -------
+    Examples
+    --------
     >>> from skpro.distributions.chi_squared import ChiSquared
     >>> chi = ChiSquared(dof=[[1, 2], [3, 4], [5, 6]])
     """

--- a/skpro/distributions/compose/_iid.py
+++ b/skpro/distributions/compose/_iid.py
@@ -28,8 +28,8 @@ class IID(BaseDistribution):
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
 
-    Example
-    -------
+    Examples
+    --------
     >>> import pandas as pd
     >>> from skpro.distributions.compose import IID
     >>> from skpro.distributions.normal import Normal

--- a/skpro/distributions/delta.py
+++ b/skpro/distributions/delta.py
@@ -30,8 +30,8 @@ class Delta(BaseDistribution):
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
 
-    Example
-    -------
+    Examples
+    --------
     >>> from skpro.distributions.delta import Delta
 
     >>> delta = Delta(c=[[0, 1], [2, 3], [4, 5]])

--- a/skpro/distributions/empirical.py
+++ b/skpro/distributions/empirical.py
@@ -42,8 +42,8 @@ class Empirical(BaseDistribution):
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
 
-    Example
-    -------
+    Examples
+    --------
     >>> import pandas as pd
     >>> from skpro.distributions.empirical import Empirical
 

--- a/skpro/distributions/fisk.py
+++ b/skpro/distributions/fisk.py
@@ -29,8 +29,8 @@ class Fisk(_ScipyAdapter):
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
 
-    Example
-    -------
+    Examples
+    --------
     >>> from skpro.distributions.fisk import Fisk
 
     >>> d = Fisk(beta=[[1, 1], [2, 3], [4, 5]], alpha=2)

--- a/skpro/distributions/gamma.py
+++ b/skpro/distributions/gamma.py
@@ -32,8 +32,8 @@ class Gamma(_ScipyAdapter):
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
 
-    Example
-    -------
+    Examples
+    --------
     >>> from skpro.distributions.gamma import Gamma
 
     >>> d = Gamma(beta=[[1, 1], [2, 3], [4, 5]], alpha=2)

--- a/skpro/distributions/halfcauchy.py
+++ b/skpro/distributions/halfcauchy.py
@@ -39,8 +39,8 @@ class HalfCauchy(_ScipyAdapter):
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
 
-    Example
-    -------
+    Examples
+    --------
     >>> from skpro.distributions.halfcauchy import HalfCauchy
 
     >>> hc = HalfCauchy(beta=1)

--- a/skpro/distributions/halflogistic.py
+++ b/skpro/distributions/halflogistic.py
@@ -40,8 +40,8 @@ class HalfLogistic(_ScipyAdapter):
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
 
-    Example
-    -------
+    Examples
+    --------
     >>> from skpro.distributions.halflogistic import HalfLogistic
 
     >>> hl = HalfLogistic(beta=1)

--- a/skpro/distributions/halfnormal.py
+++ b/skpro/distributions/halfnormal.py
@@ -35,8 +35,8 @@ class HalfNormal(_ScipyAdapter):
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
 
-    Example
-    -------
+    Examples
+    --------
     >>> from skpro.distributions.halfnormal import HalfNormal
 
     >>> hn = HalfNormal(sigma=1)

--- a/skpro/distributions/inversegamma.py
+++ b/skpro/distributions/inversegamma.py
@@ -31,8 +31,8 @@ class InverseGamma(_ScipyAdapter):
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
 
-    Example
-    -------
+    Examples
+    --------
     >>> from skpro.distributions.inversegamma import InverseGamma
 
     >>> d = InverseGamma(beta=[[1, 1], [2, 3], [4, 5]], alpha=2)

--- a/skpro/distributions/laplace.py
+++ b/skpro/distributions/laplace.py
@@ -36,8 +36,8 @@ class Laplace(BaseDistribution):
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
 
-    Example
-    -------
+    Examples
+    --------
     >>> from skpro.distributions import Laplace
 
     >>> n = Laplace(mu=[[0, 1], [2, 3], [4, 5]], scale=1)

--- a/skpro/distributions/logistic.py
+++ b/skpro/distributions/logistic.py
@@ -29,8 +29,8 @@ class Logistic(BaseDistribution):
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
 
-    Example
-    -------
+    Examples
+    --------
     >>> from skpro.distributions.logistic import Logistic
 
     >>> l = Logistic(mu=[[0, 1], [2, 3], [4, 5]], scale=1)

--- a/skpro/distributions/loglaplace.py
+++ b/skpro/distributions/loglaplace.py
@@ -39,8 +39,8 @@ class LogLaplace(_ScipyAdapter):
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
 
-    Example
-    -------
+    Examples
+    --------
     >>> from skpro.distributions.loglaplace import LogLaplace
 
     >>> ll = LogLaplace(scale=1)

--- a/skpro/distributions/lognormal.py
+++ b/skpro/distributions/lognormal.py
@@ -27,8 +27,8 @@ class LogNormal(BaseDistribution):
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
 
-    Example
-    -------
+    Examples
+    --------
     >>> from skpro.distributions.lognormal import LogNormal
 
     >>> n = LogNormal(mu=[[0, 1], [2, 3], [4, 5]], sigma=1)

--- a/skpro/distributions/meanscale.py
+++ b/skpro/distributions/meanscale.py
@@ -35,8 +35,8 @@ class MeanScale(BaseDistribution):
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
 
-    Example
-    -------
+    Examples
+    --------
     >>> from skpro.distributions.normal import Normal
 
     >>> n = Normal(mu=[[0, 1], [2, 3], [4, 5]], sigma=2)

--- a/skpro/distributions/mixture.py
+++ b/skpro/distributions/mixture.py
@@ -31,8 +31,8 @@ class Mixture(BaseMetaObject, BaseDistribution):
     index : pd.Index, optional, default = inferred from component distributions
     columns : pd.Index, optional, default = inferred from component distributions
 
-    Example
-    -------
+    Examples
+    --------
     >>> from skpro.distributions.mixture import Mixture
     >>> from skpro.distributions.normal import Normal
 

--- a/skpro/distributions/normal.py
+++ b/skpro/distributions/normal.py
@@ -33,8 +33,8 @@ class Normal(BaseDistribution):
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
 
-    Example
-    -------
+    Examples
+    --------
     >>> from skpro.distributions.normal import Normal
 
     >>> n = Normal(mu=[[0, 1], [2, 3], [4, 5]], sigma=1)

--- a/skpro/distributions/normal.py
+++ b/skpro/distributions/normal.py
@@ -19,7 +19,7 @@ class Normal(BaseDistribution):
     The normal distribution is parametrized by mean :math:`\mu` and
     standard deviation :math:`\sigma`, such that the pdf is
 
-    .. math:: f(x) = \frac{1}{\sigma \sqrt{2\pi}} \exp\left(-\frac{(x - \mu)^2}{2\sigma^2}\right)  # noqa E501
+    .. math:: f(x) = \frac{1}{\sigma \sqrt{2\pi}} \exp\left(-\frac{(x - \mu)^2}{2\sigma^2}\right)
 
     The mean :math:`\mu` is represented by the parameter ``mu``,
     and the standard deviation :math:`\sigma` by the parameter ``sigma``.
@@ -38,7 +38,7 @@ class Normal(BaseDistribution):
     >>> from skpro.distributions.normal import Normal
 
     >>> n = Normal(mu=[[0, 1], [2, 3], [4, 5]], sigma=1)
-    """
+    """  # noqa E501
 
     _tags = {
         "capabilities:approx": ["pdfnorm"],

--- a/skpro/distributions/pareto.py
+++ b/skpro/distributions/pareto.py
@@ -29,8 +29,8 @@ class Pareto(BaseDistribution):
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
 
-    Example
-    -------
+    Examples
+    --------
     >>> from skpro.distributions.pareto import Pareto
 
     >>> n = Pareto(scale=[[1, 1.5], [2, 2.5], [3, 4]], alpha=3)

--- a/skpro/distributions/pareto.py
+++ b/skpro/distributions/pareto.py
@@ -16,7 +16,8 @@ class Pareto(BaseDistribution):
     and the Pareto index (or shape parameter) :math:`\alpha`
     by the parameter ``alpha``.
 
-    The CDF can be represented as,
+    The CDF can be represented as
+
     :math:`F(x) = 1-\left(\frac{\text{scale}}{x}\right)^\alpha
     \text{ if } x>0, 0 \text{ if } x<0`
 

--- a/skpro/distributions/poisson.py
+++ b/skpro/distributions/poisson.py
@@ -21,8 +21,8 @@ class Poisson(_ScipyAdapter):
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
 
-    Example
-    -------
+    Examples
+    --------
     >>> from skpro.distributions import Poisson
 
     >>> distr = Poisson(mu=[[1, 1], [2, 3], [4, 5]])

--- a/skpro/distributions/qpd.py
+++ b/skpro/distributions/qpd.py
@@ -53,8 +53,8 @@ class QPD_Johnson(_DelegatedDistribution):
     base_dist: str, one of ``'normal'`` (default), ``'logistic'``
         options are ``'normal'`` (default) or ``'logistic'``
 
-    Example
-    -------
+    Examples
+    --------
     >>> from skpro.distributions.qpd import QPD_Johnson  # doctest: +SKIP
 
     >>> qpd = QPD_Johnson(
@@ -193,8 +193,8 @@ class QPD_S(BaseDistribution):
     base_dist: str, one of ``'normal'`` (default), ``'logistic'``
         options are ``'normal'`` (default) or ``'logistic'``
 
-    Example
-    -------
+    Examples
+    --------
     >>> from skpro.distributions.qpd import QPD_S  # doctest: +SKIP
 
     >>> qpd = QPD_S(
@@ -371,8 +371,8 @@ class QPD_B(BaseDistribution):
     base_dist: str, one of ``'normal'`` (default), ``'logistic'``
         options are ``'normal'`` (default) or ``'logistic'``
 
-    Example
-    -------
+    Examples
+    --------
     >>> from skpro.distributions.qpd import QPD_B  # doctest: +SKIP
 
     >>> qpd = QPD_B(
@@ -555,8 +555,8 @@ class QPD_U(BaseDistribution):
     base_dist: str, one of ``'normal'`` (default), ``'logistic'``
         options are ``'normal'`` (default) or ``'logistic'``
 
-    Example
-    -------
+    Examples
+    --------
     >>> from skpro.distributions.qpd import QPD_U  # doctest: +SKIP
 
     >>> qpd = QPD_U(

--- a/skpro/distributions/qpd_empirical.py
+++ b/skpro/distributions/qpd_empirical.py
@@ -57,8 +57,8 @@ class QPD_Empirical(Empirical):
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
 
-    Example
-    -------
+    Examples
+    --------
     >>> import pandas as pd
     >>> from skpro.distributions import QPD_Empirical
 

--- a/skpro/distributions/t.py
+++ b/skpro/distributions/t.py
@@ -24,8 +24,8 @@ class TDistribution(BaseDistribution):
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
 
-    Example
-    -------
+    Examples
+    --------
     >>> from skpro.distributions.t import TDistribution
 
     >>> n = TDistribution(mu=[[0, 1], [2, 3], [4, 5]], sigma=1, df=10)

--- a/skpro/distributions/truncated_normal.py
+++ b/skpro/distributions/truncated_normal.py
@@ -33,8 +33,8 @@ class TruncatedNormal(_ScipyAdapter):
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
 
-    Example
-    -------
+    Examples
+    --------
     >>> from skpro.distributions.truncated_normal import TruncatedNormal
 
     >>> d = TruncatedNormal(\

--- a/skpro/distributions/uniform.py
+++ b/skpro/distributions/uniform.py
@@ -29,8 +29,8 @@ class Uniform(BaseDistribution):
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
 
-    Example
-    -------
+    Examples
+    --------
     >>> from skpro.distributions import Uniform
 
     >>> u = Uniform(lower=0, upper=5)

--- a/skpro/distributions/weibull.py
+++ b/skpro/distributions/weibull.py
@@ -30,8 +30,8 @@ class Weibull(BaseDistribution):
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
 
-    Example
-    -------
+    Examples
+    --------
     >>> from skpro.distributions.weibull import Weibull
 
     >>> w = Weibull(scale=[[1, 1], [2, 3], [4, 5]], k=1)

--- a/skpro/regression/cyclic_boosting.py
+++ b/skpro/regression/cyclic_boosting.py
@@ -102,8 +102,8 @@ class CyclicBoosting(BaseProbaRegressor):
     qpd: skpro.distributions.J_QPD_S
         Johnson Quantile-Parameterized Distributions instance
 
-    Example
-    -------
+    Examples
+    --------
     >>> from skpro.regression.cyclic_boosting import CyclicBoosting
     >>> from sklearn.datasets import load_diabetes  # doctest: +SKIP
     >>> from sklearn.model_selection import train_test_split  # doctest: +SKIP

--- a/skpro/regression/mapie.py
+++ b/skpro/regression/mapie.py
@@ -144,8 +144,8 @@ class MapieRegressor(BaseProbaRegressor):
     conformity_scores_: ArrayLike of shape (n_samples_train,)
         Conformity scores between ``y_train`` and ``y_pred``.
 
-    Example
-    -------
+    Examples
+    --------
     >>> from skpro.regression.mapie import MapieRegressor  # doctest: +SKIP
     >>> from sklearn.ensemble import RandomForestRegressor  # doctest: +SKIP
     >>> from sklearn.datasets import load_diabetes  # doctest: +SKIP

--- a/skpro/regression/residual.py
+++ b/skpro/regression/residual.py
@@ -101,8 +101,8 @@ class ResidualDouble(BaseProbaRegressor):
     estimator_resid_ : sklearn regressor, clone of ``estimator_resid``
         fitted estimator predicting the scale of the residual
 
-    Example
-    -------
+    Examples
+    --------
     >>> from skpro.regression.residual import ResidualDouble
     >>> from sklearn.ensemble import RandomForestRegressor
     >>> from sklearn.linear_model import LinearRegression

--- a/skpro/utils/plotting.py
+++ b/skpro/utils/plotting.py
@@ -37,8 +37,8 @@ def plot_crossplot_interval(y_true, y_pred, coverage=None, ax=None):
         If ax was None, a new figure is created and returned
         If ax was not None, the same ax is returned with plot added
 
-    Example
-    -------
+    Examples
+    --------
     >>> from skpro.utils.plotting import plot_crossplot_interval  # doctest: +SKIP
     >>> from skpro.regression.residual import ResidualDouble  # doctest: +SKIP
     >>> from sklearn.ensemble import RandomForestRegressor  # doctest: +SKIP
@@ -119,8 +119,8 @@ def plot_crossplot_std(y_true, y_pred, ax=None):
         If ax was None, a new figure is created and returned
         If ax was not None, the same ax is returned with plot added
 
-    Example
-    -------
+    Examples
+    --------
     >>> from skpro.utils.plotting import plot_crossplot_std  # doctest: +SKIP
     >>> from skpro.regression.residual import ResidualDouble  # doctest: +SKIP
     >>> from sklearn.ensemble import RandomForestRegressor  # doctest: +SKIP
@@ -191,8 +191,8 @@ def plot_crossplot_loss(y_true, y_pred, metric, ax=None):
         If ax was None, a new figure is created and returned
         If ax was not None, the same ax is returned with plot added
 
-    Example
-    -------
+    Examples
+    --------
     >>> from skpro.utils.plotting import plot_crossplot_loss  # doctest: +SKIP
     >>> from skpro.metrics import CRPS  # doctest: +SKIP
     >>> from skpro.regression.residual import ResidualDouble  # doctest: +SKIP


### PR DESCRIPTION
It seems that examples in a docstring section with title `Example` are not displayed by sphinx, the name needs to be `Examples`.

This PR corrects the section header in a number of docstrings.

Mirror of https://github.com/sktime/sktime/pull/7341 in `sktime`.