### PR TITLE
[ENH] Synchronize dependency checker with `sktime` counterpart

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -177,6 +177,15 @@
       ]
     },
     {
+      "login": "meraldoantonio",
+      "name": "Meraldo Antonio",
+      "avatar_url": "https://avatars.githubusercontent.com/u/37468543?v=4",
+      "profile": "https://github.com/meraldoantonio",
+      "contributions": [
+        "bug"
+      ]
+    },
+    {
       "login": "szepeviktor",
       "name": "Viktor Szépe",
       "avatar_url": "https://avatars.githubusercontent.com/u/952007?v=4",

--- a/skpro/utils/_maint/_show_versions.py
+++ b/skpro/utils/_maint/_show_versions.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3 -u
 # License: BSD 3 clause
-
 """Utility methods to print system info for debugging.
 
-adapted from :func:`sklearn.show_versions`
+adapted from
+:func: `sklearn.show_versions`
 """
 
 __author__ = ["mloning", "fkiraly"]
@@ -15,8 +15,7 @@ import sys
 
 
 def _get_sys_info():
-    """
-    System information.
+    """System information.
 
     Return
     ------
@@ -37,28 +36,33 @@ def _get_sys_info():
 # dependencies to print versions of, by default
 DEFAULT_DEPS_TO_SHOW = [
     "pip",
-    "skpro",
-    "skbase",
+    "sktime",
     "sklearn",
+    "skbase",
     "numpy",
     "scipy",
     "pandas",
     "matplotlib",
     "joblib",
     "numba",
-    "tabulate",
-    "uncertainties",
+    "statsmodels",
+    "pmdarima",
+    "statsforecast",
+    "tsfresh",
+    "tslearn",
+    "torch",
+    "tensorflow",
+    "tensorflow_probability",
 ]
 
 
 def _get_deps_info(deps=None):
-    """
-    Overview of the installed version of main dependencies.
+    """Overview of the installed version of main dependencies.
 
     Parameters
     ----------
     deps : optional, list of strings with import names
-        if None, behaves as deps = ["skpro"]
+        if None, behaves as deps = ["sktime"]
 
     Returns
     -------
@@ -68,10 +72,10 @@ def _get_deps_info(deps=None):
         of the import as present in the current python environment
     """
     if deps is None:
-        deps = ["skpro"]
+        deps = ["sktime"]
 
     def get_version(module):
-        return module.__version__
+        return getattr(module, "__version__", None)
 
     deps_info = {}
 
@@ -81,16 +85,17 @@ def _get_deps_info(deps=None):
                 mod = sys.modules[modname]
             else:
                 mod = importlib.import_module(modname)
-            ver = get_version(mod)
-            deps_info[modname] = ver
         except ImportError:
             deps_info[modname] = None
+        else:
+            ver = get_version(mod)
+            deps_info[modname] = ver
 
     return deps_info
 
 
 def show_versions():
-    """Print python version, OS version, skpro version, selected dependency versions.
+    """Print python version, OS version, sktime version, selected dependency versions.
 
     Pretty prints:
 

--- a/skpro/utils/_maint/tests/test_show_versions.py
+++ b/skpro/utils/_maint/tests/test_show_versions.py
@@ -20,7 +20,7 @@ def test_deps_info():
     """Test that _get_deps_info returns package/version dict as per contract."""
     deps_info = _get_deps_info()
     assert isinstance(deps_info, dict)
-    assert set(deps_info.keys()) == {"skpro"}
+    assert set(deps_info.keys()) == {"sktime"}
 
     deps_info_default = _get_deps_info(DEFAULT_DEPS_TO_SHOW)
     assert isinstance(deps_info_default, dict)

--- a/skpro/utils/_maint/tests/test_show_versions.py
+++ b/skpro/utils/_maint/tests/test_show_versions.py
@@ -1,4 +1,6 @@
 """Tests for the show_versions utility."""
+import pathlib
+import uuid
 
 from skpro.utils._maint._show_versions import (
     DEFAULT_DEPS_TO_SHOW,
@@ -24,10 +26,33 @@ def test_deps_info():
     assert isinstance(deps_info_default, dict)
     assert set(deps_info_default.keys()) == set(DEFAULT_DEPS_TO_SHOW)
 
+    PKG_IMPORT_ALIAS = {"scikit-learn": "sklearn", "scikit-base": "skbase"}
+    KEY_ALIAS = {"sklearn": "scikit-learn", "skbase": "scikit-base"}
+
     for key in DEFAULT_DEPS_TO_SHOW:
-        key_is_available = _check_soft_dependencies(key, severity="none")
+        pkg_name = KEY_ALIAS.get(key, key)
+        key_is_available = _check_soft_dependencies(
+            pkg_name,
+            severity="none",
+            package_import_alias=PKG_IMPORT_ALIAS,
+        )
         assert (deps_info_default[key] is None) != key_is_available
         if key_is_available:
-            assert _check_soft_dependencies(f"{key}=={deps_info_default[key]}")
+            assert _check_soft_dependencies(
+                f"{pkg_name}=={deps_info_default[key]}",
+                package_import_alias=PKG_IMPORT_ALIAS,
+            )
         deps_single_key = _get_deps_info([key])
         assert set(deps_single_key.keys()) == {key}
+
+
+def test_deps_info_deps_missing_package_present_directory():
+    """Test that _get_deps_info does not fail if a dependency is missing."""
+    dummy_package_name = uuid.uuid4().hex
+
+    dummy_folder_path = pathlib.Path(dummy_package_name)
+    dummy_folder_path.mkdir()
+
+    assert _get_deps_info([dummy_package_name]) == {dummy_package_name: None}
+
+    dummy_folder_path.rmdir()


### PR DESCRIPTION
#### Reference Issues/PRs
Potentially fixes #358 (failing Python tests)
Addresses issue #489

#### What does this implement/fix? Explain your changes.

Synchronized dependency checking utilities in utils with the one from `sktime`

The current version is a fork of a much earlier version of `sktime` and is problematic as it must import packages in order to check presence of dependencies. This is causing the failures in the test collection phase in #358, or more generally, in a case where the imported package is faulty, with import causing exceptions.

#### Does your contribution introduce a new dependency? If yes, which one?
No

#### What should a reviewer concentrate their feedback on?
Compatibility of the content with  the wider `skpro` ecosystem

#### Did you add any tests for the change?
Yes, I copied the corresponding dependency test `test_show_versions` from `sktime`

#### Any other comments?
No

#### PR checklist
##### For all contributions
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

