### PR TITLE
[ENH] set up exclude list for estimators

### DIFF
--- a/skpro/tests/_config.py
+++ b/skpro/tests/_config.py
@@ -2,4 +2,10 @@
 
 # list of str, names of estimators to exclude from testing
 # WARNING: tests for these estimators will be skipped
-EXCLUDE_ESTIMATORS = ["DummySkipped"]
+EXCLUDE_ESTIMATORS = [
+    "DummySkipped",
+    "ClassName",  # exclude classes from extension templates
+]
+
+
+EXCLUDED_TESTS = {"GLMRegressor": ["test_online_update"]}

--- a/skpro/tests/test_all_estimators.py
+++ b/skpro/tests/test_all_estimators.py
@@ -13,6 +13,7 @@ from skbase.testing import TestAllObjects as _TestAllObjects
 from skbase.testing.utils.inspect import _get_args
 
 from skpro.registry import OBJECT_TAG_LIST, all_objects
+from skpro.tests._config import EXCLUDE_ESTIMATORS, EXCLUDED_TESTS
 from skpro.tests.scenarios.scenarios_getter import retrieve_scenarios
 from skpro.tests.test_switch import run_test_for_class
 from skpro.utils.deep_equals import deep_equals
@@ -35,7 +36,12 @@ class PackageConfig:
 
     # list of object types (class names) to exclude
     # expected type: list of str, str are class names
-    exclude_objects = ["ClassName"]  # exclude classes from extension templates
+    exclude_objects = EXCLUDE_ESTIMATORS
+
+    # list of tests to exclude
+    # expected type: dict of lists, key:str, value: List[str]
+    # keys are class names of estimators, values are lists of test names to exclude
+    excluded_tests = EXCLUDED_TESTS
 
     # list of valid tags
     # expected type: list of str, str are tag names


### PR DESCRIPTION
This PR sets up an exclude list for estimators in `skpro`.

Similar to `sktime`, excluded tests or estimators can now be specified in `skpro.tests._config`.

Also adds a skip for https://github.com/sktime/skpro/issues/497.