### PR TITLE
[ENH] Erlang Distribution

### DIFF
--- a/docs/source/api_reference/distributions.rst
+++ b/docs/source/api_reference/distributions.rst
@@ -55,6 +55,7 @@ Continuous support - non-negative reals
     Beta
     ChiSquared
     Exponential
+    Erlang
     Fisk
     Gamma
     HalfCauchy

--- a/skpro/distributions/__init__.py
+++ b/skpro/distributions/__init__.py
@@ -10,6 +10,7 @@ __all__ = [
     "ChiSquared",
     "Delta",
     "Empirical",
+    "Erlang",
     "Exponential",
     "Fisk",
     "Gamma",
@@ -46,6 +47,7 @@ from skpro.distributions.chi_squared import ChiSquared
 from skpro.distributions.compose import IID
 from skpro.distributions.delta import Delta
 from skpro.distributions.empirical import Empirical
+from skpro.distributions.erlang import Erlang
 from skpro.distributions.exponential import Exponential
 from skpro.distributions.fisk import Fisk
 from skpro.distributions.gamma import Gamma

--- a/skpro/distributions/erlang.py
+++ b/skpro/distributions/erlang.py
@@ -8,25 +8,25 @@ from scipy.stats import erlang, rv_continuous
 
 from skpro.distributions.adapters.scipy import _ScipyAdapter
 
+
 class Erlang(_ScipyAdapter):
     r"""Erlang Distribution
 
     Most methods wrap ``scipy.stats.erlang``.
 
-    The Erlang Distribution is parameterized by shape :math:`k` 
+    The Erlang Distribution is parameterized by shape :math:`k`
     and rate :math:`\lambda`, such that the pdf is
 
     .. math:: f(x) = \frac{x^{k-1}\exp\left(-\lambda x\right) \lambda^{k}}{(k-1)!}
 
-
     Parameters
     ----------
-    - shape : int or array of int (1D or 2D)  
+    shape : int or array of int (1D or 2D)
         Represents the shape parameter.
-    - rate : float or array of float (1D or 2D)  
+    rate : float or array of float (1D or 2D)
         Represents the rate parameter, which is also the inverse of the scale parameter.
-    - index : pd.Index, optional, default = RangeIndex
-    - columns : pd.Index, optional, default = RangeIndex  
+    index : pd.Index, optional, default = RangeIndex
+    columns : pd.Index, optional, default = RangeIndex
 
     Examples
     ----------
@@ -34,7 +34,7 @@ class Erlang(_ScipyAdapter):
 
     >>> d = Erlang(rate=[[1, 1], [2, 3], [4, 5]], shape=2)
     """
-    
+
     _tags = {
         "capabilities:approx": ["energy", "pdfnorm"],
         "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
@@ -42,43 +42,41 @@ class Erlang(_ScipyAdapter):
         "distr:paramtype": "parametric",
         "broadcast_init": "on",
     }
-    def __init__(self,rate, shape, index=None, columns=None):
-        if(rate <= 0):
+
+    def __init__(self, rate, shape, index=None, columns=None):
+        if rate <= 0:
             raise ValueError("Rate must be greater than 0.")
         if not isinstance(shape, int):
             raise ValueError("shape must be a positive integer.")
-        if(shape <= 0):
+        if shape <= 0:
             raise ValueError("shape must be a positive integer.")
         self.rate = rate
         self.shape = shape
-        
+
         super().__init__(index=index, columns=columns)
+
     def _get_scipy_object(self) -> rv_continuous:
         return erlang
-    
+
     def _get_scipy_param(self):
         rate = self._bc_params["rate"]
         shape = self._bc_params["shape"]
-        return [],{"scale":1/rate,"a":shape}
+
+        return [], {"scale": 1 / rate, "a": shape}
+
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Return testing parameter settings for the estimator."""
         # Array case examples
         params1 = {
             "rate": 2.0,
-            "shape": 3,          
-            "index": pd.Index([0, 1, 2]),  
-            "columns": pd.Index(["x", "y"]),  
+            "shape": 3,
+            "index": pd.Index([0, 1, 2]),
+            "columns": pd.Index(["x", "y"]),
         }
         # Scalar case examples
-        params2 = {
-            "rate": 0.8,
-            "shape": 2
-        }
-        
-        params3 = {
-            "rate": 3.0,
-            "shape": 1
-        }
+        params2 = {"rate": 0.8, "shape": 2}
+
+        params3 = {"rate": 3.0, "shape": 1}
 
         return [params1, params2, params3]

--- a/skpro/distributions/erlang.py
+++ b/skpro/distributions/erlang.py
@@ -21,10 +21,10 @@ class Erlang(_ScipyAdapter):
 
     Parameters
     ----------
-    - k : int or array of int (1D or 2D)  
-    Represents the shape parameter.
-    - lambda_ : float or array of float (1D or 2D)  
-    Represents the rate parameter, which is also the inverse of the scale parameter.
+    - shape : int or array of int (1D or 2D)  
+        Represents the shape parameter.
+    - rate : float or array of float (1D or 2D)  
+        Represents the rate parameter, which is also the inverse of the scale parameter.
     - index : pd.Index, optional, default = RangeIndex
     - columns : pd.Index, optional, default = RangeIndex  
 
@@ -32,7 +32,7 @@ class Erlang(_ScipyAdapter):
     ----------
     >>> from skpro.distributions.erlang import Erlang
 
-    >>> d = Erlang(lambda_=[[1, 1], [2, 3], [4, 5]], k=2)
+    >>> d = Erlang(rate=[[1, 1], [2, 3], [4, 5]], shape=2)
     """
     
     _tags = {
@@ -42,41 +42,41 @@ class Erlang(_ScipyAdapter):
         "distr:paramtype": "parametric",
         "broadcast_init": "on",
     }
-    def __init__(self,lambda_, k, index=None, columns=None):
-        if(lambda_ <= 0):
-            raise ValueError("lambda_ must be greater than 0.")
-        if( isinstance(k, int) == False or k <= 0):
-            raise ValueError("k must be a positive integer.")
-        self.lambda_ = lambda_
-        self.k = k
+    def __init__(self,rate, shape, index=None, columns=None):
+        if(rate <= 0):
+            raise ValueError("Rate must be greater than 0.")
+        if( isinstance(shape, int) == False or shape <= 0):
+            raise ValueError("shape must be a positive integer.")
+        self.rate = rate
+        self.shape = shape
         
         super().__init__(index=index, columns=columns)
     def _get_scipy_object(self) -> rv_continuous:
         return erlang
     
     def _get_scipy_param(self):
-        lambda_ = self._bc_params["lambda_"]
-        k = self._bc_params["k"]
-        return [],{"scale":1/lambda_,"a":k}
+        rate = self._bc_params["rate"]
+        shape = self._bc_params["shape"]
+        return [],{"scale":1/rate,"a":shape}
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Return testing parameter settings for the estimator."""
         # Array case examples
         params1 = {
-            "lambda_": 2.0,
-            "k": 3,          
+            "rate": 2.0,
+            "shape": 3,          
             "index": pd.Index([0, 1, 2]),  
             "columns": pd.Index(["x", "y"]),  
         }
         # Scalar case examples
         params2 = {
-            "lambda_": 0.8,
-            "k": 2
+            "rate": 0.8,
+            "shape": 2
         }
         
         params3 = {
-            "lambda_": 3.0,
-            "k": 1
+            "rate": 3.0,
+            "shape": 1
         }
 
         return [params1, params2, params3]

--- a/skpro/distributions/erlang.py
+++ b/skpro/distributions/erlang.py
@@ -1,0 +1,82 @@
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+"""Erlang probability distribution."""
+
+__author__ = ["RUPESH-KUMAR01"]
+
+import pandas as pd
+from scipy.stats import erlang, rv_continuous
+
+from skpro.distributions.adapters.scipy import _ScipyAdapter
+
+class Erlang(_ScipyAdapter):
+    r"""Erlang Distribution
+
+    Most methods wrap ``scipy.stats.erlang``.
+
+    The Erlang Distribution is parameterized by shape :math:`k` 
+    and rate :math:`\lambda`, such that the pdf is
+
+    .. math:: f(x) = \frac{x^{k-1}\exp\left(-\lambda x\right) \lambda^{k}}{(k-1)!}
+
+
+    Parameters
+    ----------
+    - k : int or array of int (1D or 2D)  
+    Represents the shape parameter.
+    - lambda_ : float or array of float (1D or 2D)  
+    Represents the rate parameter, which is also the inverse of the scale parameter.
+    - index : pd.Index, optional, default = RangeIndex
+    - columns : pd.Index, optional, default = RangeIndex  
+
+    Examples
+    ----------
+    >>> from skpro.distributions.erlang import Erlang
+
+    >>> d = Erlang(λ=[[1, 1], [2, 3], [4, 5]], k=2)
+    """
+    
+    _tags = {
+        "capabilities:approx": ["energy", "pdfnorm"],
+        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
+        "distr:measuretype": "continuous",
+        "distr:paramtype": "parametric",
+        "broadcast_init": "on",
+    }
+    def __init__(self,lambda_, k, index=None, columns=None):
+        if(lambda_ <= 0):
+            raise ValueError("lambda_ must be greater than 0.")
+        if( isinstance(k, int) == False or k <= 0):
+            raise ValueError("k must be a positive integer.")
+        self.lambda_ = lambda_
+        self.k = k
+        
+        super().__init__(index=index, columns=columns)
+    def _get_scipy_object(self) -> rv_continuous:
+        return erlang
+    
+    def _get_scipy_param(self):
+        lambda_ = self._bc_params["lambda_"]
+        k = self._bc_params["k"]
+        return [],{"scale":1/lambda_,"a":k}
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator."""
+        # Array case examples
+        params1 = {
+            "lambda_": 2.0,
+            "k": 3,          
+            "index": pd.Index([0, 1, 2]),  
+            "columns": pd.Index(["x", "y"]),  
+        }
+        # Scalar case examples
+        params2 = {
+            "lambda_": 0.8,
+            "k": 2
+        }
+        
+        params3 = {
+            "lambda_": 3.0,
+            "k": 1
+        }
+
+        return [params1, params2, params3]

--- a/skpro/distributions/erlang.py
+++ b/skpro/distributions/erlang.py
@@ -45,7 +45,9 @@ class Erlang(_ScipyAdapter):
     def __init__(self,rate, shape, index=None, columns=None):
         if(rate <= 0):
             raise ValueError("Rate must be greater than 0.")
-        if( isinstance(shape, int) == False or shape <= 0):
+        if not isinstance(shape, int):
+            raise ValueError("shape must be a positive integer.")
+        if(shape <= 0):
             raise ValueError("shape must be a positive integer.")
         self.rate = rate
         self.shape = shape

--- a/skpro/distributions/erlang.py
+++ b/skpro/distributions/erlang.py
@@ -32,7 +32,7 @@ class Erlang(_ScipyAdapter):
     ----------
     >>> from skpro.distributions.erlang import Erlang
 
-    >>> d = Erlang(λ=[[1, 1], [2, 3], [4, 5]], k=2)
+    >>> d = Erlang(lambda_=[[1, 1], [2, 3], [4, 5]], k=2)
     """
     
     _tags = {


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skpro.readthedocs.io/en/latest/contribute.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Implementing a distribution towards #22 

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
Implements Erlang Distribution
#### Does your contribution introduce a new dependency? If yes, which one?
No
<!--
If your contribution does add a new core dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core skpro package to a minimum.
-->

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
I am unsure about the get_test_params(). I tried to write it similar to other distributions following the distribution conditions. It would be helpful if I could get feedback on it.
#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
