### PR TITLE
[DOC] improved docstring for the `TDistribution`

### DIFF
--- a/skpro/distributions/t.py
+++ b/skpro/distributions/t.py
@@ -16,13 +16,13 @@ class TDistribution(BaseDistribution):
     Parameters
     ----------
     mean : float or array of float (1D or 2D)
-        median of the t-distribution distribution.
+        median of the t-distribution.
         Same as the mean, if it exists.
     sd : float or array of float (1D or 2D), must be positive
         scale parameter of the t-distribution.
         Same as the standard deviation in the limit of large degrees of freedom.
     df : float or array of float (1D or 2D), must be positive
-        Degrees of freedom of the t-distribution
+        Degrees of freedom of the t-distribution.
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
 

--- a/skpro/distributions/t.py
+++ b/skpro/distributions/t.py
@@ -16,9 +16,11 @@ class TDistribution(BaseDistribution):
     Parameters
     ----------
     mean : float or array of float (1D or 2D)
-        mean of the t-distribution distribution
+        median of the t-distribution distribution.
+        Same as the mean, if it exists.
     sd : float or array of float (1D or 2D), must be positive
-        standard deviation of the t-distribution distribution
+        scale parameter of the t-distribution.
+        Same as the standard deviation in the limit of large degrees of freedom.
     df : float or array of float (1D or 2D), must be positive
         Degrees of freedom of the t-distribution
     index : pd.Index, optional, default = RangeIndex


### PR DESCRIPTION
Fixes some mathematical errors in the docstring of the `TDistribution`:

* the `mean` is not a mean as it may not exist. Replaced with median in the explanation.
* the `sd` is in general not the standard deviation, which may also not exist. Corrected the explanation.