### PR TITLE
[MNT] move release to trusted publishers

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -103,5 +103,4 @@ jobs:
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
           packages-dir: wheelhouse/


### PR DESCRIPTION
Moves the release to trusted publishers.

All secrets have been removed from the repo.