### PR TITLE
[ENH] `MultiQuantileRegressor` sensible defaults

### DIFF
--- a/skpro/regression/multiquantile.py
+++ b/skpro/regression/multiquantile.py
@@ -121,21 +121,22 @@ class MultipleQuantileRegressor(BaseProbaRegressor):
         self.n_jobs = n_jobs
         self.sort_quantiles = sort_quantiles
 
-        # input checks
-        if len(alpha) == 0:
-            raise ValueError("at least one value in alpha is required.")
-        elif np.amin(alpha) <= 0 or np.amax(alpha) >= 1:
-            raise ValueError(
-                "values in alpha must lie in the open interval (0, 1), "
-                f"but found alpha: {alpha}."
-            )
-
         super().__init__()
 
         if alpha is None:
-            self._alpha = [0.1, 0.25, 0.5, 0.75, 0.9]
+            _alpha = [0.1, 0.25, 0.5, 0.75, 0.9]
         else:
-            self._alpha = alpha
+            _alpha = alpha
+
+        # input checks
+        if len(_alpha) == 0:
+            raise ValueError("at least one value in alpha is required.")
+        elif np.amin(_alpha) <= 0 or np.amax(_alpha) >= 1:
+            raise ValueError(
+                "values in alpha must lie in the open interval (0, 1), "
+                f"but found alpha: {_alpha}."
+            )
+        self._alpha = _alpha
 
         if quantile_regressor is None:
             from sklearn.ensemble import GradientBoostingRegressor

--- a/skpro/regression/multiquantile.py
+++ b/skpro/regression/multiquantile.py
@@ -125,17 +125,15 @@ class MultipleQuantileRegressor(BaseProbaRegressor):
 
         if alpha is None:
             _alpha = [0.1, 0.25, 0.5, 0.75, 0.9]
-        else:
-            _alpha = alpha
-
-        # input checks
-        if len(_alpha) == 0:
+        elif len(alpha) == 0:
             raise ValueError("at least one value in alpha is required.")
-        elif np.amin(_alpha) <= 0 or np.amax(_alpha) >= 1:
+        elif np.amin(alpha) <= 0 or np.amax(alpha) >= 1:
             raise ValueError(
                 "values in alpha must lie in the open interval (0, 1), "
-                f"but found alpha: {_alpha}."
+                f"but found alpha: {alpha}."
             )
+        else:
+            _alpha = alpha
         self._alpha = _alpha
 
         if quantile_regressor is None:

--- a/skpro/regression/multiquantile.py
+++ b/skpro/regression/multiquantile.py
@@ -168,7 +168,7 @@ class MultipleQuantileRegressor(BaseProbaRegressor):
         """
         # clone, set alpha and list all regressors
         regressors = [clone(self._mean_regressor)]
-        for a in self.alpha:
+        for a in self._alpha:
             q_est = clone(self._quantile_regressor)
             q_est = q_est.set_params(**{self.alpha_name: a})
             q_est_p = q_est.get_params()
@@ -190,7 +190,7 @@ class MultipleQuantileRegressor(BaseProbaRegressor):
         # put fitted regressors in dict and write to self
         regressors_ = {}
         regressors_["mean"] = fitted_regressors.pop(0)
-        for i, a in enumerate(self.alpha):
+        for i, a in enumerate(self._alpha):
             regressors_[a] = fitted_regressors[i]
         self.regressors_ = regressors_
 
@@ -254,7 +254,7 @@ class MultipleQuantileRegressor(BaseProbaRegressor):
         # per a in alpha, list fitted regressor that is nearest to a
         regressors = []
         for a in sorted(alpha):
-            nearest_fitted_a = min(self.alpha, key=lambda p: abs(p - a))
+            nearest_fitted_a = min(self._alpha, key=lambda p: abs(p - a))
             regressors.append(self.regressors_[nearest_fitted_a])
 
         # predict
@@ -307,7 +307,7 @@ class MultipleQuantileRegressor(BaseProbaRegressor):
         """
         from skpro.distributions import QPD_Empirical
 
-        alpha_sorted = sorted(self.alpha)
+        alpha_sorted = sorted(self._alpha)
 
         # get quantile prediction for all fitted quantile regressors
         quantile_preds = self._predict_quantiles(X, alpha_sorted)


### PR DESCRIPTION
This Pr sets sensible defaults for `MultiQuantileRegressor` components - namely, `GradientBoostingRegressor`.

A test case for all-defaults is added.

FYI @Ram0nB.