### PR TITLE
[BUG] fix `MapieRegressor` dependency check, and `BaseProbaRegressor._predict_proba` default

### DIFF
--- a/skpro/regression/base/_base.py
+++ b/skpro/regression/base/_base.py
@@ -336,7 +336,10 @@ class BaseProbaRegressor(BaseEstimator):
 
         from skpro.distributions.normal import Normal
 
-        index = X.index
+        if hasattr(X, "index"):
+            index = X.index
+        else:
+            index = pd.RangeIndex(start=0, stop=len(X), step=1)
         columns = self._get_columns(method="predict")
         pred_dist = Normal(mu=pred_mean, sigma=pred_std, index=index, columns=columns)
 

--- a/skpro/regression/base/_base.py
+++ b/skpro/regression/base/_base.py
@@ -336,8 +336,8 @@ class BaseProbaRegressor(BaseEstimator):
 
         from skpro.distributions.normal import Normal
 
-        index = pred_mean.index
-        columns = pred_mean.columns
+        index = X.index
+        columns = self._get_columns(method="predict")
         pred_dist = Normal(mu=pred_mean, sigma=pred_std, index=index, columns=columns)
 
         return pred_dist

--- a/skpro/regression/mapie.py
+++ b/skpro/regression/mapie.py
@@ -167,7 +167,7 @@ class MapieRegressor(BaseProbaRegressor):
         # packaging info
         # --------------
         "authors": ["fkiraly"],
-        "python_dependencies": ["mapie"],
+        "python_dependencies": ["MAPIE"],
         # estimator tags
         # --------------
         "capability:missing": True,
@@ -215,7 +215,7 @@ class MapieRegressor(BaseProbaRegressor):
         self : reference to self
         """
         # construct mapie regressor
-        from mapie.regression.regression import MapieRegressor
+        from mapie.regression import MapieRegressor
 
         PARAMS_TO_FORWARD = [
             "estimator",


### PR DESCRIPTION
This PR fixes two unreported bugs:

* the `MapieRegressor` dependency check was always failing due to the capitalization of `MAPIE` on pypi - not `mapie`. This led to the estimator not being useable since the upgrade to strict PEP 440 (which included capitalization sensitivity) of the `python_dependencies` tag.
* the `BaseProbaRegressor._predict_proba` sensible default would not work properly if the expected return of `predict` was not a `pd.DataFrame`. This has been remedied by using the idiomatic method `_get_columns` to determine the column names.