### PR TITLE
[BUG] fix `NgboostRegressor` not working with custom `sklearn` estimator

### DIFF
--- a/skpro/regression/ensemble/_ngboost.py
+++ b/skpro/regression/ensemble/_ngboost.py
@@ -145,6 +145,8 @@ class NGBoostRegressor(BaseProbaRegressor, NGBoostAdapter):
                 splitter="best",
                 random_state=None,
             )
+        else:
+            self.estimator_ = clone(self.estimator)
 
         dist_ngboost = self._dist_to_ngboost_instance(self.dist, survival=False)
 
@@ -257,10 +259,14 @@ class NGBoostRegressor(BaseProbaRegressor, NGBoostAdapter):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
+        from sklearn.ensemble import RandomForestRegressor
+        from sklearn.linear_model import LinearRegression
+
         params1 = {"dist": "Normal"}
         params2 = {
             "dist": "Laplace",
             "n_estimators": 800,
+            "estimator": LinearRegression(),
         }
         params3 = {}
         params4 = {
@@ -272,6 +278,7 @@ class NGBoostRegressor(BaseProbaRegressor, NGBoostAdapter):
             "dist": "LogNormal",
             "learning_rate": 0.001,
             "validation_fraction": 0.2,
+            "estimator": RandomForestRegressor(),
         }
 
         params6 = {

--- a/skpro/regression/ensemble/_ngboost.py
+++ b/skpro/regression/ensemble/_ngboost.py
@@ -21,19 +21,23 @@ class NGBoostRegressor(BaseProbaRegressor, NGBoostAdapter):
         distribution that must be used for
         probabilistic prediction.
         Available distribution types
+
         1. "Normal"
         2. "Laplace"
         3. "LogNormal"
         4. "Poisson"
         5. "TDistribution"
         6. "Exponential"
+
     score : string , default = "LogScore"
         A score from ngboost.scores for LogScore
         rule to compare probabilistic
         predictions P̂ to the observed data y.
+
     estimator : default learner/estimator: DecisionTreeRegressor()
         base learner to use in the boosting algorithm.
         Any instantiated sklearn regressor.
+
     natural_gradient : boolean , default = True
         whether natural gradient must be used or not.
     n_estimators : int , default = 500

--- a/skpro/regression/ensemble/_ngboost.py
+++ b/skpro/regression/ensemble/_ngboost.py
@@ -126,6 +126,7 @@ class NGBoostRegressor(BaseProbaRegressor, NGBoostAdapter):
         """
         from ngboost import NGBRegressor
         from ngboost.scores import LogScore
+        from sklearn.base import clone
         from sklearn.tree import DecisionTreeRegressor
 
         # coerce y to numpy array
@@ -174,7 +175,6 @@ class NGBoostRegressor(BaseProbaRegressor, NGBoostAdapter):
             validation_fraction=self.validation_fraction,
             early_stopping_rounds=self.early_stopping_rounds,
         )
-        from sklearn.base import clone
 
         self.ngb_ = clone(self.ngb)
         self.ngb_.fit(X, y)

--- a/skpro/regression/ensemble/_ngboost.py
+++ b/skpro/regression/ensemble/_ngboost.py
@@ -65,10 +65,27 @@ class NGBoostRegressor(BaseProbaRegressor, NGBoostAdapter):
         Set to None to disable early stopping and validation
         None enables running over the full data set.
 
-
-    Returns
+    Example
     -------
-    An NGBRegressor object that can be fit.
+    from sklearn.datasets import load_diabetes
+    from sklearn.linear_model import LinearRegression
+    from sklearn.model_selection import train_test_split
+    from skpro.regression.ensemble import NGBoostRegressor
+    from skpro.metrics import LogLoss
+
+    X, y = load_diabetes(return_X_y=True, as_frame=True)
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)
+    ngb = NGBoostRegressor(
+        dist="Normal",
+        score="LogScore",
+        estimator=LinearRegression(),
+        n_estimators=100,
+    )
+    ngb.fit(X_train, y_train)
+    y_pred = ngb.predict_proba(X_test)
+
+    logloss = LogLoss()
+    score = logloss(y_test, y_pred)
     """
 
     _tags = {

--- a/skpro/survival/ensemble/_ngboost_surv.py
+++ b/skpro/survival/ensemble/_ngboost_surv.py
@@ -23,9 +23,11 @@ class NGBoostSurvival(BaseSurvReg, NGBoostAdapter):
     dist : string , default = "LogNormal"
         assumed distributional form of Y|X=x.
         A distribution from ngboost.distns, e.g. LogNormal
-        Available distribution types
+        Available distribution types:
+
         1. "LogNormal"
         2. "Exponential"
+
     score : string , default = "LogScore"
         rule to compare probabilistic predictions P̂ to the observed data y.
         A score from ngboost.scores, e.g. LogScore
@@ -120,6 +122,7 @@ class NGBoostSurvival(BaseSurvReg, NGBoostAdapter):
         import pandas as pd
         from ngboost import NGBSurvival
         from ngboost.scores import LogScore
+        from sklearn.base import clone
         from sklearn.tree import DecisionTreeRegressor
 
         # skpro => 0 = uncensored, 1 = (right) censored
@@ -149,6 +152,8 @@ class NGBoostSurvival(BaseSurvReg, NGBoostAdapter):
                 splitter="best",
                 random_state=None,
             )
+        else:
+            self.estimator_ = clone(self.estimator)
 
         dist_ngboost = self._dist_to_ngboost_instance(self.dist, survival=True)
 
@@ -260,6 +265,8 @@ class NGBoostSurvival(BaseSurvReg, NGBoostAdapter):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
+        from sklearn.linear_model import LinearRegression
+
         params1 = {}
         params2 = {
             "dist": "LogNormal",
@@ -273,5 +280,10 @@ class NGBoostSurvival(BaseSurvReg, NGBoostAdapter):
             "dist": "Exponential",
             "n_estimators": 600,
         }
+        params5 = {
+            "n_estimators": 200,
+            "minibatch_frac": 0.8,
+            "estimator": LinearRegression(),
+        }
 
-        return [params1, params2, params3, params4]
+        return [params1, params2, params3, params4, params5]


### PR DESCRIPTION
This PR fixes `NgboostRegressor` not working with custom `sklearn` estimator.

In this case, the estimator clone was not properly initialized internally.

This was not detected since none of the seven (!) test cases contained a non-default for the estimator.