### PR TITLE
[BUG] fix doctest runs in testing framework

### DIFF
--- a/skpro/distributions/erlang.py
+++ b/skpro/distributions/erlang.py
@@ -44,10 +44,6 @@ class Erlang(_ScipyAdapter):
     }
 
     def __init__(self, rate, k=1, index=None, columns=None):
-        if rate <= 0:
-            raise ValueError("Rate must be greater than 0.")
-        if k <= 0:
-            raise ValueError("shape must be a positive integer.")
         self.rate = rate
         self.k = k
 

--- a/skpro/distributions/erlang.py
+++ b/skpro/distributions/erlang.py
@@ -32,7 +32,7 @@ class Erlang(_ScipyAdapter):
     --------
     >>> from skpro.distributions.erlang import Erlang
 
-    >>> d = Erlang(rate=[[1, 1], [2, 3], [4, 5]], shape=2)
+    >>> d = Erlang(rate=[[1, 1], [2, 3], [4, 5]], k=2)
     """
 
     _tags = {

--- a/skpro/distributions/meanscale.py
+++ b/skpro/distributions/meanscale.py
@@ -38,7 +38,8 @@ class MeanScale(BaseDistribution):
     Examples
     --------
     >>> from skpro.distributions.normal import Normal
-
+    >>> from skpro.distributions.meanscale import MeanScale
+    >>>
     >>> n = Normal(mu=[[0, 1], [2, 3], [4, 5]], sigma=2)
     >>> d = MeanScale(d=n, mu=2, sigma=3)
     """

--- a/skpro/regression/delta.py
+++ b/skpro/regression/delta.py
@@ -35,6 +35,7 @@ class DeltaPointRegressor(BaseProbaRegressor):
     >>> from sklearn.linear_model import LinearRegression
     >>> from sklearn.datasets import load_diabetes
     >>> from sklearn.model_selection import train_test_split
+    >>> from skpro.regression.delta import DeltaPointRegressor
     >>>
     >>> X, y = load_diabetes(return_X_y=True, as_frame=True)
     >>> X_train, X_test, y_train, y_test = train_test_split(X, y)

--- a/skpro/tests/test_all_estimators.py
+++ b/skpro/tests/test_all_estimators.py
@@ -16,6 +16,7 @@ from skpro.registry import OBJECT_TAG_LIST, all_objects
 from skpro.tests._config import EXCLUDE_ESTIMATORS, EXCLUDED_TESTS
 from skpro.tests.scenarios.scenarios_getter import retrieve_scenarios
 from skpro.tests.test_switch import run_test_for_class
+from skpro.utils._doctest import run_doctest
 from skpro.utils.deep_equals import deep_equals
 from skpro.utils.random_state import set_random_state
 
@@ -174,9 +175,7 @@ class TestAllObjects(PackageConfig, BaseFixtureGenerator, _TestAllObjects):
 
     def test_doctest_examples(self, object_class):
         """Runs doctests for estimator class."""
-        import doctest
-
-        doctest.run_docstring_examples(object_class, globals())
+        run_doctest(estimator_class, name=f"class {estimator_class.__name__}")
 
     # override this due to reserved_params index, columns, in the BaseDistribution class
     # index and columns params behave like pandas, i.e., are changed after __init__

--- a/skpro/tests/test_all_estimators.py
+++ b/skpro/tests/test_all_estimators.py
@@ -175,7 +175,7 @@ class TestAllObjects(PackageConfig, BaseFixtureGenerator, _TestAllObjects):
 
     def test_doctest_examples(self, object_class):
         """Runs doctests for estimator class."""
-        run_doctest(estimator_class, name=f"class {estimator_class.__name__}")
+        run_doctest(object_class, name=f"class {object_class.__name__}")
 
     # override this due to reserved_params index, columns, in the BaseDistribution class
     # index and columns params behave like pandas, i.e., are changed after __init__

--- a/skpro/tests/test_doctest.py
+++ b/skpro/tests/test_doctest.py
@@ -8,6 +8,7 @@ from functools import lru_cache
 
 from skpro.tests.test_all_estimators import ONLY_CHANGED_MODULES
 from skpro.tests.test_switch import run_test_module_changed
+from skpro.utils._doctest import run_doctest
 
 EXCLUDE_MODULES_STARTING_WITH = ("all", "test")
 
@@ -112,6 +113,4 @@ def pytest_generate_tests(metafunc):
 
 def test_all_functions_doctest(func):
     """Run doctest for all functions in skpro."""
-    import doctest
-
-    doctest.run_docstring_examples(func, globals())
+    run_doctest(func, name=f"function {func.__name__}")

--- a/skpro/tests/test_doctest.py
+++ b/skpro/tests/test_doctest.py
@@ -104,7 +104,7 @@ def pytest_generate_tests(metafunc):
     funcs_and_names = _all_functions("skpro")
 
     if len(funcs_and_names) > 0:
-        funcs, names = zip(*funcs_and_names)
+        names, funcs = zip(*funcs_and_names)
 
         metafunc.parametrize("func", funcs, ids=names)
     else:

--- a/skpro/utils/_doctest.py
+++ b/skpro/utils/_doctest.py
@@ -1,0 +1,64 @@
+"""Doctest utilities."""
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+
+import contextlib
+import doctest
+import io
+
+
+def run_doctest(
+    f,
+    verbose=False,
+    name=None,
+    compileflags=None,
+    optionflags=doctest.ELLIPSIS,
+    raise_on_error=True,
+):
+    """Run doctests for a given function or class, and return or raise.
+
+    Parameters
+    ----------
+    f : callable
+        Function or class to run doctests for.
+    verbose : bool, optional (default=False)
+        If True, print the results of the doctests.
+    name : str, optional (default=f.__name__, if available, otherwise "NoName")
+        Name of the function or class.
+    compileflags : int, optional (default=None)
+        Flags to pass to the Python parser.
+    optionflags : int, optional (default=doctest.ELLIPSIS)
+        Flags to control the behaviour of the doctest.
+    raise_on_error : bool, optional (default=True)
+        If True, raise an exception if the doctests fail.
+
+    Returns
+    -------
+    doctest_output : str
+        Output of the doctests.
+
+    Raises
+    ------
+    RuntimeError
+        If raise_on_error=True and the doctests fail.
+    """
+    doctest_output_io = io.StringIO()
+    with contextlib.redirect_stdout(doctest_output_io):
+        doctest.run_docstring_examples(
+            f=f,
+            globs=globals(),
+            verbose=verbose,
+            name=name,
+            compileflags=compileflags,
+            optionflags=optionflags,
+        )
+    doctest_output = doctest_output_io.getvalue()
+
+    if name is None:
+        name = f.__name__ if hasattr(f, "__name__") else "NoName"
+
+    if raise_on_error and len(doctest_output) > 0:
+        raise RuntimeError(
+            f"Docstring examples failed doctests "
+            f"for {name}, doctest output: {doctest_output}"
+        )
+    return doctest_output


### PR DESCRIPTION
This PR fixes the doctest runs via the testing framework.

Previously, failures were only causing printouts but no exceptions, as intended.