### PR TITLE
[MNT] update release wheel build runner to `ubuntu-latest`

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build_wheels:
     name: Build wheels
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -36,6 +36,7 @@ Maintenance
 * [MNT] move release to trusted publishers (:pr:`533`) :user:`fkiraly`
 * [MNT] remove deprecated ``pkg_import_alias`` from private soft dependency checker tests (:pr:`539`) :user:`fkiraly`
 * [MNT] reduce dependencies in ``all_extras`` dependency sets (:pr:`541`) :user:`fkiraly`
+* [MNT] update release wheel build runner to ``ubuntu-latest`` (:pr:`547`) :user:`fkiraly`
 
 Documentation
 ~~~~~~~~~~~~~


### PR DESCRIPTION
This PR updates the release wheel build runner to `ubuntu-latest`, from a removed fixed ubuntu version.