### PR TITLE
[ENH] `MAPIE<1.0` bound for legacy `MapieRegressor`

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -29,6 +29,7 @@ Enhancements
 * [ENH] Negative Binomial distribution (:pr:`560`) :user:`tingiskhan`
 * [ENH] probabilistic ``TransformedTargetRegressor`` (:pr:`558`) :user:`fkiraly`
 * [ENH] verbose printout for ``check_estimator`` in ``raise_exceptions`` case (:pr:`562`) :user:`fkiraly`
+* [ENH] ``MAPIE<1.0`` bound for legacy ``MapieRegressor`` (:pr:`564`) :user:`fkiraly`
 
 Maintenance
 ~~~~~~~~~~~

--- a/skpro/regression/mapie.py
+++ b/skpro/regression/mapie.py
@@ -17,7 +17,8 @@ class MapieRegressor(BaseProbaRegressor):
     ``mapie`` package.
 
     NOTE: only for the "all-in-one" regressor present in ``mapie<1.0``. Later
-    ``mapie`` versions have a more modular interface.
+    ``mapie`` versions have a more modular interface, this class is not
+    compatible with ``MAPIE>=1.0``.
 
     Uses jackknife+ to estimate prediction intervals on a per-sample basis.
 

--- a/skpro/regression/mapie.py
+++ b/skpro/regression/mapie.py
@@ -16,6 +16,9 @@ class MapieRegressor(BaseProbaRegressor):
     Direct interface to ``mapie.regression.regression.MapieRegressor`` from the
     ``mapie`` package.
 
+    NOTE: only for the "all-in-one" regressor present in ``mapie<1.0``. Later
+    ``mapie`` versions have a more modular interface.
+
     Uses jackknife+ to estimate prediction intervals on a per-sample basis.
 
     Any (non-probabilistic) sklearn regressor can be used as the base regressor,
@@ -146,28 +149,28 @@ class MapieRegressor(BaseProbaRegressor):
 
     Examples
     --------
-    >>> from skpro.regression.mapie import MapieRegressor  # doctest: +SKIP
-    >>> from sklearn.ensemble import RandomForestRegressor  # doctest: +SKIP
-    >>> from sklearn.datasets import load_diabetes  # doctest: +SKIP
-    >>> from sklearn.model_selection import train_test_split  # doctest: +SKIP
+    >>> from skpro.regression.mapie import MapieRegressor
+    >>> from sklearn.ensemble import RandomForestRegressor
+    >>> from sklearn.datasets import load_diabetes
+    >>> from sklearn.model_selection import train_test_split
     >>>
-    >>> X, y = load_diabetes(return_X_y=True, as_frame=True)  # doctest: +SKIP
-    >>> X_train, X_test, y_train, y_test = train_test_split(X, y)  # doctest: +SKIP
+    >>> X, y = load_diabetes(return_X_y=True, as_frame=True)
+    >>> X_train, X_test, y_train, y_test = train_test_split(X, y)
     >>>
-    >>> reg_tabular = RandomForestRegressor()  # doctest: +SKIP
+    >>> reg_tabular = RandomForestRegressor()
     >>>
-    >>> reg_proba = MapieRegressor(reg_tabular)  # doctest: +SKIP
-    >>> reg_proba.fit(X_train, y_train)  # doctest: +SKIP
+    >>> reg_proba = MapieRegressor(reg_tabular)
+    >>> reg_proba.fit(X_train, y_train)
     MapieRegressor(...)
-    >>> y_pred_int = reg_proba.predict_interval(X_test)  # doctest: +SKIP
-    >>> y_pred_dist = reg_proba.predict_proba(X_test)  # doctest: +SKIP
+    >>> y_pred_int = reg_proba.predict_interval(X_test)
+    >>> y_pred_dist = reg_proba.predict_proba(X_test)
     """
 
     _tags = {
         # packaging info
         # --------------
         "authors": ["fkiraly"],
-        "python_dependencies": ["MAPIE"],
+        "python_dependencies": ["MAPIE<1.0"],
         # estimator tags
         # --------------
         "capability:missing": True,


### PR DESCRIPTION
The `MAPIE` package have restructured their regression algorithms in 1.0, see https://github.com/sktime/skpro/issues/563.

The current `MapieRegressor` gets the `MAPIE<1.0` dependency bound, new estimators should be added according to issue https://github.com/sktime/skpro/issues/563.