### PR TITLE
[ENH] improving stability of test parameter settings for `CoxPHlifelines`

### DIFF
--- a/skpro/survival/coxph/_coxph_lifelines.py
+++ b/skpro/survival/coxph/_coxph_lifelines.py
@@ -195,10 +195,10 @@ class CoxPHlifelines(_LifelinesAdapter, BaseSurvReg):
         params1 = {}
 
         params2 = {
-            "baseline_estimation_method": "spline",
+            # "baseline_estimation_method": "spline",
             "penalizer": 0.01,
             "l1_ratio": 0.01,
-            "n_baseline_knots": 5,
+            # "n_baseline_knots": 5,
         }
 
         # breakpoints are specific to data ranges,

--- a/skpro/survival/coxph/_coxph_lifelines.py
+++ b/skpro/survival/coxph/_coxph_lifelines.py
@@ -196,9 +196,9 @@ class CoxPHlifelines(_LifelinesAdapter, BaseSurvReg):
 
         params2 = {
             "baseline_estimation_method": "spline",
-            "penalizer": 0.1,
-            "l1_ratio": 0.1,
-            "n_baseline_knots": 3,
+            "penalizer": 0.01,
+            "l1_ratio": 0.01,
+            "n_baseline_knots": 5,
         }
 
         # breakpoints are specific to data ranges,


### PR DESCRIPTION
The second test parameter setting for `CoxPHlifelines` has sporadic convergence issues on the CI test data.

This PR improves the parameter settings to be more stable.