### PR TITLE
[MNT] temporarily skip failing `Hurdle` tests

### DIFF
--- a/skpro/tests/_config.py
+++ b/skpro/tests/_config.py
@@ -8,4 +8,7 @@ EXCLUDE_ESTIMATORS = [
 ]
 
 
-EXCLUDED_TESTS = {"GLMRegressor": ["test_online_update"]}
+EXCLUDED_TESTS = {
+    "GLMRegressor": ["test_online_update"],  # see 497
+    "Hurdle": ["test_ppf_and_cdf"],  # see 556
+}


### PR DESCRIPTION
Temporarily skips the failing test in https://github.com/sktime/skpro/issues/566 to unblock the release.