### PR TITLE
[CI] Addresses stochasticity of Hurdle tests

### DIFF
--- a/skpro/distributions/hurdle.py
+++ b/skpro/distributions/hurdle.py
@@ -167,12 +167,12 @@ class Hurdle(BaseDistribution):
     def get_test_params(cls, parameter_set="default"):  # noqa: D102
         import pandas as pd
 
-        from skpro.distributions import Poisson
+        from skpro.distributions import NegativeBinomial
 
         # scalar
         params_1 = {
             "p": 0.3,
-            "distribution": Poisson(mu=1.0),
+            "distribution": NegativeBinomial(mu=1.0, alpha=1.0),
         }
 
         # array 1
@@ -180,10 +180,10 @@ class Hurdle(BaseDistribution):
         idx = pd.Index([0, 1])
         cols = pd.Index(["a", "b", "c"])
 
-        poisson = Poisson(mu=mu, columns=cols, index=idx)
+        negbin = NegativeBinomial(mu=mu, alpha=1.0, columns=cols, index=idx)
         params_2 = {
             "p": 0.3,
-            "distribution": poisson,
+            "distribution": negbin,
             "index": idx,
             "columns": cols,
         }
@@ -191,7 +191,7 @@ class Hurdle(BaseDistribution):
         # array 2
         params_3 = {
             "p": np.array([0.2, 0.3]).reshape(-1, 1),
-            "distribution": poisson,
+            "distribution": negbin,
             "index": idx,
             "columns": cols,
         }

--- a/skpro/tests/_config.py
+++ b/skpro/tests/_config.py
@@ -10,5 +10,4 @@ EXCLUDE_ESTIMATORS = [
 
 EXCLUDED_TESTS = {
     "GLMRegressor": ["test_online_update"],  # see 497
-    "Hurdle": ["test_ppf_and_cdf"],  # see 556
 }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skpro.readthedocs.io/en/latest/contribute.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

None referenced.

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

Addresses the stochasticity of the tests associated with Hurdle distribution by switching out the Poisson test with Negative Binomial instead, since Poisson doesn't implement an exact PPF.

#### Does your contribution introduce a new dependency? If yes, which one?
<!--
If your contribution does add a new core dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core skpro package to a minimum.
-->

No.

#### What should a reviewer concentrate their feedback on?
<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

That tests pass deterministically.

#### Did you add any tests for the change?
<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

No.

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [x] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [x] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [x] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
