### PR TITLE
[ENH] correctly set tags of `Hurdle` and `Truncated` depending on inner distribution

### DIFF
--- a/skpro/distributions/truncated.py
+++ b/skpro/distributions/truncated.py
@@ -74,6 +74,30 @@ class TruncatedDistribution(BaseDistribution):
             columns=columns if columns is not None else distribution.columns,
         )
 
+        # the capabilities of this (self) distribution are exact
+        # if and only if the capabilities of the inner distribution are exact
+        self_exact_capas = self.get_tag("capabilities:exact", []).copy()
+        self_approx_capas = self.get_tag("capabilities:approx", []).copy()
+        distr_exact_capas = distribution.get_tag("capabilities:exact", []).copy()
+        for capa in self_exact_capas:
+            if capa not in distr_exact_capas:
+                self_exact_capas.remove(capa)
+                self_approx_capas.append(capa)
+
+        self.set_tags(**{"capabilities:exact": self_exact_capas})
+        self.set_tags(**{"capabilities:approx": self_approx_capas})
+
+        # the measure type of this distribution is discrete if the inner distribution
+        # is discrete, and it is continuous if the inner distribution is continuous;
+        # if the measure type of the inner distribution is mixed,
+        # the result is indeterminate, but we keep it as mixed for API reasons
+        inner_measuretype = distribution.get_tag("distr:measuretype", "mixed")
+        self.set_tags(**{"distr:measuretype": inner_measuretype})
+
+        inner_paramtype = distribution.get_tag("distr:paramtype", "parametric")
+        if inner_paramtype != "parametric":
+            self.set_tags(**{"distr:paramtype": inner_paramtype})
+
     def _get_low_high_prob(self) -> Tuple[float, float]:
         prob_at_lower = (
             self.distribution.cdf(self.lower) if self.lower is not None else 0.0


### PR DESCRIPTION
This PR correctly sets the tag of `Hurdle` and `Truncated` depending on the inner distribution.

Hopefully this fixes #566 as a secondary effect.