### PR TITLE
[BUG] correctly set tags for `Poisson` distribution

### DIFF
--- a/skpro/distributions/poisson.py
+++ b/skpro/distributions/poisson.py
@@ -29,8 +29,8 @@ class Poisson(_ScipyAdapter):
     """
 
     _tags = {
-        "capabilities:approx": ["ppf", "energy"],
-        "capabilities:exact": ["mean", "var", "pmf", "log_pmf", "cdf"],
+        "capabilities:approx": ["energy", "pdfnorm"],
+        "capabilities:exact": ["mean", "var", "pmf", "log_pmf", "cdf", "ppf"],
         "distr:measuretype": "discrete",
         "distr:paramtype": "parametric",
         "broadcast_init": "on",

--- a/skpro/distributions/poisson.py
+++ b/skpro/distributions/poisson.py
@@ -54,7 +54,7 @@ class Poisson(_ScipyAdapter):
         """Return testing parameter settings for the estimator."""
         params1 = {"mu": [[1, 1], [2, 3], [4, 5]]}
         params2 = {
-            "mu": 0,
+            "mu": 0.1,
             "index": pd.Index([1, 2, 5]),
             "columns": pd.Index(["a", "b"]),
         }


### PR DESCRIPTION
The "approximate vs exact" tag for the `Poisson` distribution were not set correctly - `Poisson` has an exact `ppf` interfaced from `scipy`.

Also fixes a problem with the 2nd test example which had a (non-permissible) mean zero for the Poisson.