### PR TITLE
[ENH] `pandas.Multiindex` support for distributions

### DIFF
--- a/skpro/distributions/base/_base.py
+++ b/skpro/distributions/base/_base.py
@@ -806,39 +806,6 @@ class BaseDistribution(BaseObject):
 
         raise NotImplementedError(self._method_error_msg("log_pdf", "error"))
 
-    def pdfj(self, x):
-        r"""Probability density function.
-
-        Let :math:`X` be a random variables with the distribution of ``self``,
-        taking values in ``(N, n)`` ``DataFrame``-s
-        Let :math:`x\in \mathbb{R}^{N\times n}`.
-        By :math:`p_{X_{ij}}`, denote the marginal pdf of :math:`X` at the
-        :math:`(i,j)`-th entry.
-
-        The output of this method, for input ``x`` representing :math:`x`,
-        is a ``DataFrame`` with same columns and indices as ``self``,
-        and entries :math:`p_{X_{ij}}(x_{ij})`.
-
-        If ``self`` has a mixed or discrete distribution, this returns
-        the weighted continuous part of `self`'s distribution instead of the pdf,
-        i.e., the marginal pdf integrate to the weight of the continuous part.
-
-        Parameters
-        ----------
-        x : ``pandas.DataFrame`` or 2D ``np.ndarray``
-            representing :math:`x`, as above
-
-        Returns
-        -------
-        ``pd.DataFrame`` with same columns and index as ``self``
-            containing :math:`p_{X_{ij}}(x_{ij})`, as above
-        """
-        distr_type = self.get_tag("distr:measuretype", "mixed", raise_error=False)
-        if distr_type == "discrete":
-            return self._coerce_to_self_index_df(0, flatten=False)
-
-        return self._boilerplate("_pdf", x=x)
-
     def _pdf(self, x):
         """Probability density function.
 

--- a/skpro/distributions/base/tests/test_multiindex.py
+++ b/skpro/distributions/base/tests/test_multiindex.py
@@ -1,0 +1,58 @@
+"""Test cases for the MultiIndex functionality of the BaseDistribution.
+
+Uses the Normal distribution, but is intended to trigger the base layer.
+"""
+
+import pandas as pd
+import numpy as np
+import pytest
+
+from skpro.distributions.normal import Normal
+
+
+@pytest.fixture
+def normal_dist():
+    ix = pd.MultiIndex.from_product([(1, 2), (2, 3)])
+    return Normal(np.array([[1, 2], [2, 3], [4, 5], [6, 7]]), 2, index=ix)
+
+def test_loc_partial_level(normal_dist):
+    result = normal_dist.loc[1]
+    expected_index = pd.MultiIndex.from_tuples([(1, 2), (1, 3)])
+    np.testing.assert_array_equal(result.index, expected_index)
+    assert result.mean().shape == (2, 2)
+
+def test_loc_full_tuple(normal_dist):
+    result = normal_dist.loc[(2, 2)]
+    expected_index = pd.MultiIndex.from_tuples([(2, 2)])
+    np.testing.assert_array_equal(result.index, expected_index)
+    assert result.mean().shape == (1, 2)
+
+def test_loc_list_of_keys(normal_dist):
+    result = normal_dist.loc[[ (1, 2), (2, 3) ]]
+    expected_index = pd.MultiIndex.from_tuples([(1, 2), (2, 3)])
+    np.testing.assert_array_equal(result.index, expected_index)
+    assert result.mean().shape == (2, 2)
+
+def test_iloc_single_row(normal_dist):
+    result = normal_dist.iloc[0]
+    expected_index = pd.MultiIndex.from_tuples([(1, 2)])
+    np.testing.assert_array_equal(result.index, expected_index)
+    assert result.mean().shape == (1, 2)
+
+def test_iloc_multiple_rows(normal_dist):
+    result = normal_dist.iloc[[0, 3]]
+    expected_index = pd.MultiIndex.from_tuples([(1, 2), (2, 3)])
+    np.testing.assert_array_equal(result.index, expected_index)
+    assert result.mean().shape == (2, 2)
+
+def test_iloc_column_slice(normal_dist):
+    result = normal_dist.iloc[:, 1]
+    expected_index = normal_dist.index
+    assert result.mean().shape == (4, 1)
+    np.testing.assert_array_equal(result.index, expected_index)
+
+def test_loc_row_col(normal_dist):
+    result = normal_dist.loc[(1, 2), :]
+    expected_index = pd.MultiIndex.from_tuples([(1, 2)])
+    assert result.mean().shape == (1, 2)
+    np.testing.assert_array_equal(result.index, expected_index)


### PR DESCRIPTION
Fixes https://github.com/sktime/skpro/issues/212.

Introdues `MultiIndex` support for distributions, including through `iloc` and `loc` calls.

Behaves like `pandas`, except that:

* `loc` calls never remove levels
* the dimension after `loc` and `iloc` call always remains 2D, since there are no 1D distributions