### PR TITLE
[ENH] replace apply linalg norm with native pandas ufuncs

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -214,5 +214,13 @@
         "code",
       ]
     },
+    {
+      "login": "joshdunnlime",
+      "name": "Josh Dunn",
+      "profile": "https://github.com/joshdunnlime",
+      "contributions": [
+        "code",
+      ]
+    }
   ]
 }

--- a/skpro/distributions/base/_base.py
+++ b/skpro/distributions/base/_base.py
@@ -1204,7 +1204,7 @@ class BaseDistribution(BaseObject):
 
         # approx E[abs(X-Y)] via mean of samples of abs(X-Y) obtained from splx, sply
         spl = splx - sply
-        energy = spl.apply(np.linalg.norm, axis=1, ord=1)
+        energy = spl.abs().sum(axis=1)
 
         # todo: check if can use self._sample_mean
         if self.ndim > 0:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skpro.readthedocs.io/en/latest/contribute.html
-->

#### Reference Issues/PRs
Fixes #591


#### What does this implement/fix? Explain your changes.
Very simply, it replaces a pandas `.apply` (which under the hood is just a loop) with a pandas/numpy native ufunc. This mean that is operation is now fully vectorised.

#### Does your contribution introduce a new dependency? If yes, which one?
No

#### What should a reviewer concentrate their feedback on?

Edge cases such as how the reviewer expects values such as `np.inf` and `np.NaN` to be handled.

#### Did you add any tests for the change?

No tests added. All previous tests passed.

#### Any other comments?
Reduction in total run time for line `_base.py:1207` was from 16.56 seconds to 0.11 seconds (150x speed-up).

Modified example from `examples/01_skpro_intro.ipynb`:

```python
import pandas as pd

from sklearn.datasets import load_diabetes
from sklearn.linear_model import LinearRegression
from sklearn.model_selection import KFold

from skpro.benchmarking.evaluate import evaluate
from skpro.metrics import CRPS
from skpro.regression.residual import ResidualDouble

# 1. specify dataset]
# create more data to show vectorisation on larger dataset
n_copies = 10
X, y = load_diabetes(return_X_y=True, as_frame=True)
X = pd.concat([X] * n_copies, ignore_index=True)
y = pd.concat([y] * n_copies, ignore_index=True)

# 2. specify estimator
estimator = ResidualDouble(LinearRegression(), distr_type="t")

# 3. specify cross-validation schema
cv = KFold(n_splits=3)

# 4. specify evaluation metric
crps = CRPS()

# 5. evaluate - run the benchmark
results = evaluate(estimator=estimator, X=X, y=y, cv=cv, scoring=crps)
```

Left: Run with linalg.norm. Right: Run with .abs().sum(axis=1).

<img width="293" height="310" alt="Run with linalg.norm" src="https://github.com/user-attachments/assets/cac22df7-e26e-44e6-96f8-3a3e5f5331b4" />

<img width="293" height="310" alt="Run with .abs().sum(axis=1)" src="https://github.com/user-attachments/assets/33499bd5-9246-40a9-bb13-866140b3becf" />

Profiler displays are with [Flamegraph](https://marketplace.visualstudio.com/items?itemName=rafaelha.vscode-flamegraph) in VS Code.

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
