### PR TITLE
[ENH] export all distributions in `skpro.distributions`, minor fixes to API reference

### DIFF
--- a/docs/source/api_reference/distributions.rst
+++ b/docs/source/api_reference/distributions.rst
@@ -128,6 +128,17 @@ Mixture composition
 
     Mixture
 
+Transformation composition
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: skpro.distributions
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    TransformedDistribution
+
 Sampling and multivariate composition
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/skpro/distributions/__init__.py
+++ b/skpro/distributions/__init__.py
@@ -39,6 +39,7 @@ __all__ = [
     "QPD_Johnson",
     "SkewNormal",
     "TDistribution",
+    "TransformedDistribution",
     "TruncatedDistribution",
     "TruncatedNormal",
     "Uniform",
@@ -77,6 +78,7 @@ from skpro.distributions.qpd import QPD_B, QPD_S, QPD_U, QPD_Johnson
 from skpro.distributions.qpd_empirical import QPD_Empirical
 from skpro.distributions.skew_normal import SkewNormal
 from skpro.distributions.t import TDistribution
+from skpro.distributions.trafo import TransformedDistribution
 from skpro.distributions.truncated import TruncatedDistribution
 from skpro.distributions.truncated_normal import TruncatedNormal
 from skpro.distributions.uniform import Uniform

--- a/skpro/distributions/qpd.py
+++ b/skpro/distributions/qpd.py
@@ -534,7 +534,7 @@ class QPD_B(BaseDistribution):
 
 
 class QPD_U(BaseDistribution):
-    """Johnson Quantile-Parameterized Distributions with bounded mode.
+    """Johnson Quantile-Parameterized Distributions with unbounded mode.
 
     see https://repositories.lib.utexas.edu/bitstream/handle/2152
         /63037/HADLOCK-DISSERTATION-2017.pdf


### PR DESCRIPTION
This PR ensures all distributions are exported in `skpro.distributions`, and makes minor fixes to API reference.

* adds all distributions to `skpro.distributions` module export
* fixes missing distributions in API reference
* fixes to description of distributions