### PR TITLE
[ENH] Add Beta Distribution to XGBoostLSS

### DIFF
--- a/skpro/regression/xgboostlss.py
+++ b/skpro/regression/xgboostlss.py
@@ -320,4 +320,5 @@ class XGBoostLSS(BaseProbaRegressor):
         params3 = {"dist": "Weibull", "max_minutes": 1}
         params4 = {"dist": "TDistribution", "max_minutes": 1}
         params5 = {"dist": "Laplace", "max_minutes": 1}
-        return [params0, params1, params2, params3, params4, params5]
+        params6 = {"dist": "Beta", "max_minutes": 1}
+        return [params0, params1, params2, params3, params4, params5, params6]

--- a/skpro/regression/xgboostlss.py
+++ b/skpro/regression/xgboostlss.py
@@ -21,6 +21,7 @@ class XGBoostLSS(BaseProbaRegressor):
         * "LogNormal": LogNormal distribution.
         * "TDistribution": Student's T distribution.
         * "Weibull": Weibull distribution.
+        * "Beta": Beta distribution.
 
     stabilization: str, optional, default="None"
         Stabilization method for the Gradient and Hessian.
@@ -165,6 +166,7 @@ class XGBoostLSS(BaseProbaRegressor):
             "LogNormal": {"mu": "loc", "sigma": "scale"},
             "TDistribution": {"mu": "loc", "sigma": "scale", "df": "df"},
             "Weibull": {"scale": "scale", "k": "concentration"},
+            "Beta": {"alpha": "concentration1", "beta": "concentration0"},
         }
         map = name_map.get(distr, {})
 


### PR DESCRIPTION
XGBoostLSS uses pytorch backend with "concentration" nomenclature instead of skpro alpha and beta.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skpro.readthedocs.io/en/latest/contribute.html
-->

#### Reference Issues/PRs

No reference as it is a very simple PR.


#### What does this implement/fix? Explain your changes.

This adds the Beta Distribution to XGBoostLSS. It is a simple conversion from the [pytorch Beta](https://docs.pytorch.org/docs/stable/distributions.html#beta) to skpro Beta. It is the simple mapping of `concentration1 -> alpha` and `concentration0 -> beta`.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

Only one line of code and one line of docs changed.

#### Did you add any tests for the change?

Yes. Added Beta to the XGBoostLSS `get_test_params`.

#### Any other comments?

No.

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
