### PR TITLE
[ENH] Allow `n_trails=0` for fast optimisation-free training of XGBoostLSS

### DIFF
--- a/skpro/regression/xgboostlss.py
+++ b/skpro/regression/xgboostlss.py
@@ -59,6 +59,7 @@ class XGBoostLSS(BaseProbaRegressor):
     n_trials: int, optional, default=30
         The number of trials in tuning.
         If this argument is set to None, there is no limitation on the number of trials.
+        If set to 0, no tuning is done, and default parameters of xgboost are used.
     """
 
     _tags = {
@@ -207,44 +208,48 @@ class XGBoostLSS(BaseProbaRegressor):
             )
         )
 
-        param_dict = {
-            "eta": ["float", {"low": 1e-5, "high": 1, "log": True}],
-            "max_depth": ["int", {"low": 1, "high": 10, "log": False}],
-            "gamma": ["float", {"low": 1e-8, "high": 40, "log": True}],
-            "subsample": ["float", {"low": 0.2, "high": 1.0, "log": False}],
-            "colsample_bytree": ["float", {"low": 0.2, "high": 1.0, "log": False}],
-            "min_child_weight": ["float", {"low": 1e-8, "high": 500, "log": True}],
-            "booster": ["categorical", ["gbtree"]],
-        }
+        if self.n_trials == 0:
+            opt_params = {}  # empty dict, use default parameters
+            n_rounds = self.num_boost_round
+        else:
+            param_dict = {
+                "eta": ["float", {"low": 1e-5, "high": 1, "log": True}],
+                "max_depth": ["int", {"low": 1, "high": 10, "log": False}],
+                "gamma": ["float", {"low": 1e-8, "high": 40, "log": True}],
+                "subsample": ["float", {"low": 0.2, "high": 1.0, "log": False}],
+                "colsample_bytree": ["float", {"low": 0.2, "high": 1.0, "log": False}],
+                "min_child_weight": ["float", {"low": 1e-8, "high": 500, "log": True}],
+                "booster": ["categorical", ["gbtree"]],
+            }
 
-        opt_param = xgblss.hyper_opt(
-            param_dict,
-            dtrain,
-            num_boost_round=self.num_boost_round,
-            # Number of boosting iterations.
-            nfold=self.nfold,
-            # Number of cv-folds.
-            early_stopping_rounds=self.early_stopping_rounds,
-            # Number of early-stopping rounds
-            max_minutes=self.max_minutes,
-            # Time budget in minutes,
-            # i.e., stop study after the given number of minutes.
-            n_trials=self.n_trials,
-            # The number of trials. If this argument is set to None,
-            # there is no limitation on the number of trials.
-            silence=True,
-            # Controls the verbosity of the trail,
-            # i.e., user can silence the outputs of the trail.
-            seed=123,
-            # Seed used to generate cv-folds.
-            hp_seed=123,
-            # Seed for random number generator used
-            # in the Bayesian hyperparameter search.
-        )
+            opt_param = xgblss.hyper_opt(
+                param_dict,
+                dtrain,
+                num_boost_round=self.num_boost_round,
+                # Number of boosting iterations.
+                nfold=self.nfold,
+                # Number of cv-folds.
+                early_stopping_rounds=self.early_stopping_rounds,
+                # Number of early-stopping rounds
+                max_minutes=self.max_minutes,
+                # Time budget in minutes,
+                # i.e., stop study after the given number of minutes.
+                n_trials=self.n_trials,
+                # The number of trials. If this argument is set to None,
+                # there is no limitation on the number of trials.
+                silence=True,
+                # Controls the verbosity of the trail,
+                # i.e., user can silence the outputs of the trail.
+                seed=123,
+                # Seed used to generate cv-folds.
+                hp_seed=123,
+                # Seed for random number generator used
+                # in the Bayesian hyperparameter search.
+            )
 
-        opt_params = opt_param.copy()
-        n_rounds = opt_params["opt_rounds"]
-        del opt_params["opt_rounds"]
+            opt_params = opt_param.copy()
+            n_rounds = opt_params["opt_rounds"]
+            del opt_params["opt_rounds"]
 
         # Train Model with optimized hyperparameters
         xgblss.train(opt_params, dtrain, num_boost_round=n_rounds)


### PR DESCRIPTION
This is useful when testing XGBoostLLS and hyperparameter optimisation is not important. XGBoostLLS can be computationally expensive when searching over the default 30 trials.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skpro.readthedocs.io/en/latest/contribute.html
-->

#### Reference Issues/PRs

None. Very simple PR.

#### What does this implement/fix? Explain your changes.

Allows XGBoostLSS models to be trained and tested without the overhead of hyperparameter optimisation. This is particularly useful for testing and creating examples.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

Not a big PR. Mainly, is the reviewer happy with the defaults.

#### Did you add any tests for the change?

No. `n_trials` appears unreferenced in the testing suite. It seems unnecessary to add `n_trials=0` when the defaults are not tested. This can be added if desired.

#### Any other comments?

No.

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
