### PR TITLE
[DOC] improve docstring formatting for description of censoring variable `C`

### DIFF
--- a/skpro/benchmarking/evaluate.py
+++ b/skpro/benchmarking/evaluate.py
@@ -135,12 +135,14 @@ def evaluate(
 
     C : pd.DataFrame, optional (default=None)
         censoring information to use in the evaluation experiment,
-        should have same column name as y, same length as X and y
-        should have entries 0 and 1 (float or int)
-        0 = uncensored, 1 = (right) censored
-        if None, all observations are assumed to be uncensored
+
+        * should have same column name as y, same length as X and y
+        * should have entries 0 and 1 (float or int),
+          0 = uncensored, 1 = (right) censored
+
+        if None, all observations are assumed to be uncensored.
         Can be passed to any probabilistic regressor,
-        but is ignored if capability:survival tag is False.
+        but is ignored if ``capability:survival`` tag is ``False``.
 
     Returns
     -------

--- a/skpro/regression/base/_base.py
+++ b/skpro/regression/base/_base.py
@@ -85,7 +85,9 @@ class BaseProbaRegressor(BaseEstimator):
             labels to fit regressor to
         C : ignored, optional (default=None)
             censoring information for survival analysis
-            All probabilistic regressors assume data to be uncensored
+            All probabilistic regressors assume data to be uncensored,
+            and ignore this input unless the ``capability:survival`` tag is ``True``.
+            Present for API consistency with survival regressors.
 
         Returns
         -------

--- a/skpro/survival/base.py
+++ b/skpro/survival/base.py
@@ -36,10 +36,12 @@ class BaseSurvReg(BaseProbaRegressor):
             labels to fit regressor to
         C : pd.DataFrame, optional (default=None)
             censoring information for survival analysis,
-            should have same column name as y, same length as X and y
-            should have entries 0 and 1 (float or int)
+
+            * should have same column name as y, same length as X and y
+            * should have entries 0 and 1 (float or int),
             0 = uncensored, 1 = (right) censored
-            if None, all observations are assumed to be uncensored
+
+            if None, all observations are assumed to be uncensored.
 
         Returns
         -------


### PR DESCRIPTION
improves docstring formatting for descriptions of the censoring variable `C`