### PR TITLE
&joshdunnlime [ENH] `TransformedDistribution` and `TransformedTargetRegressor` `cdf` support

### DIFF
--- a/skpro/distributions/trafo/_transformed.py
+++ b/skpro/distributions/trafo/_transformed.py
@@ -275,7 +275,24 @@ class TransformedDistribution(BaseDistribution):
             "columns": pd.Index(["a", "b"]),  # this should override n_row.columns
         }
 
-        return [params1, params2]
+        # array case example with inverse transform
+        n_array = Normal(mu=[[1, 2], [3, 4]], sigma=1, columns=pd.Index(["c", "d"]))
+        params3 = {
+            "distribution": n_array,
+            "transform": np.exp,
+            "inverse_transform": np.log,
+            "index": pd.Index([1, 2]),
+            "columns": pd.Index(["a", "b"]),  # this should override n_row.columns
+        }
+
+        # scalar case example with inverse transform
+        params4 = {
+            "distribution": n_scalar,
+            "transform": np.exp,
+            "inverse_transform": np.log,
+        }
+
+        return [params1, params2, params3, params4]
 
 
 def is_scalar_notnone(obj):

--- a/skpro/distributions/trafo/_transformed.py
+++ b/skpro/distributions/trafo/_transformed.py
@@ -150,8 +150,8 @@ class TransformedDistribution(BaseDistribution):
                 "ppf is implemented only for monotonic transforms, "
                 "set `assume_monotonic=True` to use this method"
             )
-        elif self.inverse_transform is not None:
-            return super()._ppf(p)
+        elif not self.assume_monotonic and self.inverse_transform is not None:
+            return super().ppf(p)
 
         trafo = self.transform
 

--- a/skpro/distributions/trafo/_transformed.py
+++ b/skpro/distributions/trafo/_transformed.py
@@ -286,8 +286,8 @@ class TransformedDistribution(BaseDistribution):
         n_array = Normal(mu=[[1, 2], [3, 4]], sigma=1, columns=pd.Index(["c", "d"]))
         params3 = {
             "distribution": n_array,
-            "transform": np.log,
-            "inverse_transform": np.exp,
+            "transform": lambda x: 2*x,
+            "inverse_transform": lambda x: x/2,
             "index": pd.Index([1, 2]),
             "columns": pd.Index(["a", "b"]),  # this should override n_row.columns
         }

--- a/skpro/distributions/trafo/_transformed.py
+++ b/skpro/distributions/trafo/_transformed.py
@@ -157,7 +157,9 @@ class TransformedDistribution(BaseDistribution):
         2D np.ndarray, same shape as ``self``
             ppf values at the given points
         """
-        p = pd.DataFrame(p, index=self.index, columns=self.columns)
+        if self.ndim != 0:
+            p = pd.DataFrame(p, index=self.index, columns=self.columns)
+
         if not self.assume_monotonic and self.inverse_transform is None:
             raise ValueError(
                 "if inverse_transform is not given, "
@@ -200,7 +202,9 @@ class TransformedDistribution(BaseDistribution):
 
         inv_trafo = self.inverse_transform
 
-        x = pd.DataFrame(x, index=self.index, columns=self.columns)
+        if self.ndim != 0:
+            x = pd.DataFrame(x, index=self.index, columns=self.columns)
+
         inv_x = inv_trafo(x)
         cdf_res = self.distribution.cdf(inv_x)
 

--- a/skpro/distributions/trafo/_transformed.py
+++ b/skpro/distributions/trafo/_transformed.py
@@ -168,7 +168,7 @@ class TransformedDistribution(BaseDistribution):
 
         return outer_ppf
 
-    def _cdf(self, p):
+    def _cdf(self, x):
         """Cumulative distribution function.
 
         Parameters
@@ -182,12 +182,12 @@ class TransformedDistribution(BaseDistribution):
             cdf values at the given points
         """
         if self.inverse_transform is None:
-            return super().cdf(p)
+            return super()._cdf(x)
 
         inv_trafo = self.inverse_transform
 
-        inv_p = inv_trafo(p)
-        cdf_res = self.distribution.cdf(inv_p)
+        inv_x = inv_trafo(x)
+        cdf_res = self.distribution.cdf(inv_x)
 
         if isinstance(cdf_res, pd.DataFrame):
             # if the transform returns a DataFrame, we ensure the index and columns

--- a/skpro/distributions/trafo/_transformed.py
+++ b/skpro/distributions/trafo/_transformed.py
@@ -94,7 +94,7 @@ class TransformedDistribution(BaseDistribution):
         if self.inverse_transform is not None:
             self.set_tags(
                 **{
-                    "capabilities:exact": ["ppf", "cdf"]
+                    "capabilities:exact": ["ppf", "cdf"],
                     "capabilities:approx": ["pdfnorm", "mean", "var", "energy"],
                 }
             )

--- a/skpro/distributions/trafo/_transformed.py
+++ b/skpro/distributions/trafo/_transformed.py
@@ -90,7 +90,7 @@ class TransformedDistribution(BaseDistribution):
 
         # transformed discret distributions are always discrete
         # (otherwise we only know that they are mixed)
-        if distribution.get_tag("measuretype") == "discrete":
+        if distribution.get_tag("distr:measuretype") == "discrete":
             self.set_tags(**{"distr:measuretype": "discrete"})
 
         # if inverse_transform is given, we can do exact cdf

--- a/skpro/distributions/trafo/_transformed.py
+++ b/skpro/distributions/trafo/_transformed.py
@@ -88,9 +88,13 @@ class TransformedDistribution(BaseDistribution):
 
         super().__init__(index=index, columns=columns)
 
+        # transformed discret distributions are always discrete
+        # (otherwise we only know that they are mixed)
         if distribution.get_tag("measuretype") == "discrete":
             self.set_tags(**{"distr:measuretype": "discrete"})
 
+        # if inverse_transform is given, we can do exact cdf
+        # due to the formula F_g(x)(y) = F_X(g^-1(x))
         if self.inverse_transform is not None:
             self.set_tags(
                 **{

--- a/skpro/distributions/trafo/_transformed.py
+++ b/skpro/distributions/trafo/_transformed.py
@@ -151,7 +151,7 @@ class TransformedDistribution(BaseDistribution):
                 "set `assume_monotonic=True` to use this method"
             )
         elif not self.assume_monotonic and self.inverse_transform is not None:
-            return super().ppf(p)
+            return super()._ppf(p)
 
         trafo = self.transform
 

--- a/skpro/distributions/trafo/_transformed.py
+++ b/skpro/distributions/trafo/_transformed.py
@@ -123,13 +123,19 @@ class TransformedDistribution(BaseDistribution):
         else:
             new_columns = self.columns
 
+        # these parameters are manually subset
+        # the other parameters are passed through
+        POP_PARAMS = ["distribution", "index", "columns"]
+
         cls = type(self)
+        params_dict = self.get_params(deep=False)
+        [params_dict.pop(param) for param in POP_PARAMS]
+
         return cls(
             distribution=distr,
-            transform=self.transform,
-            assume_monotonic=self.assume_monotonic,
             index=new_index,
             columns=new_columns,
+            **params_dict,
         )
 
     def _iat(self, rowidx=None, colidx=None):

--- a/skpro/distributions/trafo/_transformed.py
+++ b/skpro/distributions/trafo/_transformed.py
@@ -157,6 +157,7 @@ class TransformedDistribution(BaseDistribution):
         2D np.ndarray, same shape as ``self``
             ppf values at the given points
         """
+        p = pd.DataFrame(p, index=self.index, columns=self.columns)
         if not self.assume_monotonic and self.inverse_transform is None:
             raise ValueError(
                 "if inverse_transform is not given, "
@@ -186,7 +187,7 @@ class TransformedDistribution(BaseDistribution):
 
         Parameters
         ----------
-        p : 2D np.ndarray, same shape as ``self``
+        x : 2D np.ndarray, same shape as ``self``
             values to evaluate the cdf at
 
         Returns
@@ -199,6 +200,7 @@ class TransformedDistribution(BaseDistribution):
 
         inv_trafo = self.inverse_transform
 
+        x = pd.DataFrame(x, index=self.index, columns=self.columns)
         inv_x = inv_trafo(x)
         cdf_res = self.distribution.cdf(inv_x)
 

--- a/skpro/distributions/trafo/_transformed.py
+++ b/skpro/distributions/trafo/_transformed.py
@@ -286,8 +286,8 @@ class TransformedDistribution(BaseDistribution):
         n_array = Normal(mu=[[1, 2], [3, 4]], sigma=1, columns=pd.Index(["c", "d"]))
         params3 = {
             "distribution": n_array,
-            "transform": np.exp,
-            "inverse_transform": np.log,
+            "transform": np.log,
+            "inverse_transform": np.exp,
             "index": pd.Index([1, 2]),
             "columns": pd.Index(["a", "b"]),  # this should override n_row.columns
         }

--- a/skpro/distributions/trafo/_transformed.py
+++ b/skpro/distributions/trafo/_transformed.py
@@ -286,8 +286,8 @@ class TransformedDistribution(BaseDistribution):
         n_array = Normal(mu=[[1, 2], [3, 4]], sigma=1, columns=pd.Index(["c", "d"]))
         params3 = {
             "distribution": n_array,
-            "transform": lambda x: 2*x,
-            "inverse_transform": lambda x: x/2,
+            "transform": lambda x: 2 * x,
+            "inverse_transform": lambda x: x / 2,
             "index": pd.Index([1, 2]),
             "columns": pd.Index(["a", "b"]),  # this should override n_row.columns
         }

--- a/skpro/distributions/trafo/_transformed.py
+++ b/skpro/distributions/trafo/_transformed.py
@@ -44,6 +44,13 @@ class TransformedDistribution(BaseDistribution):
     >>> n = Normal(mu=0, sigma=1)
     >>> # transform the distribution by taking the exponential
     >>> t = TransformedDistribution(distribution=n, transform=np.exp)
+
+    If the inverse is known, it can be given to ensure more methods are exact:
+    >>> t = TransformedDistribution(
+    ...     distribution=n,
+    ...     transform=np.exp,
+    ...     inverse_transform=np.log,
+    ... )
     """
 
     _tags = {

--- a/skpro/distributions/trafo/_transformed.py
+++ b/skpro/distributions/trafo/_transformed.py
@@ -182,7 +182,7 @@ class TransformedDistribution(BaseDistribution):
             cdf values at the given points
         """
         if self.inverse_transform is None:
-            return super()._cdf(p)
+            return super().cdf(p)
 
         inv_trafo = self.inverse_transform
 

--- a/skpro/distributions/trafo/_transformed.py
+++ b/skpro/distributions/trafo/_transformed.py
@@ -158,7 +158,7 @@ class TransformedDistribution(BaseDistribution):
                 "set `assume_monotonic=True` to use this method"
             )
         elif not self.assume_monotonic and self.inverse_transform is not None:
-            return super()._ppf(p)
+            return super().ppf(p)
 
         trafo = self.transform
 

--- a/skpro/regression/compose/_ttr.py
+++ b/skpro/regression/compose/_ttr.py
@@ -284,6 +284,7 @@ class TransformedTargetRegressor(BaseProbaRegressor):
         y_pred_it = TransformedDistribution(
             distribution=y_pred,
             transform=self.transformer_.inverse_transform,
+            inverse_transform=self.transformer_.transform,
             assume_monotonic=True,
             index=X.index,
             columns=self._y_metadata["feature_names"],


### PR DESCRIPTION
This PR adds `cdf` support to `TransformedTargetRegressor`, via changes in `TransformedDistribution`:

* `TransformedDistribution` now accepts `inverse_transform`, which can be used for an exact `cdf`
* `TransformedTargetRegressor` passes the fitted `self.transformer_transform` to the `inverse_transform` of `TransformedDistribution`

Together with https://github.com/sktime/skpro/pull/610, it means that `TransformedTargetRegressor` can now produce distributions with reasonably reliable `cdf` and `pdf`.

Goes partially towards #601.