### PR TITLE
[BUG] fix approximate `cdf` for distributions without implementation

### DIFF
--- a/skpro/distributions/base/_base.py
+++ b/skpro/distributions/base/_base.py
@@ -924,7 +924,7 @@ class BaseDistribution(BaseObject):
 
         splx = self._sample_multiply(x, N)
         sply = self.sample(N)
-        spl = splx <= sply
+        spl = sply <= splx
         return self._sample_mean(spl)
 
     def surv(self, x):

--- a/skpro/distributions/tests/test_base_default_methods.py
+++ b/skpro/distributions/tests/test_base_default_methods.py
@@ -135,7 +135,6 @@ class _DistrDefaultMethodTesterOnlySample(BaseDistribution):
 
         super().__init__(index=index, columns=columns)
 
-
     def sample(self, n_samples=None):
         """Sample from the distribution.
 
@@ -157,7 +156,7 @@ class _DistrDefaultMethodTesterOnlySample(BaseDistribution):
         # else: self.ndim is 2
         if n_samples is None:
             res_shape = self.shape
-            vals = np.random.normal(loc=self.mu, scale=self.sigma, size=res_shape),
+            vals = np.random.normal(loc=self.mu, scale=self.sigma, size=res_shape)
             return pd.DataFrame(vals, index=self.index, columns=self.columns)
         # else: n_samples is given
         res_shape = (n_samples * self.shape[0], self.shape[1])

--- a/skpro/distributions/tests/test_base_default_methods.py
+++ b/skpro/distributions/tests/test_base_default_methods.py
@@ -110,7 +110,7 @@ def test_base_default():
 
 
 # normal distribution with only sample method
-class _DistrDefaultMethodTesterMinimal(BaseDistribution):
+class _DistrDefaultMethodTesterOnlySample(BaseDistribution):
     """Tester distribution for default methods."""
 
     _tags = {
@@ -135,6 +135,36 @@ class _DistrDefaultMethodTesterMinimal(BaseDistribution):
 
         super().__init__(index=index, columns=columns)
 
+
+    def sample(self, n_samples=None):
+        """Sample from the distribution.
+
+        Parameters
+        ----------
+        n_samples : int, optional, default = None
+            number of samples to draw from the distribution
+
+        Returns
+        -------
+        pd.DataFrame
+            samples from the distribution
+        """
+        if self.ndim == 0:
+            if n_samples is None:
+                return np.random.normal(loc=self.mu, scale=self.sigma)
+            res = np.random.normal(loc=self.mu, scale=self.sigma, size=n_samples)
+            return pd.DataFrame(res)
+        # else: self.ndim is 2
+        if n_samples is None:
+            res_shape = self.shape
+            vals = np.random.normal(loc=self.mu, scale=self.sigma, size=res_shape),
+            return pd.DataFrame(vals, index=self.index, columns=self.columns)
+        # else: n_samples is given
+        res_shape = (n_samples * self.shape[0], self.shape[1])
+        vals = np.random.normal(loc=self.mu, scale=self.sigma, size=res_shape)
+        multiindes = pd.MultiIndex.from_product(np.arange(n_samples), self.index)
+        return pd.DataFrame(vals, index=multiindes, columns=self.columns)
+
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Return testing parameter settings for the estimator."""
@@ -157,5 +187,5 @@ class _DistrDefaultMethodTesterMinimal(BaseDistribution):
 )
 def test_base_default_minimal_cdf():
     """Test default cdf method."""
-    minimal_n = _DistrDefaultMethodTesterMinimal(mu=0, sigma=1)
+    minimal_n = _DistrDefaultMethodTesterOnlySample(mu=0, sigma=1)
     assert minimal_n.cdf(0) < minimal_n.cdf(100)

--- a/skpro/distributions/tests/test_base_default_methods.py
+++ b/skpro/distributions/tests/test_base_default_methods.py
@@ -107,3 +107,55 @@ def test_base_default():
     check_estimator invokes a TestAllDistributions call.
     """
     check_estimator(_DistrDefaultMethodTester, raise_exceptions=True)
+
+
+# normal distribution with only sample method
+class _DistrDefaultMethodTesterMinimal(BaseDistribution):
+    """Tester distribution for default methods."""
+
+    _tags = {
+        "capabilities:approx": [
+            "pdfnorm",
+            "mean",
+            "var",
+            "energy",
+            "log_pdf",
+            "cdf",
+            "pdf",
+            "ppf",
+        ],
+        "capabilities:exact": [],
+        "distr:measuretype": "continuous",
+        "broadcast_init": "on",
+    }
+
+    def __init__(self, mu, sigma, index=None, columns=None):
+        self.mu = mu
+        self.sigma = sigma
+
+        super().__init__(index=index, columns=columns)
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator."""
+        # array case examples
+        params1 = {"mu": [[0, 1], [2, 3], [4, 5]], "sigma": 1}
+        params2 = {
+            "mu": 0,
+            "sigma": 1,
+            "index": pd.Index([1, 2, 5]),
+            "columns": pd.Index(["a", "b"]),
+        }
+        # scalar case examples
+        params3 = {"mu": 1, "sigma": 2}
+        return [params1, params2, params3]
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
+def test_base_default_minimal_cdf():
+    """Test default cdf method."""
+    minimal_n = _DistrDefaultMethodTesterMinimal(mu=0, sigma=1)
+    assert minimal_n.cdf(0) < minimal_n.cdf(100)


### PR DESCRIPTION
This PR fixes an unreported but with the approximate `cdf` used whenever the distribution does implement only a `sample` method.

The current state had an error of sign, where the indicator function was flipped the wrong way round, so the function estimated was 1 - cdf, and not the cdf.

This is now fixed; a test is added to prevent regression.