### PR TITLE
[BUG] fixes to `TransformedDistribution` subsetting

### DIFF
--- a/skpro/distributions/trafo/_transformed.py
+++ b/skpro/distributions/trafo/_transformed.py
@@ -190,7 +190,7 @@ class TransformedDistribution(BaseDistribution):
         inner_ppf = self.distribution.ppf(p)
 
         if self.ndim == 0:
-            inner_ppf = pd.DataFrame([[inner_ppf]], columns=[self.columns[0]])
+            inner_ppf = pd.DataFrame([[inner_ppf]])
         outer_ppf = trafo(inner_ppf)
         if self.ndim == 0:
             outer_ppf = _coerce_to_scalar(outer_ppf)
@@ -226,7 +226,7 @@ class TransformedDistribution(BaseDistribution):
         if self.ndim != 0:
             x = pd.DataFrame(x, index=self.index, columns=self.columns)
         else:
-            x = pd.DataFrame([[x]], columns=[self.columns[0]])
+            x = pd.DataFrame([[x]])
 
         inv_x = inv_trafo(x)
         if self.ndim == 0:

--- a/skpro/distributions/trafo/_transformed.py
+++ b/skpro/distributions/trafo/_transformed.py
@@ -349,11 +349,11 @@ def _coerce_to_scalar(x):
     """Coerce numpy or pd.DataFrame to numpy float."""
     if isinstance(x, pd.DataFrame):
         if x.shape != (1, 1):
-            raise ValueError("input DataFrame must be of shape (1, 1) to coerce to scalar")
+            raise ValueError("input must be of shape (1, 1) to coerce to scalar")
         return x.iat[0, 0]
     elif isinstance(x, np.ndarray):
         if x.shape != (1, 1):
-            raise ValueError("input array must be of shape (1, 1) to coerce to scalar")
+            raise ValueError("input must be of shape (1, 1) to coerce to scalar")
         return x[0, 0]
     else:
         return x

--- a/skpro/distributions/trafo/_transformed.py
+++ b/skpro/distributions/trafo/_transformed.py
@@ -227,7 +227,6 @@ class TransformedDistribution(BaseDistribution):
             x = pd.DataFrame(x, index=self.index, columns=self.columns)
         else:
             x = pd.DataFrame([[float(x)]])
-            print(x.dtypes)
 
         inv_x = inv_trafo(x)
         if self.ndim == 0:

--- a/skpro/distributions/trafo/_transformed.py
+++ b/skpro/distributions/trafo/_transformed.py
@@ -190,7 +190,7 @@ class TransformedDistribution(BaseDistribution):
         inner_ppf = self.distribution.ppf(p)
 
         if self.ndim == 0:
-            inner_ppf = pd.DataFrame([[inner_ppf]])
+            inner_ppf = pd.DataFrame([[float(inner_ppf)]])
         outer_ppf = trafo(inner_ppf)
         if self.ndim == 0:
             outer_ppf = _coerce_to_scalar(outer_ppf)
@@ -226,7 +226,8 @@ class TransformedDistribution(BaseDistribution):
         if self.ndim != 0:
             x = pd.DataFrame(x, index=self.index, columns=self.columns)
         else:
-            x = pd.DataFrame([[x]])
+            x = pd.DataFrame([[float(x)]])
+            print(x.dtypes)
 
         inv_x = inv_trafo(x)
         if self.ndim == 0:

--- a/skpro/regression/compose/_ttr.py
+++ b/skpro/regression/compose/_ttr.py
@@ -49,6 +49,27 @@ class TransformedTargetRegressor(BaseProbaRegressor):
         clone of ``regressor``, fitted to transformed target variable
     transformer_ : the fitted transformer, sklearn transformer
         clone of ``transformer``, fitted to target variable
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from sklearn.datasets import load_diabetes
+    >>> from skpro.regression.residual import ResidualDouble
+    >>> from skpro.regression.compose import TransformedTargetRegressor
+    >>> from sklearn.preprocessing import StandardScaler
+    >>> from sklearn.model_selection import train_test_split
+    >>>
+    >>> X, y = load_diabetes(return_X_y=True, as_frame=True)
+    >>> y = pd.DataFrame(y)
+    >>> X_train, X_test, y_train, y_test = train_test_split(X, y)
+    >>>
+    >>> reg = TransformedTargetRegressor(
+    ...     regressor=ResidualDouble.create_test_instance(),
+    ...     transformer=StandardScaler()
+    ... )
+    >>> reg.fit(X_train, y_train)
+    TransformedTargetRegressor(...)
+    >>> y_pred = reg.predict_proba(X_test)
     """
 
     _tags = {


### PR DESCRIPTION
This PR fixes a few of bugs with `TransformedDistribution` subsetting:

* indices were not properly coerced for all `iloc` calls
* scalar distibutions were not correctly handled