### PR TITLE
WIP [ENH] Multivariate distribution framework support

### DIFF
--- a/skpro/distributions/tests/test_all_distrs.py
+++ b/skpro/distributions/tests/test_all_distrs.py
@@ -50,12 +50,10 @@ def _has_capability(distr, method):
 
 METHODS_SCALAR = ["mean", "var", "energy"]
 METHODS_SCALAR_POS = ["var", "energy"]  # result always non-negative?
-METHODS_X = ["energy", "pdf", "log_pdf", "pmf", "log_pmf", "cdf", "pdfj"]
-METHODS_X_POS = [
-    "energy", "pdf", "pmf", "cdf", "surv", "haz", "pdfj"
-]  # result non-negative?
+METHODS_X = ["energy", "pdf", "log_pdf", "pmf", "log_pmf", "cdf"]
+METHODS_X_POS = ["energy", "pdf", "pmf", "cdf", "surv", "haz"]  # result non-negative?
 METHODS_P = ["ppf"]
-METHODS_ROWWISE = ["energy", "pdfj"]  # results in one column
+METHODS_ROWWISE = ["energy"]  # results in one column
 
 
 class TestAllDistributions(PackageConfig, DistributionFixtureGenerator, QuickTester):


### PR DESCRIPTION
WIP PR to discuss how to support multivariate distributions.

Currently contains one additional method `pdfj` which would explain how we distinguish the current variable-marginal `pdf`, and the joint `pdf`.
The default for `pdfj` would be the row-wise product of the `pdf` output, but can be overridden for multivariate distributions.

Questions about API:

* is this a reasonable design?
* this would directly generalize to `log_pdfj`, `cdfj` etc - it feels a bit duplicative.
* another option would be to include an argument `marginal` to all the methods, and it could be `"entry"` (default and current behaviour), `"row"`, or `"none"`?