### PR TITLE
[MNT] remove conflicting dependencies from `all_extras`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ all_extras = [
     "matplotlib>=3.3.2",
     "ngboost<0.6.0; python_version < '3.13'",
     "polars<1.35.0",
-    "pyarrow<14.0.0; python_version < '3.12'",
     "pymc; python_version < '3.13'",
     "statsmodels>=0.12.1",
 ]


### PR DESCRIPTION
It seems `pyarrow` and `xgboostlss` in `all_extras` is causing some dependency resolution error on python 3.11. This PR removes aforementioned dependencies from `all_extras` for diagnosis, and as a possible solution.