### PR TITLE
[MNT] Remove <3.13 bounds from soft dependencies in all_extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,10 +50,10 @@ dependencies = [
 [project.optional-dependencies]
 all_extras = [
     "distfit",
-    "lifelines<0.31.0",
+    "lifelines<0.31.0; python_version < '3.14'",
     "mapie",
     "matplotlib>=3.3.2",
-    "ngboost<0.6.0",
+    "ngboost<0.6.0; python_version < '3.14'",
     "polars<1.36.0",
     "pymc<3.14",
     "statsmodels>=0.12.1",


### PR DESCRIPTION
Removes the `python_version < '3.13'` constraints from the optional dependencies in the `all_extras` group of `pyproject.toml`, as per issue #478. No other version constraints were modified. Compatibility with Python 3.13 and NumPy 2 will be checked via CI.

Fixes #478.
