### PR TITLE
[BUG] Fix `GLMRegressor` class 

### DIFF
--- a/skpro/regression/linear/_glm.py
+++ b/skpro/regression/linear/_glm.py
@@ -565,7 +565,7 @@ class GLMRegressor(BaseProbaRegressor):
             X = X.drop(columns_to_drop, axis=1)
 
         if self._add_constant:
-            X_ = add_constant(X)
+            X_ = add_constant(X, has_constant="add")
             if rtn_off_exp_arr:
                 return X_, offset_arr, exposure_arr
             return X_

--- a/skpro/tests/_config.py
+++ b/skpro/tests/_config.py
@@ -17,6 +17,4 @@ EXCLUDE_ESTIMATORS = [
 ]
 
 
-EXCLUDED_TESTS = {
-    "GLMRegressor": ["test_online_update"],  # see 497
-}
+EXCLUDED_TESTS = {}


### PR DESCRIPTION
## Summary

This PR fixes an issue where `GLMRegressor` failed `test_online_update`  when `add_constant=True`. Fixes #497

---

## Problem

`statsmodels.tools.add_constant` only adds an intercept if it does **not** detect an existing constant column.
In `test_online_update`, the data is processed in small chunks.
If a chunk happens to contain a column that is **locally constant** (all identical values), `add_constant()` incorrectly assumes a constant already exists and skips adding the intercept.

This created a **design matrix mismatch**:

* The full training set (used during `fit()`) included the intercept column.
* A small batch passed to `predict()` might not include it.
* Result: shape mismatch errors during prediction.

---

## Fix

<img width="632" height="912" alt="image" src="https://github.com/user-attachments/assets/765bfc95-9004-4ba9-9491-3d325b6fc59e" />


The regressor now forces constant-column insertion by calling:

```python
add_constant(X, has_constant="add")
```

whenever `self._add_constant` is `True`.

This guarantees:

* The intercept column is **always added**, independent of the data content.
* `fit()` and `predict()` always receive consistent feature matrices.

---

## Safety Check

`statsmodels` handles duplicate or collinear constant columns gracefully (typically setting one coefficient to zero), so forcing the constant column is safe even when:

* The user already includes a constant feature, and/or
* The data batch itself contains a constant column.

## Testing
---

<img width="1370" height="792" alt="image" src="https://github.com/user-attachments/assets/c692002c-0a4a-413a-a7ea-cb86784553f3" />
