### PR TITLE
[DOC] add missing API reference entry for `GAMRegressor`

### DIFF
--- a/docs/source/api_reference/regression.rst
+++ b/docs/source/api_reference/regression.rst
@@ -177,7 +177,7 @@ Linear regression
 Generalized Additive Models
 ---------------------------
 
-.. currentmodule:: skpro.regression.pygam
+.. currentmodule:: skpro.regression.gam
 
 .. autosummary::
     :toctree: auto_generated/


### PR DESCRIPTION
Solves - [#634](https://github.com/sktime/skpro/issues/634)