### PR TITLE
[BUG] Ensure gamma/poission always get positive y in doctest

### DIFF
--- a/skpro/regression/gam/_gam.py
+++ b/skpro/regression/gam/_gam.py
@@ -78,6 +78,7 @@ class GAMRegressor(BaseProbaRegressor):
     >>> X, y = make_regression(n_samples=100, n_features=3, random_state=42)
     >>> X = pd.DataFrame(X, columns=['f1', 'f2', 'f3'])
     >>> y = pd.DataFrame(y, columns=['target'])
+    >>> y_positive = y.abs() + 1  # ensure positive targets for Poisson/Gamma
     >>>
     >>> # Normal distribution (default)
     >>> gam_normal = GAMRegressor(distribution='Normal')
@@ -86,12 +87,12 @@ class GAMRegressor(BaseProbaRegressor):
     >>>
     >>> # Poisson distribution for count data
     >>> gam_poisson = GAMRegressor(distribution='Poisson', link='log')
-    >>> gam_poisson.fit(X, y)
+    >>> gam_poisson.fit(X, y_positive)
     GAMRegressor(...)
     >>>
     >>> # Gamma distribution for positive continuous data
     >>> gam_gamma = GAMRegressor(distribution='Gamma', link='log')
-    >>> gam_gamma.fit(X, y)
+    >>> gam_gamma.fit(X, y_positive)
     GAMRegressor(...)
     """
 


### PR DESCRIPTION
Fixes #659 

## Issue 
--- 

The issue was in doc_test itwas passing non-positive values to distributions like poisson and binomial 

> Exception raised:
    Traceback (most recent call last):
      File "C:\Users\omswa\AppData\Local\Programs\Python\Python312\Lib\doctest.py", line 1368, in __run
        exec(compile(example.source, filename, "single",
      File "<doctest GAMRegressor[11]>", line 1, in <module>
        gam_gamma.fit(X, y)
      File "C:\Users\omswa\Desktop\skpro\skpro\regression\base\_base.py", line 116, in fit
        return self._fit(X_inner, y_inner)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "C:\Users\omswa\Desktop\skpro\skpro\regression\gam\_gam.py", line 189, in _fit
        self.estimator_.fit(X_np, y_np)
      File "C:\Users\omswa\Desktop\skpro\.venv\Lib\site-packages\pygam\pygam.py", line 886, in fit
        y = check_y(y, self.link, self.distribution, verbose=self.verbose)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "C:\Users\omswa\Desktop\skpro\.venv\Lib\site-packages\pygam\utils.py", line 238, in check_y
        raise ValueError(
    ValueError: y data is not in domain of log link function. Expected domain: [np.float64(0.0), np.float64(inf)], but found [-169.89, 312.82]

## Approach 
---
Ensured always positive values being passed to `poission ` or `gamma ` . 

<img width="1588" height="312" alt="image" src="https://github.com/user-attachments/assets/46f7b44f-31fb-4571-9794-c8086305fb42" />

