### PR TITLE
[ENH] Geometric Distribution

### DIFF
--- a/docs/source/api_reference/distributions.rst
+++ b/docs/source/api_reference/distributions.rst
@@ -78,6 +78,7 @@ Integer support
     :template: class.rst
 
     Binomial
+    Geometric
     Hurdle
     NegativeBinomial
     Poisson

--- a/skpro/distributions/__init__.py
+++ b/skpro/distributions/__init__.py
@@ -14,6 +14,7 @@ __all__ = [
     "Exponential",
     "Fisk",
     "Gamma",
+    "Geometric",
     "HalfCauchy",
     "HalfLogistic",
     "HalfNormal",
@@ -57,6 +58,7 @@ from skpro.distributions.erlang import Erlang
 from skpro.distributions.exponential import Exponential
 from skpro.distributions.fisk import Fisk
 from skpro.distributions.gamma import Gamma
+from skpro.distributions.geometric import Geometric
 from skpro.distributions.halfcauchy import HalfCauchy
 from skpro.distributions.halflogistic import HalfLogistic
 from skpro.distributions.halfnormal import HalfNormal

--- a/skpro/distributions/geometric.py
+++ b/skpro/distributions/geometric.py
@@ -1,0 +1,70 @@
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+"""Geometric probability distribution."""
+
+__author__ = ["aryabhatta-dey"]
+
+import pandas as pd
+from scipy.stats import geom, rv_discrete
+
+from skpro.distributions.adapters.scipy import _ScipyAdapter
+
+
+class Geometric(_ScipyAdapter):
+    r"""Geometric Distribution.
+
+    Most methods wrap ``scipy.stats.geom``.
+
+    The Geometric distribution is parameterized by the probability of
+    success :math:`p` in a given trial
+    such that the probability mass function (PMF) is given by:
+
+    .. math:: P(X = k) = p(1 - p)^{k - 1} \quad \text{where} \quad k = 1, 2, 3, \ldots
+
+    Parameters
+    ----------
+    p : float or array of float (1D or 2D), must be in (0, 1]
+    index : pd.Index, optional, default = RangeIndex
+    columns : pd.Index, optional, default = RangeIndex
+
+    Examples
+    --------
+    >>> from skpro.distributions.geometric import Geometric
+    >>> d = Geometric(p=0.5)
+    """
+
+    _tags = {
+        "capabilities:approx": ["pmf"],
+        "capabilities:exact": ["mean", "var", "pmf", "log_pmf", "cdf", "ppf"],
+        "distr:measuretype": "discrete",
+        "distr:paramtype": "parametric",
+        "broadcast_init": "on",
+    }
+
+    def __init__(self, p, index=None, columns=None):
+        self.p = p
+
+        super().__init__(index=index, columns=columns)
+
+    def _get_scipy_object(self) -> rv_discrete:
+        return geom
+
+    def _get_scipy_param(self):
+        p = self._bc_params["p"]
+
+        return [], {"p": p}
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator."""
+        # array case examples
+        params1 = {"p": [0.2, 0.5, 0.8]}
+        params2 = {
+            "p": 0.4,
+            "index": pd.Index([1, 2, 5]),
+            "columns": pd.Index(["a", "b"]),
+        }
+
+        # scalar case examples
+        params3 = {"p": 0.7}
+
+        return [params1, params2, params3]


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Adds geometric distribution.

#### Does your contribution introduce a new dependency? If yes, which one?
No it does not.

#### What should a reviewer concentrate their feedback on?
Anything that is possibly wrong with the pr. I am new to ml in general and am trying to learn at the moment. So I expect there to be mistakes though I double checked everything. In case there is please let me know. I will try to fix them.
I largely based my code on
1. https://github.com/sktime/skpro/blob/main/skpro/distributions/binomial.py and https://docs.scipy.org/doc//scipy-1.9.2/reference/generated/scipy.stats.binom.html
2. https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.geom.html

#### Did you add any tests for the change?
Yes

#### Any other comments?
Not at the moment.

#### PR checklist
##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [x] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [x] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [x] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).
