### PR TITLE
[ENH] Add `interval_type` for configurable bounds in `TruncatedDistribution`

### DIFF
--- a/skpro/distributions/truncated.py
+++ b/skpro/distributions/truncated.py
@@ -17,8 +17,9 @@ class TruncatedDistribution(BaseDistribution):
     .. math::
         Y \sim f(y \vert y \in I) = \frac{f(y)}{P(Y \in I)},
 
-    where :math:`I` is the interval defined by the bounds and ``interval_type``
-    and :math:`P(Y \in I)` is the total probability mass within that interval.
+    where :math:`I` is the interval defined by the bounds and ``interval_type``,
+    :math:`P(Y \in I)` is the total probability mass within that interval and
+    :math:`f(y)` is the probability mass/density function.
 
     Parameters
     ----------


### PR DESCRIPTION

#### Reference Issues/PRs
Fixes #666


#### What does this implement/fix? Explain your changes.
This PR extends `TruncatedDistribution` to support an inclusive lower bound.

#### Does your contribution introduce a new dependency? If yes, which one?
None

#### What should a reviewer concentrate their feedback on?
- Correctness of implementation

#### Did you add any tests for the change?
Yes, updated `get_test_params`  to include a test case with `inclusive_lower=True`.

#### Any other comments?
This PR currently only implements `inclusive_lower` (and not `inclusive_upper`) as this was the immediate blocker for Zero-Inflated models. However, the logic can be similarly applied to `inclusive_upper`. If this implementation pattern is correct, we can add inclusive_upper to this PR

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


