### PR TITLE
Allow scalar distributions to accept vector inputs

### DIFF
--- a/skpro/distributions/base/_base.py
+++ b/skpro/distributions/base/_base.py
@@ -695,7 +695,7 @@ class BaseDistribution(BaseObject):
                 res_cols = d.columns
             res = pd.DataFrame(res, index=d.index, columns=res_cols)
         # if numpy scalar, convert to python scalar, e.g., float
-        if isinstance(res, np.ndarray) and self.ndim == 0:
+        if isinstance(res, np.ndarray) and self.ndim == 0 and res.ndim == 0:
             res = res[()]
         return res
 
@@ -1500,8 +1500,12 @@ class BaseDistribution(BaseObject):
         """
         # scalar case
         if self.ndim == 0:
-            x = np.float64(x)
-            return x
+            x_arr = np.array(x)
+            if flatten and x_arr.ndim > 1:
+                x_arr = x_arr.reshape(1, -1)
+            if x_arr.ndim == 0:
+                return np.float64(x_arr)
+            return x_arr
 
         # array-like case
         x = np.array(x)
@@ -1534,6 +1538,10 @@ class BaseDistribution(BaseObject):
             If ``flatten`` is True, flattens ``x`` before broadcasting,
         """
         x = np.array(x)
+        if self.ndim == 0:
+            if flatten and x.ndim > 1:
+                x = x.reshape(1, -1)
+            return x
         if flatten:
             x = x.reshape(1, -1)
         df_shape = self.shape

--- a/skpro/distributions/tests/test_base_scalar.py
+++ b/skpro/distributions/tests/test_base_scalar.py
@@ -58,6 +58,32 @@ def test_scalar_distribution():
     not run_test_module_changed("skpro.distributions"),
     reason="run only if skpro.distributions has been changed",
 )
+def test_scalar_distribution_vectorized_eval():
+    """Vectorized evaluation of scalar continuous distributions."""
+    mu = 0.0
+    sigma = 1.5
+    d = Normal(mu=mu, sigma=sigma)
+    x = np.linspace(-2, 2, 9)
+
+    pdf_vec = d.pdf(x)
+    pdf_expected = np.array([d.pdf(float(val)) for val in x])
+    assert isinstance(pdf_vec, np.ndarray)
+    assert pdf_vec.shape == x.shape
+    np.testing.assert_allclose(pdf_vec, pdf_expected)
+
+    log_pdf_vec = d.log_pdf(x)
+    log_pdf_expected = np.array([d.log_pdf(float(val)) for val in x])
+    np.testing.assert_allclose(log_pdf_vec, log_pdf_expected)
+
+    cdf_vec = d.cdf(x)
+    cdf_expected = np.array([d.cdf(float(val)) for val in x])
+    np.testing.assert_allclose(cdf_vec, cdf_expected)
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
 def test_broadcast_ambiguous():
     """Test broadcasting in cases of ambiguous parameter dimensions."""
     mu = [1]
@@ -99,6 +125,31 @@ def test_broadcast_ambiguous():
     assert isinstance(spl_mult.index, pd.MultiIndex)
     assert spl_mult.index.nlevels == 2
     assert spl_mult.columns.equals(pd.RangeIndex(1))
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
+def test_scalar_discrete_vectorized_eval():
+    """Vectorized evaluation of scalar discrete distributions."""
+    mu = 3.0
+    d = Poisson(mu=mu)
+    x = np.arange(0, 6)
+
+    pmf_vec = d.pmf(x)
+    pmf_expected = np.array([d.pmf(int(val)) for val in x])
+    assert isinstance(pmf_vec, np.ndarray)
+    assert pmf_vec.shape == x.shape
+    np.testing.assert_allclose(pmf_vec, pmf_expected)
+
+    log_pmf_vec = d.log_pmf(x)
+    log_pmf_expected = np.array([d.log_pmf(int(val)) for val in x])
+    np.testing.assert_allclose(log_pmf_vec, log_pmf_expected)
+
+    cdf_vec = d.cdf(x)
+    cdf_expected = np.array([d.cdf(int(val)) for val in x])
+    np.testing.assert_allclose(cdf_vec, cdf_expected)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary
- Allow scalar (0‑D) distributions to accept vector inputs by relaxing the coercion helpers so they no longer broadcast every input to shape `()`, while still returning scalars for scalar calls.
- Adjust the boilerplate to only unwrap true 0‑D numpy outputs, ensuring vectorized results remain arrays.
- Add regression tests for scalar Normal and Poisson showing that pdf/log-pdf/cdf (and pmf/log-pmf) now work on numpy arrays without manual loops.

## Testing
- pytest skpro/distributions/tests/test_base_scalar.py