### PR TITLE
[ENH] Add explicit energy computations for multiple distributions

### DIFF
--- a/skpro/distributions/beta.py
+++ b/skpro/distributions/beta.py
@@ -37,9 +37,6 @@ class Beta(_ScipyAdapter):
 
     >>> d = Beta(beta=[[1, 1], [2, 3], [4, 5]], alpha=2)
 
-    Energy computations (exact, via deterministic numerical quadrature):
-
-    >>> d_scalar = Beta(alpha=2, beta=3)
     """
 
     _tags = {

--- a/skpro/distributions/exponential.py
+++ b/skpro/distributions/exponential.py
@@ -34,10 +34,6 @@ class Exponential(_ScipyAdapter):
     --------
     >>> from skpro.distributions.exponential import Exponential
     >>> d = Exponential(rate=2)
-
-    Energy computations (exact, closed-form formulas):
-
-    >>> d = Exponential(rate=2)
     """
 
     _tags = {

--- a/skpro/distributions/gamma.py
+++ b/skpro/distributions/gamma.py
@@ -40,9 +40,6 @@ class Gamma(_ScipyAdapter):
 
     >>> d = Gamma(beta=[[1, 1], [2, 3], [4, 5]], alpha=2)
 
-    Energy computations (exact, via deterministic numerical quadrature):
-
-    >>> d_scalar = Gamma(alpha=2, beta=1)
     """  # noqa: E501
 
     _tags = {

--- a/skpro/distributions/logistic.py
+++ b/skpro/distributions/logistic.py
@@ -35,10 +35,6 @@ class Logistic(BaseDistribution):
     >>> from skpro.distributions.logistic import Logistic
 
     >>> l = Logistic(mu=[[0, 1], [2, 3], [4, 5]], scale=1)
-
-    Energy computations (exact, via closed-form formula):
-
-    >>> d_scalar = Logistic(mu=0, scale=1)
     """
 
     _tags = {

--- a/skpro/distributions/meanscale.py
+++ b/skpro/distributions/meanscale.py
@@ -46,11 +46,6 @@ class MeanScale(BaseDistribution):
     >>>
     >>> n = Normal(mu=[[0, 1], [2, 3], [4, 5]], sigma=2)
     >>> d = MeanScale(d=n, mu=2, sigma=3)
-
-    Energy computations (exact, via delegation and scaling):
-
-    >>> n_scalar = Normal(mu=0, sigma=1)
-    >>> d_scalar = MeanScale(d=n_scalar, mu=1, sigma=2)
     """
 
     _tags = {

--- a/skpro/distributions/pareto.py
+++ b/skpro/distributions/pareto.py
@@ -36,10 +36,6 @@ class Pareto(BaseDistribution):
     >>> from skpro.distributions.pareto import Pareto
 
     >>> n = Pareto(scale=[[1, 1.5], [2, 2.5], [3, 4]], alpha=3)
-
-    Energy computations (exact, via closed-form formula):
-
-    >>> d_scalar = Pareto(scale=1, alpha=2.5)
     """
 
     _tags = {

--- a/skpro/distributions/weibull.py
+++ b/skpro/distributions/weibull.py
@@ -36,10 +36,6 @@ class Weibull(BaseDistribution):
     >>> from skpro.distributions.weibull import Weibull
 
     >>> w = Weibull(scale=[[1, 1], [2, 3], [4, 5]], k=1)
-
-    Energy computations (exact, via deterministic numerical quadrature):
-
-    >>> d_scalar = Weibull(scale=1, k=2)
     """
 
     _tags = {


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #267

#### What does this implement/fix? Explain your changes.
- Implement closed-form energy for Exponential (2/λ self-energy, piecewise cross)
- Add deterministic quadrature energy for Gamma, Logistic, Weibull, Pareto, Beta
- Implement MeanScale energy using delegation and scaling
- Move energy from approximate to exact capabilities for all above distributions
- Fix escape sequence warnings in MeanScale docstrings


#### Does your contribution introduce a new dependency? If yes, which one?

#### What should a reviewer concentrate their feedback on?
All implementations use either closed-form formulas or deterministic numerical integration (scipy.integrate.quad) instead of Monte Carlo approximation.

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [x] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [x] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
