### PR TITLE
[DOC] add missing `Uniform` distribution to API reference

### DIFF
--- a/docs/source/api_reference/distributions.rst
+++ b/docs/source/api_reference/distributions.rst
@@ -41,6 +41,7 @@ Continuous support - full reals
     SkewNormal
     TDistribution
     TruncatedNormal
+    Uniform
 
 
 Continuous support - non-negative reals


### PR DESCRIPTION
The `Uniform` distribution was missing from the API reference, this PR adds it