### PR TITLE
[MNT] allow `pandas 3.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 requires-python = ">=3.9,<3.15"
 dependencies = [
     "numpy>=1.21.0,<2.5",
-    "pandas>=1.1.0,<2.4.0",
+    "pandas>=1.1.0,<3.1.0",
     "packaging",
     "scikit-base>=0.6.1,<0.14.0",
     "scikit-learn>=0.24.0,<1.8.0",


### PR DESCRIPTION
Bumps the `pandas` bound to allow `pandas 3.0`.

Tests all seem to pass: https://github.com/sktime/skpro/pull/709