### PR TITLE
[MNT] migrate all CI environments to `uv`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,7 +162,7 @@ jobs:
 
       - name: Install skpro and dependencies
         shell: bash
-        run: uv pip install pip install .[dev] --no-cache-dir
+        run: uv pip install .[dev] --no-cache-dir
         env:
           UV_SYSTEM_PYTHON: 1
 
@@ -208,7 +208,7 @@ jobs:
 
       - name: Install skpro and dependencies
         shell: bash
-        run: uv pip install pip install .[dev] --no-cache-dir
+        run: uv pip install .[dev] --no-cache-dir
         env:
           UV_SYSTEM_PYTHON: 1
 


### PR DESCRIPTION
This PR migrates all remaining CI environments to use `uv` for speed