### PR TITLE
[BUG] Update GLM Normal and Gamma distribution parameter calculations to use self.scale_

### DIFF
--- a/skpro/regression/linear/_glm.py
+++ b/skpro/regression/linear/_glm.py
@@ -464,10 +464,12 @@ class GLMRegressor(BaseProbaRegressor):
         elif skp_dist == Gamma:
             y_mean = y_predictions_df["mean"]
             scale = self.scale_
-            
+
             y_alpha = pd.Series(1 / scale, index=y_mean.index, name="alpha").to_frame()
-            y_beta = pd.Series(1 / (scale * y_mean), index=y_mean.index, name="beta").to_frame()
-            
+            y_beta = pd.Series(
+                1 / (scale * y_mean), index=y_mean.index, name="beta"
+            ).to_frame()
+
             params["alpha"] = y_alpha
             params["beta"] = y_beta
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skpro.readthedocs.io/en/latest/contribute.html
-->

#### Reference Issues/PRs

Fixes #717 

#### What does this implement/fix? Explain your changes.

This PR fixes the construction of predictive distributions in `GLMRegressor` for the Normal and Gamma families.

Previously, the implementation used `mean_se` from `get_prediction().summary_frame()` to derive `sigma` (Normal) and `alpha`/`beta` (Gamma). However, `mean_se` represents the standard error of the estimated mean, not the conditional variance of the response.

This PR updates the implementation to use the fitted dispersion parameter (`scale_`) instead, following standard GLM theory:

- For Normal: `sigma = sqrt(scale_)`
- For Gamma: `alpha = 1 / scale`, `beta = 1 / (scale * mu)`

This ensures that predictive distributions model observation noise rather than estimation uncertainty.


#### Does your contribution introduce a new dependency? If yes, which one?

No, this change does not introduce any new dependencies.


#### What should a reviewer concentrate their feedback on?

- Correctness of the updated Normal and Gamma parameterization.
- Consistency with GLM variance and dispersion theory.
- Compatibility with existing `skpro` distribution interfaces.


#### Did you add any tests for the change?

No new tests were added in this PR.

I would be happy to add tests for probabilistic calibration if requested.


#### Any other comments?

This change aligns the probabilistic output of `GLMRegressor` with the theoretical definition of GLMs and the documentation of `statsmodels`.

Feedback and suggestions are welcome.


#### PR checklist

##### For all contributions
- [ ] I've added myself to the list of contributors with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].

##### For new estimators
- [ ] I've added the estimator to the API reference.
- [ ] I've added one or more illustrative usage examples to the docstring.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured dependency isolation.