### PR TITLE
Fix incorrect converter store usage in BaseProbaRegressor.predict() and _check_C()

### DIFF
--- a/skpro/regression/base/_base.py
+++ b/skpro/regression/base/_base.py
@@ -233,7 +233,7 @@ class BaseProbaRegressor(BaseEstimator):
             from_type=self.get_tag("y_inner_mtype"),
             to_type=self._y_metadata["mtype"],
             as_scitype="Table",
-            store=self._X_converter_store,
+            store=self._y_converter_store,
         )
 
         return y_pred
@@ -852,14 +852,14 @@ class BaseProbaRegressor(BaseEstimator):
         if not valid:
             check_is_error_msg(msg, var_name="C", raise_exception=True)
 
-        # convert y to y_inner_mtype
+        # convert C to C_inner_mtype
         C_inner_mtype = self.get_tag("C_inner_mtype")
         C_inner = convert(
             obj=C,
             from_type=metadata["mtype"],
             to_type=C_inner_mtype,
             as_scitype="Table",
-            store=self._y_converter_store,
+            store=self._C_converter_store,
         )
 
         return C_inner, metadata


### PR DESCRIPTION
# Summary

This PR fixes incorrect metadata store usage in `BaseProbaRegressor` that caused silent column corruption during prediction and censoring data conversion.

The issue exists in:

* `skpro/regression/base/_base.py`
* `BaseProbaRegressor.predict()`
* `BaseProbaRegressor._check_C()`

The base class maintains three separate converter stores:

```python
self._X_converter_store = {}
self._y_converter_store = {}
self._C_converter_store = {}
```

Each store is intended to preserve column/index metadata during `convert()` round-trips for:

* `X` → feature data
* `y` → target data
* `C` → censoring data

However, two methods were wired to the wrong store:

1. `predict()` used `_X_converter_store` instead of `_y_converter_store`
2. `_check_C()` used `_y_converter_store` instead of `_C_converter_store`

Because `convert()` automatically switches to `"freeze"` mode when the store is non-empty, this resulted in incorrect column reconstruction.

### Practical Impact

* `predict()` returned `y_pred` with:

  * X feature names applied to predictions (if shapes matched), **or**
  * integer columns (fallback case), silently dropping target names
* `predict_proba()` inherited the corrupted column structure
* Survival models reconstructed censoring data (`C`) using `y` metadata
* `_C_converter_store` was effectively dead code

This affected every probabilistic regression model using the base class.

---

# Fix

Two one-line corrections restore proper metadata routing.

### 1️⃣ Fix in `predict()`

Before:

```python
y_pred = convert(
    y_pred,
    from_type=self.get_tag("y_inner_mtype"),
    to_type=self._y_metadata["mtype"],
    as_scitype="Table",
    store=self._X_converter_store,  # incorrect
)
```

After:

```python
store=self._y_converter_store,
```

Now predictions are reconstructed using the correct target metadata.

---

### 2️⃣ Fix in `_check_C()`

Before:

```python
C_inner = convert(
    obj=C,
    from_type=metadata["mtype"],
    to_type=C_inner_mtype,
    as_scitype="Table",
    store=self._y_converter_store,  # incorrect
)
```

After:

```python
store=self._C_converter_store,
```

This activates `_C_converter_store` as originally intended and ensures censoring data round-trips with its own metadata.

---

# Verification

### ✔ Column Preservation After Predict

```python
X = pd.DataFrame({"feat1": [1,2,3], "feat2": [4,5,6]})
y = pd.DataFrame({"target": [10,20,30]})

model.fit(X, y)
y_pred = model.predict(X)

assert list(y_pred.columns) == ["target"]
```

After the fix:

* `predict()` consistently returns the original `y` column names
* No integer fallback columns appear
* No accidental reuse of X metadata

---

### ✔ Distribution Path Integrity

`predict_proba()` internally calls:

```python
pred_mean = self.predict(X=X)
```

Since `predict()` now returns correct columns:

* `Normal(mu=pred_mean, ...)` is constructed with proper target column index
* All downstream methods (`.mean()`, `.var()`, `.ppf()`) preserve correct structure

---

### ✔ Survival / Censoring Roundtrip

Censoring data (`C`) now uses `_C_converter_store` instead of `_y_converter_store`, ensuring:

* C metadata is stored independently
* Survival event/time columns remain correctly labeled
* `_C_converter_store` is no longer unused allocation

---

# Result

After this fix:

* `predict()` correctly reconstructs `y` with original column names
* `predict_proba()` inherits valid column structure
* Survival censoring metadata round-trips correctly
* `_C_converter_store` becomes active instead of dead state
* No architectural changes were required ,fix is contained to two lines

This restores correct metadata isolation between X, y, and C and prevents silent corruption in prediction outputs.
