### PR TITLE
[DOC] Fix typo variancee → variance in BaseDistribution warning message

### DIFF
--- a/skpro/distributions/base/_base.py
+++ b/skpro/distributions/base/_base.py
@@ -1417,7 +1417,7 @@ class BaseDistribution(BaseObject):
         approx_spl_size = self.get_tag("approx_var_spl")
         if self._has_implementation_of("_ppf"):
             approx_method = (
-                "by approximating the variancee integrals of the ppf, "
+                "by approximating the variance integrals of the ppf, "
                 "integral of ppf-squared minus square of integral of ppf, "
                 f"each with {approx_spl_size} equidistant nodes"
             )


### PR DESCRIPTION
## Description

This PR fixes a minor typo in the variance approximation warning message
in `BaseDistribution`.

The word `"variancee"` was misspelled and has been corrected to `"variance"`.

## Location

File:
skpro/distributions/base/_base.py

## Impact

- No functional changes
- Improves clarity and professionalism of user-facing warning messages

## Related Issue

Closes #730