### PR TITLE
[BUG] Fix `_check_C` using wrong converter store `_y_converter_store` -> `_C_converter_store`

### DIFF
--- a/skpro/regression/base/_base.py
+++ b/skpro/regression/base/_base.py
@@ -852,14 +852,14 @@ class BaseProbaRegressor(BaseEstimator):
         if not valid:
             check_is_error_msg(msg, var_name="C", raise_exception=True)
 
-        # convert y to y_inner_mtype
+        # convert C to C_inner_mtype
         C_inner_mtype = self.get_tag("C_inner_mtype")
         C_inner = convert(
             obj=C,
             from_type=metadata["mtype"],
             to_type=C_inner_mtype,
             as_scitype="Table",
-            store=self._y_converter_store,
+            store=self._C_converter_store,
         )
 
         return C_inner, metadata


### PR DESCRIPTION
**Reference Issues/PRs**

Fixes #749

**What does this implement/fix? Explain your changes.**
This PR fixes a bug in BaseProbaRegressor._check_C.

Previously, the censoring indicator C was converted using self._y_converter_store instead of the dedicated self._C_converter_store. As a result, y and C could share the same converter dictionary, potentially corrupting inverse-transform state when their mtypes differ (e.g., pd.DataFrame vs ndarray). This could lead to silent round-trip conversion errors in survival regressors.

The fix changes the converter store used in _check_C to self._C_converter_store.

Additionally, this PR corrects a stale copy-paste comment inside _check_C that incorrectly referenced converting y.

**Does your contribution introduce a new dependency? If yes, which one?**
No new dependencies are introduced.

**What should a reviewer concentrate their feedback on?**

- Correctness of the store replacement in _check_C
- Consistency with _check_X and _check_y
- Confirmation that survival estimators behave correctly when y and C have different mtypes

**Did you add any tests for the change?**
No new tests were added. This is a one-line bug fix aligning _check_C with the existing design pattern used in _check_X and _check_y.

**Any other comments?**
This is a minimal, targeted bug fix with no API changes and no behavioral changes outside survival regression.