### PR TITLE
[DOC] fix broken community links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,10 +193,10 @@ specification: all kinds of contributions are welcome - not just code.
 | :money_with_wings: **[Donate]** | Fund sktime and skpro maintenance and development. |
 | :classical_building: **[Governance]** | How and by whom decisions are made in the sktime community.   |
 
-[contribute]: https://skpro.readthedocs.io/en/latest/get_involved/contributing.html
+[contribute]: https://github.com/sktime/skpro/blob/main/CONTRIBUTING.md
 [donate]: https://opencollective.com/sktime
 [developer guides]: https://skpro.readthedocs.io/en/latest/developer_guide.html
-[contributors]: https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md
+[contributors]: https://github.com/sktime/skpro/graphs/contributors
 [governance]: https://www.sktime.net/en/latest/get_involved/governance.html
 [mentoring]: https://github.com/sktime/mentoring
 [meetings]: https://calendar.google.com/calendar/u/0/embed?src=sktime.toolbox@gmail.com&ctz=UTC


### PR DESCRIPTION
### Description
This PR fixes several broken (404) links in the "How to get involved" section of the main `README.md`. 

Specifically, it updates:
* **Contribute**: Points to the local `CONTRIBUTING.md` guide.
* **Contributors**: Points to the GitHub repository contributors graph for accurate credit.
* **Mentoring**: Points to the official GC.OS 2026 Mentoring page to align with the current GSoC cycle.

### Related Issue
Fixes #[INSERT_YOUR_ISSUE_NUMBER_HERE]

### Motivation and Context
As a GSoC 2026 applicant, I noticed these links were broken during my onboarding. Fixing these is critical for the new cohort of contributors joining for the 2026 cycle.

### Types of changes
- [x] Documentation fix