### PR TITLE
[DOC] Fix 404 broken links in README 'How to get involved' section (#751)

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,12 +193,12 @@ specification: all kinds of contributions are welcome - not just code.
 | :money_with_wings: **[Donate]** | Fund sktime and skpro maintenance and development. |
 | :classical_building: **[Governance]** | How and by whom decisions are made in the sktime community.   |
 
-[contribute]: https://skpro.readthedocs.io/en/latest/get_involved/contributing.html
+[contribute]: CONTRIBUTING.md
 [donate]: https://opencollective.com/sktime
 [developer guides]: https://skpro.readthedocs.io/en/latest/developer_guide.html
-[contributors]: https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md
+[contributors]: https://github.com/sktime/skpro/graphs/contributors
 [governance]: https://www.sktime.net/en/latest/get_involved/governance.html
-[mentoring]: https://github.com/sktime/mentoring
+[mentoring]: https://github.com/gc-os-ai/mentoring-projects/blob/main/2026/ideas_list.md
 [meetings]: https://calendar.google.com/calendar/u/0/embed?src=sktime.toolbox@gmail.com&ctz=UTC
 [roles]: https://www.sktime.net/en/latest/about/team.html
 


### PR DESCRIPTION
Specifically, I updated:

- `[contribute]` → now points to local `CONTRIBUTING.md`
- `[contributors]` → now points to GitHub contributors graph
- `[mentoring]` → now points to the 2026 GSoC mentoring ideas list

Fixes #751