### PR TITLE
Fix dummy variance formula and make survival adapter reflection safe by using vars() instead of dir()

### DIFF
--- a/skpro/regression/dummy.py
+++ b/skpro/regression/dummy.py
@@ -126,7 +126,7 @@ class DummyProbaRegressor(BaseProbaRegressor):
         X_ind = X.index
         X_n_rows = X.shape[0]
         y_pred = pd.DataFrame(
-            np.ones(X_n_rows) * self._sigma, index=X_ind, columns=self._y_columns
+            np.ones(X_n_rows) * (self._sigma**2), index=X_ind, columns=self._y_columns
         )
         return y_pred
 

--- a/skpro/regression/tests/test_all_regressors.py
+++ b/skpro/regression/tests/test_all_regressors.py
@@ -1,10 +1,12 @@
 """Automated tests based on the skbase test suite template."""
+import numpy as np
 import pandas as pd
 import pytest
 from skbase.testing import QuickTester
 
 from skpro.datatypes import check_is_mtype, check_raise
 from skpro.distributions.base import BaseDistribution
+from skpro.regression.dummy import DummyProbaRegressor
 from skpro.tests.test_all_estimators import BaseFixtureGenerator, PackageConfig
 
 TEST_ALPHAS = [0.05, [0.1], [0.25, 0.75], [0.3, 0.1, 0.9]]
@@ -206,3 +208,23 @@ class TestAllRegressors(PackageConfig, BaseFixtureGenerator, QuickTester):
         assert isinstance(y_pred_test, pd.DataFrame)
         assert (y_pred_test.index == X_test.index).all()
         assert (y_pred_test.columns == y_fit.columns).all()
+
+
+def test_dummy_predict_var():
+    """Test Roadmap Point 1: Verify variance is sigma^2, not sigma."""
+
+    y_train = pd.DataFrame({"target": [10.0, 30.0]})
+    X_train = pd.DataFrame({"feat": [0, 0]})
+
+    model = DummyProbaRegressor(strategy="normal")
+    model.fit(X_train, y_train)
+
+    pred_var_df = model.predict_var(X_train)
+    actual_val = pred_var_df.iloc[0, 0]
+
+    expected_variance = 100.0
+
+    assert np.isclose(actual_val, expected_variance), (
+        f"Variance math error! Expected {expected_variance}, but got {actual_val}. "
+        "This usually means the model is returning sigma instead of sigma^2."
+    )

--- a/skpro/survival/adapters/_common.py
+++ b/skpro/survival/adapters/_common.py
@@ -80,41 +80,18 @@ def _surv_diff(surv_arr):
 
 
 def _get_fitted_params_default_safe(obj=None):
-    """Obtain fitted params of object, per sklearn convention.
+    """Obtain fitted params of object safely without triggering properties.
 
-    Same as _get_fitted_params_default, but with exception handling.
-
-    This is since in sksurv, feature_importances_ is a property
-    and may raise an exception if the estimator does not have it.
-
-    Parameters
-    ----------
-    obj : any object
-
-    Returns
-    -------
-    fitted_params : dict with str keys
-        fitted parameters, keyed by names of fitted parameter
+    Retrieves fitted parameters following sklearn convention:
+    attributes ending with "_" and not starting with "_".
+    Uses vars(obj) instead of dir(obj) to avoid triggering properties
+    that may raise exceptions.
     """
-    # default retrieves all self attributes ending in "_"
-    # and returns them with keys that have the "_" removed
-    #
-    # get all attributes ending in "_", exclude any that start with "_" (private)
-    fitted_params = [
-        attr for attr in dir(obj) if attr.endswith("_") and not attr.startswith("_")
-    ]
+    if obj is None:
+        return {}
 
-    def hasattr_safe(obj, attr):
-        try:
-            if hasattr(obj, attr):
-                getattr(obj, attr)
-                return True
-        except Exception:
-            return False
-
-    # remove the "_" at the end
-    fitted_param_dict = {
-        p[:-1]: getattr(obj, p) for p in fitted_params if hasattr_safe(obj, p)
+    return {
+        key[:-1]: value
+        for key, value in vars(obj).items()
+        if key.endswith("_") and not key.startswith("_")
     }
-
-    return fitted_param_dict


### PR DESCRIPTION
Earlier i had opened a pull request regarding the variance formula change but it was failing certain CI tests due to an issue in scikit-survival package. 
So i have closed the previous pr opened a new PR which fixes two issues. First, it corrects the variance computation in DummyProbaRegressor to ensure that the returned variance corresponds to σ² rather than σ which was opened in the prevoious pr as well. Second, it resolves a CI failure affecting survival estimators (SurvivalForestSkSurv and SurvivalForestXtraSkSurv) under scikit-survival >= 0.27.0 and scikit-learn >= 1.8.0. The failure was caused by unsafe reflection in _get_fitted_params_default_safe, which previously relied on dir(obj). Under newer versions of scikit-learn, BaseEstimator.__dir__() internally calls hasattr() and getattr(), which in turn evaluate properties such as feature_importances_ from scikit-survival.

This property raises NotImplementedError, causing the VM test to fail before attribute filtering occurs.I have updated the implementation to use vars(obj) instead, which directly accesses obj.__dict__ and avoids invoking __dir__, hasattr, or property evaluation. This preserves the intended behavior of collecting fitted attributes (which follow the sklearn convention of ending with _) while preventing the crash. The fix is backward-compatible, as fitted parameters are stored in the instance dictionary in both older and newer dependency versions. Also,I have validtaed the changes locally under scikit-learn 1.7.x with scikit-survival 0.26.x as well as scikit-learn 1.8.x with scikit-survival 0.27.0, including full pytest execution and the VM test harness, all of which passed successfully along with pre commit formatting