### PR TITLE
[ENH] systematically move distribution author credits to tag system

### DIFF
--- a/extension_templates/distributions.py
+++ b/extension_templates/distributions.py
@@ -43,9 +43,6 @@ Testing - required for test framework and check_estimator usage:
 #       estimators contributed to skpro should have the copyright notice at the top
 #       estimators of your own do not need to have permissive or BSD-3 copyright
 
-# todo: uncomment the following line, enter authors' GitHub IDs
-# __author__ = [authorGitHubID, anotherAuthorGitHubID]
-
 from skpro.distributions.base import BaseDistribution
 
 # todo: add any necessary imports here - no soft dependency imports

--- a/extension_templates/regression.py
+++ b/extension_templates/regression.py
@@ -39,9 +39,6 @@ Testing - required for test framework and check_estimator usage:
 #       estimators contributed to skpro should have the copyright notice at the top
 #       estimators of your own do not need to have permissive or BSD-3 copyright
 
-# todo: uncomment the following line, enter authors' GitHub IDs
-# __author__ = [authorGitHubID, anotherAuthorGitHubID]
-
 from skpro.regression.base import BaseProbaRegressor
 
 # todo: add any necessary imports here

--- a/extension_templates/survival.py
+++ b/extension_templates/survival.py
@@ -41,9 +41,6 @@ Testing - required for test framework and check_estimator usage:
 #       estimators contributed to skpro should have the copyright notice at the top
 #       estimators of your own do not need to have permissive or BSD-3 copyright
 
-# todo: uncomment the following line, enter authors' GitHub IDs
-# __author__ = [authorGitHubID, anotherAuthorGitHubID]
-
 from skpro.survival.base import BaseSurvReg
 
 # todo: add any necessary imports here

--- a/skpro/distributions/alpha.py
+++ b/skpro/distributions/alpha.py
@@ -1,8 +1,6 @@
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Alpha probability distribution."""
 
-__author__ = ["SaiReavanth25"]
-
 import pandas as pd
 from scipy.stats import alpha, rv_continuous
 
@@ -46,6 +44,11 @@ class Alpha(_ScipyAdapter):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["SaiRevanth25"],
+        # estimator tags
+        # --------------
         "capabilities:approx": ["pdfnorm"],
         "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
         "distr:measuretype": "continuous",

--- a/skpro/distributions/beta.py
+++ b/skpro/distributions/beta.py
@@ -1,8 +1,6 @@
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Beta probability distribution."""
 
-__author__ = ["malikrafsan"]
-
 import numpy as np
 import pandas as pd
 from scipy.integrate import quad
@@ -40,6 +38,11 @@ class Beta(_ScipyAdapter):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["malikrafsan"],
+        # estimator tags
+        # --------------
         "capabilities:approx": ["pdfnorm"],
         "capabilities:exact": [
             "mean",

--- a/skpro/distributions/binomial.py
+++ b/skpro/distributions/binomial.py
@@ -1,8 +1,6 @@
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Binomial probability distribution."""
 
-__author__ = ["meraldoantonio"]
-
 import pandas as pd
 from scipy.stats import binom, rv_discrete
 
@@ -34,6 +32,11 @@ class Binomial(_ScipyAdapter):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["meraldoantonio"],
+        # estimator tags
+        # --------------
         "capabilities:approx": ["pmf"],
         "capabilities:exact": ["mean", "var", "pmf", "log_pmf", "cdf", "ppf"],
         "distr:measuretype": "discrete",

--- a/skpro/distributions/chi_squared.py
+++ b/skpro/distributions/chi_squared.py
@@ -1,8 +1,6 @@
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Chi-Squared probability distribution."""
 
-__author__ = ["sukjingitsit"]
-
 import numpy as np
 import pandas as pd
 from scipy.integrate import quad

--- a/skpro/distributions/delta.py
+++ b/skpro/distributions/delta.py
@@ -1,8 +1,6 @@
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Delta (constant/certain) probability distribution."""
 
-__author__ = ["fkiraly"]
-
 import numpy as np
 import pandas as pd
 
@@ -39,6 +37,11 @@ class Delta(BaseDistribution):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["fkiraly"],
+        # estimator tags
+        # --------------
         "capabilities:approx": [],
         "capabilities:exact": ["mean", "var", "energy", "pmf", "log_pmf", "cdf", "ppf"],
         "distr:measuretype": "discrete",

--- a/skpro/distributions/empirical.py
+++ b/skpro/distributions/empirical.py
@@ -1,8 +1,6 @@
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Empirical distribution."""
 
-__author__ = ["fkiraly"]
-
 import numpy as np
 import pandas as pd
 
@@ -69,6 +67,11 @@ class Empirical(BaseDistribution):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["fkiraly", "marrov"],
+        # estimator tags
+        # --------------
         "capabilities:approx": [],
         "capabilities:exact": ["mean", "var", "energy", "cdf", "ppf"],
         "distr:measuretype": "discrete",

--- a/skpro/distributions/erlang.py
+++ b/skpro/distributions/erlang.py
@@ -36,6 +36,11 @@ class Erlang(_ScipyAdapter):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["RUPESH-KUMAR01"],
+        # estimator tags
+        # --------------
         "capabilities:approx": ["energy", "pdfnorm"],
         "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
         "distr:measuretype": "continuous",

--- a/skpro/distributions/exponential.py
+++ b/skpro/distributions/exponential.py
@@ -1,8 +1,6 @@
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Exponential probability distribution."""
 
-__author__ = ["ShreeshaM07"]
-
 import numpy as np
 import pandas as pd
 from scipy.stats import expon, rv_continuous
@@ -37,6 +35,11 @@ class Exponential(_ScipyAdapter):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["ShreeshaM07"],
+        # estimator tags
+        # --------------
         "capabilities:approx": ["ppf", "pdfnorm"],
         "capabilities:exact": [
             "mean",

--- a/skpro/distributions/fisk.py
+++ b/skpro/distributions/fisk.py
@@ -1,8 +1,6 @@
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Log-logistic aka Fisk probability distribution."""
 
-__author__ = ["fkiraly", "malikrafsan"]
-
 import pandas as pd
 from scipy.stats import fisk, rv_continuous
 
@@ -37,6 +35,11 @@ class Fisk(_ScipyAdapter):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["fkiraly", "malikrafsan"],
+        # estimator tags
+        # --------------
         "capabilities:approx": ["energy", "pdfnorm"],
         "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
         "distr:measuretype": "continuous",

--- a/skpro/distributions/gamma.py
+++ b/skpro/distributions/gamma.py
@@ -1,8 +1,6 @@
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Exponential probability distribution."""
 
-__author__ = ["ShreeshaM07"]
-
 import numpy as np
 import pandas as pd
 from scipy.integrate import quad
@@ -43,6 +41,11 @@ class Gamma(_ScipyAdapter):
     """  # noqa: E501
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["ShreeshaM07"],
+        # estimator tags
+        # --------------
         "capabilities:approx": ["pdfnorm"],
         "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf", "energy"],
         "distr:measuretype": "continuous",

--- a/skpro/distributions/geometric.py
+++ b/skpro/distributions/geometric.py
@@ -1,8 +1,6 @@
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Geometric probability distribution."""
 
-__author__ = ["aryabhatta-dey"]
-
 import pandas as pd
 from scipy.stats import geom, rv_discrete
 
@@ -33,6 +31,11 @@ class Geometric(_ScipyAdapter):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["aryabhatta-dey"],
+        # estimator tags
+        # --------------
         "capabilities:approx": ["pmf"],
         "capabilities:exact": ["mean", "var", "pmf", "log_pmf", "cdf", "ppf"],
         "distr:measuretype": "discrete",

--- a/skpro/distributions/halfcauchy.py
+++ b/skpro/distributions/halfcauchy.py
@@ -1,8 +1,6 @@
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Half-Cauchy probability distribution."""
 
-__author__ = ["SaiRevanth25"]
-
 import pandas as pd
 from scipy.stats import halfcauchy, rv_continuous
 
@@ -47,6 +45,11 @@ class HalfCauchy(_ScipyAdapter):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["SaiRevanth25"],
+        # estimator tags
+        # --------------
         "capabilities:approx": ["pdfnorm"],
         "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
         "distr:measuretype": "continuous",

--- a/skpro/distributions/halflogistic.py
+++ b/skpro/distributions/halflogistic.py
@@ -1,8 +1,6 @@
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Half-Logistic probability distribution."""
 
-__author__ = ["SaiRevanth25"]
-
 import pandas as pd
 from scipy.stats import halflogistic, rv_continuous
 
@@ -48,6 +46,11 @@ class HalfLogistic(_ScipyAdapter):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["SaiRevanth25"],
+        # estimator tags
+        # --------------
         "capabilities:approx": ["pdfnorm"],
         "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
         "distr:measuretype": "continuous",

--- a/skpro/distributions/halfnormal.py
+++ b/skpro/distributions/halfnormal.py
@@ -1,8 +1,6 @@
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Half-Normal probability distribution."""
 
-__author__ = ["SaiRevanth25"]
-
 import pandas as pd
 from scipy.stats import halfnorm, rv_continuous
 
@@ -43,6 +41,11 @@ class HalfNormal(_ScipyAdapter):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["SaiRevanth25"],
+        # estimator tags
+        # --------------
         "capabilities:approx": ["pdfnorm"],
         "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
         "distr:measuretype": "continuous",

--- a/skpro/distributions/histogram.py
+++ b/skpro/distributions/histogram.py
@@ -1,8 +1,6 @@
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Histogram distribution."""
 
-__author__ = ["ShreeshaM07"]
-
 import numpy as np
 import pandas as pd
 

--- a/skpro/distributions/hurdle.py
+++ b/skpro/distributions/hurdle.py
@@ -47,6 +47,11 @@ class Hurdle(BaseDistribution):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["tingiskhan"],
+        # estimator tags
+        # --------------
         "capabilities:approx": ["energy"],
         "capabilities:exact": ["ppf", "mean", "var", "log_pmf", "pmf", "cdf"],
         "distr:measuretype": "mixed",

--- a/skpro/distributions/inversegamma.py
+++ b/skpro/distributions/inversegamma.py
@@ -1,8 +1,6 @@
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Inverse Gamma probability distribution."""
 
-__author__ = ["meraldoantonio"]
-
 import pandas as pd
 from scipy.stats import invgamma, rv_continuous
 
@@ -39,6 +37,11 @@ class InverseGamma(_ScipyAdapter):
     """  # noqa: E501
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["meraldoantonio"],
+        # estimator tags
+        # --------------
         "capabilities:approx": ["energy", "pdfnorm"],
         "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
         "distr:measuretype": "continuous",

--- a/skpro/distributions/inversegaussian.py
+++ b/skpro/distributions/inversegaussian.py
@@ -1,8 +1,6 @@
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Inverse Gaussian probability distribution."""
 
-__author__ = ["Omswastik-11"]
-
 import pandas as pd
 from scipy.stats import invgauss, rv_continuous
 
@@ -42,6 +40,11 @@ class InverseGaussian(_ScipyAdapter):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["Omswastik-11"],
+        # estimator tags
+        # --------------
         "capabilities:approx": ["energy", "pdfnorm"],
         "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
         "distr:measuretype": "continuous",

--- a/skpro/distributions/laplace.py
+++ b/skpro/distributions/laplace.py
@@ -1,8 +1,6 @@
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Laplace probability distribution."""
 
-__author__ = ["fkiraly"]
-
 import numpy as np
 import pandas as pd
 
@@ -44,6 +42,11 @@ class Laplace(BaseDistribution):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["fkiraly"],
+        # estimator tags
+        # --------------
         "capabilities:approx": ["pdfnorm"],
         "capabilities:exact": ["mean", "var", "energy", "pdf", "log_pdf", "cdf", "ppf"],
         "distr:measuretype": "continuous",

--- a/skpro/distributions/loggamma.py
+++ b/skpro/distributions/loggamma.py
@@ -1,8 +1,6 @@
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Log-Gamma probability distribution."""
 
-__author__ = ["ali-john"]
-
 import pandas as pd
 from scipy.stats import loggamma, rv_continuous
 
@@ -42,6 +40,11 @@ class LogGamma(_ScipyAdapter):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["ali-john"],
+        # estimator tags
+        # --------------
         "capabilities:approx": ["energy", "pdfnorm"],
         "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
         "distr:measuretype": "continuous",

--- a/skpro/distributions/logistic.py
+++ b/skpro/distributions/logistic.py
@@ -1,8 +1,6 @@
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Logistic probability distribution."""
 
-__author__ = ["malikrafsan"]
-
 import numpy as np
 import pandas as pd
 from scipy.integrate import quad
@@ -38,6 +36,11 @@ class Logistic(BaseDistribution):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["malikrafsan"],
+        # estimator tags
+        # --------------
         "capabilities:approx": ["pdfnorm"],
         "capabilities:exact": [
             "mean",

--- a/skpro/distributions/loglaplace.py
+++ b/skpro/distributions/loglaplace.py
@@ -1,8 +1,6 @@
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Log-Laplace probability distribution."""
 
-__author__ = ["SaiRevanth25"]
-
 import pandas as pd
 from scipy.stats import loglaplace, rv_continuous
 
@@ -47,6 +45,11 @@ class LogLaplace(_ScipyAdapter):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["SaiRevanth25"],
+        # estimator tags
+        # --------------
         "capabilities:approx": ["pdfnorm"],
         "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
         "distr:measuretype": "continuous",

--- a/skpro/distributions/lognormal.py
+++ b/skpro/distributions/lognormal.py
@@ -1,8 +1,6 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Log-Normal probability distribution."""
 
-__author__ = ["bhavikar04", "fkiraly"]
-
 import numpy as np
 import pandas as pd
 from scipy.integrate import quad

--- a/skpro/distributions/meanscale.py
+++ b/skpro/distributions/meanscale.py
@@ -1,8 +1,6 @@
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Composition for mean/scale family of distributions."""
 
-__author__ = ["fkiraly"]
-
 import numpy as np
 
 from skpro.distributions.base import BaseDistribution
@@ -49,6 +47,11 @@ class MeanScale(BaseDistribution):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["fkiraly"],
+        # estimator tags
+        # --------------
         "capabilities:approx": ["pdfnorm"],
         "capabilities:exact": ["mean", "var", "energy", "pdf", "log_pdf", "cdf", "ppf"],
         "distr:measuretype": "continuous",

--- a/skpro/distributions/mixture.py
+++ b/skpro/distributions/mixture.py
@@ -1,8 +1,6 @@
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Mixture distribution."""
 
-__author__ = ["fkiraly"]
-
 import numpy as np
 import pandas as pd
 from skbase.base import BaseMetaObject
@@ -43,6 +41,11 @@ class Mixture(BaseMetaObject, BaseDistribution):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["fkiraly"],
+        # estimator tags
+        # --------------
         "capabilities:approx": ["pdfnorm", "energy", "ppf"],
         "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf"],
         "distr:measuretype": "mixed",

--- a/skpro/distributions/negative_binomial.py
+++ b/skpro/distributions/negative_binomial.py
@@ -1,8 +1,6 @@
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Negative binomial probability distribution."""
 
-__author__ = ["tingiskhan"]
-
 import pandas as pd
 from numpy.typing import ArrayLike
 from scipy.stats import nbinom, rv_discrete
@@ -33,6 +31,11 @@ class NegativeBinomial(_ScipyAdapter):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["tingiskhan"],
+        # estimator tags
+        # --------------
         "capabilities:approx": ["energy"],
         "capabilities:exact": ["mean", "var", "pmf", "log_pmf", "cdf", "ppf"],
         "distr:measuretype": "discrete",

--- a/skpro/distributions/normal.py
+++ b/skpro/distributions/normal.py
@@ -1,8 +1,6 @@
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Normal/Gaussian probability distribution."""
 
-__author__ = ["fkiraly"]
-
 import numpy as np
 import pandas as pd
 from scipy.special import erf, erfinv
@@ -41,6 +39,11 @@ class Normal(BaseDistribution):
     """  # noqa E501
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["fkiraly"],
+        # estimator tags
+        # --------------
         "capabilities:approx": ["pdfnorm"],
         "capabilities:exact": ["mean", "var", "energy", "pdf", "log_pdf", "cdf", "ppf"],
         "distr:measuretype": "continuous",

--- a/skpro/distributions/pareto.py
+++ b/skpro/distributions/pareto.py
@@ -1,8 +1,6 @@
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Pareto probability distribution."""
 
-__author__ = ["sukjingitsit"]
-
 import numpy as np
 import pandas as pd
 from scipy.integrate import quad
@@ -39,6 +37,11 @@ class Pareto(BaseDistribution):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["sukjingitsit"],
+        # estimator tags
+        # --------------
         "capabilities:approx": ["pdfnorm"],
         "capabilities:exact": [
             "mean",

--- a/skpro/distributions/poisson.py
+++ b/skpro/distributions/poisson.py
@@ -1,8 +1,6 @@
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Poisson probability distribution."""
 
-__author__ = ["fkiraly", "malikrafsan"]
-
 import pandas as pd
 from scipy.stats import poisson, rv_discrete
 
@@ -29,6 +27,11 @@ class Poisson(_ScipyAdapter):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["fkiraly", "malikrafsan"],
+        # estimator tags
+        # --------------
         "capabilities:approx": ["energy", "pdfnorm"],
         "capabilities:exact": ["mean", "var", "pmf", "log_pmf", "cdf", "ppf"],
         "distr:measuretype": "discrete",

--- a/skpro/distributions/qpd_empirical.py
+++ b/skpro/distributions/qpd_empirical.py
@@ -1,8 +1,6 @@
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Empirical quantile parametrized distribution."""
 
-__author__ = ["fkiraly"]
-
 import numpy as np
 import pandas as pd
 
@@ -75,6 +73,11 @@ class QPD_Empirical(Empirical):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["fkiraly"],
+        # estimator tags
+        # --------------
         "capabilities:approx": [],
         "capabilities:exact": ["mean", "var", "energy", "cdf", "ppf"],
         "distr:measuretype": "discrete",

--- a/skpro/distributions/skew_normal.py
+++ b/skpro/distributions/skew_normal.py
@@ -2,8 +2,6 @@
 
 """Skew-Normal probability distribution."""
 
-__author__ = ["Spinachboul"]
-
 from scipy.stats import skewnorm
 
 from skpro.distributions.adapters.scipy._distribution import _ScipyAdapter

--- a/skpro/distributions/t.py
+++ b/skpro/distributions/t.py
@@ -1,8 +1,6 @@
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Student's t-distribution."""
 
-__author__ = ["Alex-JG3", "ivarzap"]
-
 import numpy as np
 import pandas as pd
 from scipy.integrate import quad
@@ -36,7 +34,7 @@ class TDistribution(BaseDistribution):
     """
 
     _tags = {
-        "authors": ["Alex-JG3"],
+        "authors": ["Alex-JG3", "ivarzap"],
         "maintainers": ["Alex-JG3"],
         "capabilities:approx": ["pdfnorm"],
         "capabilities:exact": ["mean", "var", "energy", "pdf", "log_pdf", "cdf", "ppf"],

--- a/skpro/distributions/truncated.py
+++ b/skpro/distributions/truncated.py
@@ -52,6 +52,11 @@ class TruncatedDistribution(BaseDistribution):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["tingiskhan"],
+        # estimator tags
+        # --------------
         "capabilities:approx": ["energy", "mean", "var"],
         "capabilities:exact": [
             "ppf",

--- a/skpro/distributions/truncated_normal.py
+++ b/skpro/distributions/truncated_normal.py
@@ -1,8 +1,6 @@
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Truncated Normal probability distribution."""
 
-__author__ = ["ShreeshaM07"]
-
 import pandas as pd
 from scipy.stats import rv_continuous, truncnorm
 
@@ -46,6 +44,11 @@ class TruncatedNormal(_ScipyAdapter):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["ShreeshaM07"],
+        # estimator tags
+        # --------------
         "capabilities:approx": ["energy", "pdfnorm"],
         "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
         "distr:measuretype": "continuous",

--- a/skpro/distributions/uniform.py
+++ b/skpro/distributions/uniform.py
@@ -1,8 +1,6 @@
 # copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Uniform probability distribution."""
 
-__author__ = ["an20805"]
-
 import numpy as np
 import pandas as pd
 

--- a/skpro/distributions/weibull.py
+++ b/skpro/distributions/weibull.py
@@ -1,8 +1,6 @@
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Weibull probability distribution."""
 
-__author__ = ["malikrafsan"]
-
 import numpy as np
 import pandas as pd
 from scipy.integrate import quad
@@ -39,6 +37,11 @@ class Weibull(BaseDistribution):
     """
 
     _tags = {
+        # packaging info
+        # --------------
+        "authors": ["malikrafsan"],
+        # estimator tags
+        # --------------
         "capabilities:approx": ["pdfnorm"],
         "capabilities:exact": [
             "mean",


### PR DESCRIPTION
This PR moves the distribution author credits to the tag system, from occasional use of the `__author__` variable in the module.

The reason is to make authorship more inspectable through the `scikit-base` tag system, which is easier to use in an estimator overview, for instance, to make author credits visible programmatically.

Also removes the todo from extension templates to use the `__author__` variable, since many authors were not using the tag (that was also recommended in the extension templates). This will hopefully prompt more authors to use the tag system in the future.