### PR TITLE
[BUG] Fix ValueError in `_check_list_of_dict_table` when encountering non-dict elements

### DIFF
--- a/skpro/datatypes/_table/_check.py
+++ b/skpro/datatypes/_table/_check.py
@@ -457,9 +457,10 @@ def _check_list_of_dict_table(obj, return_metadata=False, var_name="obj"):
         return _ret(False, msg, None, return_metadata)
 
     if not np.all([isinstance(x, dict) for x in obj]):
+        invalid_indices = [i for i, x in enumerate(obj) if not isinstance(x, dict)]
         msg = (
             f"{var_name} must be a list of dict, but elements at following "
-            f"indices are not dict: {np.where(not isinstance(x, dict) for x in obj)}"
+            f"indices are not dict: {invalid_indices}"
         )
         return _ret(False, msg, None, return_metadata)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skpro.readthedocs.io/en/latest/contribute.html
-->

## Reference Issues/PR
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes an undiscovered bug in [_check_list_of_dict_table](cci:1://file:///c:/Users/kunal/skpro/skpro/datatypes/_table/_check.py:451:0-502:54) validation.

## What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
Fixes a bug in `skpro.datatypes._table._check._check_list_of_dict_table` where a generator expression was incorrectly passed to `np.where()`.

When invalid elements (non-dictionaries) were verified by this function, it attempted to return an error message containing their indices. By passing `not isinstance(x, dict) for x in obj` directly into `np.where()`, it inadvertently caused a `ValueError: Calling nonzero on 0d arrays is not allowed.` instead of returning the validation constraint violation.

This commit replaces the faulty `np.where()` generator with a standard list comprehension `[i for i, x in enumerate(obj) if not isinstance(x, dict)]`. This correctly formats the invalid indices into the error string and prevents the validation function itself from crashing.

## Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new core dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core skpro package to a minimum.
-->
No.


## PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

#### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

#### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).
