### PR TITLE
[BUG] Fix ResidualDouble using wrong estimator in CV residuals

### DIFF
--- a/skpro/regression/residual.py
+++ b/skpro/regression/residual.py
@@ -175,7 +175,6 @@ class ResidualDouble(BaseProbaRegressor):
         y_pred : pandas DataFrame, same length as `X`, same columns as `y` in `fit`
             labels predicted for `X`
         """
-        est = self.estimator_resid_
         method = "predict"
         y_pred = y.copy()
 


### PR DESCRIPTION
## Fix: Correct estimator used in cross-validated residual computation

### Title

Fix incorrect estimator shadowing in `ResidualDouble._predict_residuals_cv` causing corrupted uncertainty estimates when `cv` is set

---

## Problem

In `skpro/regression/residual.py`, inside:

- Class: `ResidualDouble`
- Method: `_predict_residuals_cv`
- Approx line: 178

The `est` parameter (intended to be the mean estimator passed from `_fit`) was unintentionally shadowed:

```python
def _predict_residuals_cv(self, X, y, cv, est):
    est = self.estimator_resid_  # BUG: shadows the passed estimator
    method = "predict"
    y_pred = y.copy()
    ...