### PR TITLE
[ENH] exact `_log_pdf` for `Uniform` distribution

### DIFF
--- a/skpro/distributions/uniform.py
+++ b/skpro/distributions/uniform.py
@@ -87,6 +87,26 @@ class Uniform(BaseDistribution):
         pdf_arr = in_bounds / (upper - lower)
         return pdf_arr
 
+    def _log_pdf(self, x):
+        """Logarithmic probability density function.
+
+        Parameters
+        ----------
+        x : 2D np.ndarray, same shape as ``self``
+            values to evaluate the log of the pdf at
+
+        Returns
+        -------
+        2D np.ndarray, same shape as ``self``
+            log pdf values at the given points
+        """
+        lower = self._bc_params["lower"]
+        upper = self._bc_params["upper"]
+
+        in_bounds = np.logical_and(x >= lower, x <= upper)
+        log_pdf_arr = np.where(in_bounds, -np.log(upper - lower), -np.inf)
+        return log_pdf_arr
+
     def _cdf(self, x):
         """Cumulative distribution function.
 


### PR DESCRIPTION

## Reference Issues/PRs

Fixes #782 

## What does this implement/fix? Explain your changes.

Adds the missing `_log_pdf` method to the `Uniform` distribution. The class already declared `"log_pdf"` in its `capabilities:exact` tag but never implemented the method, causing the base class fallback (`np.log(self.pdf(x))`) to be used at runtime. This fallback is numerically unstable for out-of-bounds points (`log(0)` triggers numpy warnings) and contradicts the exact tag.

The new implementation directly computes:

- `-np.log(upper - lower)` for in-bounds points
- `-np.inf` for out-of-bounds points

using `np.where`, which is both exact and numerically clean.

## Does your contribution introduce a new dependency? If yes, which one?

No.

## What should a reviewer concentrate their feedback on?

The `_log_pdf` implementation in uniform.py — single method addition following the same pattern as `Laplace._log_pdf` and `Normal._log_pdf`.

## Did you add any tests for the change?

No new tests were added. The existing `test_log_pdf_and_pdf` test in `test_all_distrs.py` already validates consistency between `pdf` and `log_pdf` for all distributions, including `Uniform`. All 97 existing Uniform tests pass.

## Any other comments?

This is a small, low-risk change — one method addition (~18 lines including docstring) with no changes to existing logic.

## PR checklist

### For all contributions

- [x] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either `[ENH]`, `[MNT]`, `[DOC]`, or `[BUG]`. `[ENH]` - adding or improving code.