### PR TITLE
[ENH] Add `TemporalNormal` distribution for time-dependent Gaussian

### DIFF
--- a/docs/source/api_reference/distributions.rst
+++ b/docs/source/api_reference/distributions.rst
@@ -38,6 +38,7 @@ Continuous support - full reals
     Laplace
     Logistic
     Normal
+    TemporalNormal
     SkewNormal
     TDistribution
     TruncatedNormal

--- a/skpro/distributions/__init__.py
+++ b/skpro/distributions/__init__.py
@@ -49,6 +49,7 @@ __all__ = [
     "Skellam",
     "SkewNormal",
     "TDistribution",
+    "TemporalNormal",
     "TransformedDistribution",
     "TruncatedDistribution",
     "TruncatedNormal",
@@ -100,6 +101,7 @@ from skpro.distributions.qpd_empirical import QPD_Empirical
 from skpro.distributions.skellam import Skellam
 from skpro.distributions.skew_normal import SkewNormal
 from skpro.distributions.t import TDistribution
+from skpro.distributions.temporal_normal import TemporalNormal
 from skpro.distributions.trafo import TransformedDistribution
 from skpro.distributions.truncated import TruncatedDistribution
 from skpro.distributions.truncated_normal import TruncatedNormal

--- a/skpro/distributions/temporal_normal.py
+++ b/skpro/distributions/temporal_normal.py
@@ -29,6 +29,11 @@ class TemporalNormal(Normal):
     * Modeling data with temporal trends in mean and variance
     * Representing non-stationary processes
 
+    Note
+    ----
+    This implementation models time-varying marginal normals only.
+    It does not model temporal covariance/correlation between time points.
+
     Parameters
     ----------
     mu : float, array of float (1D or 2D), pd.Series, or pd.DataFrame
@@ -90,7 +95,7 @@ class TemporalNormal(Normal):
             mu = mu.to_frame()
         if isinstance(sigma, pd.Series):
             sigma = sigma.to_frame()
-        
+
         # Handle pandas DataFrame inputs with time index
         if isinstance(mu, pd.DataFrame) and index is None:
             index = mu.index
@@ -116,16 +121,16 @@ class TemporalNormal(Normal):
         """
         if self.ndim == 0:
             return self.mu
-        
+
         # Get the broadcasted parameters
         mu_bc = self._bc_params.get("mu", self.mu)
-        
-        if isinstance(self.index, pd.DatetimeIndex) or hasattr(self.index, 'get_loc'):
+
+        if isinstance(self.index, pd.DatetimeIndex) or hasattr(self.index, "get_loc"):
             try:
                 loc = self.index.get_loc(t)
                 if isinstance(mu_bc, np.ndarray) and mu_bc.ndim >= 2:
                     return mu_bc[loc, :]
-                elif hasattr(mu_bc, '__getitem__'):
+                elif hasattr(mu_bc, "__getitem__"):
                     return mu_bc[loc]
                 else:
                     return mu_bc
@@ -135,7 +140,7 @@ class TemporalNormal(Normal):
             if isinstance(t, int) and 0 <= t < len(self.index):
                 if isinstance(mu_bc, np.ndarray) and mu_bc.ndim >= 2:
                     return mu_bc[t, :]
-                elif hasattr(mu_bc, '__getitem__'):
+                elif hasattr(mu_bc, "__getitem__"):
                     return mu_bc[t]
                 else:
                     return mu_bc
@@ -156,32 +161,32 @@ class TemporalNormal(Normal):
             Variance value(s) at time t
         """
         if self.ndim == 0:
-            return self.sigma ** 2
-        
+            return self.sigma**2
+
         # Get the broadcasted parameters
         sigma_bc = self._bc_params.get("sigma", self.sigma)
-        
-        if isinstance(self.index, pd.DatetimeIndex) or hasattr(self.index, 'get_loc'):
+
+        if isinstance(self.index, pd.DatetimeIndex) or hasattr(self.index, "get_loc"):
             try:
                 loc = self.index.get_loc(t)
                 if isinstance(sigma_bc, np.ndarray) and sigma_bc.ndim >= 2:
                     sigma_t = sigma_bc[loc, :]
-                elif hasattr(sigma_bc, '__getitem__'):
+                elif hasattr(sigma_bc, "__getitem__"):
                     sigma_t = sigma_bc[loc]
                 else:
                     sigma_t = sigma_bc
-                return sigma_t ** 2
+                return sigma_t**2
             except (KeyError, TypeError):
                 raise ValueError(f"Time point {t} not found in distribution index")
         else:
             if isinstance(t, int) and 0 <= t < len(self.index):
                 if isinstance(sigma_bc, np.ndarray) and sigma_bc.ndim >= 2:
                     sigma_t = sigma_bc[t, :]
-                elif hasattr(sigma_bc, '__getitem__'):
+                elif hasattr(sigma_bc, "__getitem__"):
                     sigma_t = sigma_bc[t]
                 else:
                     sigma_t = sigma_bc
-                return sigma_t ** 2
+                return sigma_t**2
             else:
                 raise ValueError(f"Time index {t} out of range")
 
@@ -200,16 +205,16 @@ class TemporalNormal(Normal):
         """
         if self.ndim == 0:
             return self.sigma
-        
+
         # Get the broadcasted parameters
         sigma_bc = self._bc_params.get("sigma", self.sigma)
-        
-        if isinstance(self.index, pd.DatetimeIndex) or hasattr(self.index, 'get_loc'):
+
+        if isinstance(self.index, pd.DatetimeIndex) or hasattr(self.index, "get_loc"):
             try:
                 loc = self.index.get_loc(t)
                 if isinstance(sigma_bc, np.ndarray) and sigma_bc.ndim >= 2:
                     return sigma_bc[loc, :]
-                elif hasattr(sigma_bc, '__getitem__'):
+                elif hasattr(sigma_bc, "__getitem__"):
                     return sigma_bc[loc]
                 else:
                     return sigma_bc
@@ -219,7 +224,7 @@ class TemporalNormal(Normal):
             if isinstance(t, int) and 0 <= t < len(self.index):
                 if isinstance(sigma_bc, np.ndarray) and sigma_bc.ndim >= 2:
                     return sigma_bc[t, :]
-                elif hasattr(sigma_bc, '__getitem__'):
+                elif hasattr(sigma_bc, "__getitem__"):
                     return sigma_bc[t]
                 else:
                     return sigma_bc
@@ -234,17 +239,19 @@ class TemporalNormal(Normal):
             "mu": pd.Series([0, 1, 2, 3, 4]),
             "sigma": pd.Series([0.5, 0.7, 1.0, 1.2, 1.5]),
         }
-        
+
         # Array case with explicit time index
         params2 = {
             "mu": [[0, 1], [2, 3], [4, 5]],
             "sigma": [[0.5, 0.6], [0.7, 0.8], [0.9, 1.0]],
         }
-        
+
         # Scalar variance with time-varying mean
         params3 = {
-            "mu": pd.Series([0, 2, 4, 6], index=pd.date_range('2024-01-01', periods=4, freq='D')),
+            "mu": pd.Series(
+                [0, 2, 4, 6], index=pd.date_range("2024-01-01", periods=4, freq="D")
+            ),
             "sigma": 1.0,
         }
-        
+
         return [params1, params2, params3]

--- a/skpro/distributions/temporal_normal.py
+++ b/skpro/distributions/temporal_normal.py
@@ -1,0 +1,250 @@
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+"""Temporal Normal/Gaussian probability distribution with time-varying parameters."""
+
+import numpy as np
+import pandas as pd
+
+from skpro.distributions.normal import Normal
+
+
+class TemporalNormal(Normal):
+    r"""Temporal Normal distribution with time-dependent parameters.
+
+    This distribution extends the Normal distribution to explicitly handle
+    time-varying parameters. The mean :math:`\mu(t)` and standard deviation
+    :math:`\sigma(t)` can vary over time, allowing the representation of
+    temporal correlation in the data.
+
+    The temporal normal distribution is parametrized by time-dependent mean
+    :math:`\mu(t)` and time-dependent standard deviation :math:`\sigma(t)`,
+    such that at each time point :math:`t`, the pdf is:
+
+    .. math:: f(x|t) = \frac{1}{\sigma(t) \sqrt{2\pi}} \exp\left(-\frac{(x - \mu(t))^2}{2\sigma(t)^2}\right)
+
+    The time-dependent mean :math:`\mu(t)` is represented by the parameter ``mu``,
+    and the time-dependent standard deviation :math:`\sigma(t)` by the parameter ``sigma``.
+
+    This distribution is particularly useful for:
+    * Time series forecasting with uncertainty quantification
+    * Modeling data with temporal trends in mean and variance
+    * Representing non-stationary processes
+
+    Parameters
+    ----------
+    mu : float, array of float (1D or 2D), pd.Series, or pd.DataFrame
+        time-dependent mean of the normal distribution.
+        If pd.Series or pd.DataFrame, the index represents time points.
+    sigma : float, array of float (1D or 2D), pd.Series, or pd.DataFrame, must be positive
+        time-dependent standard deviation of the normal distribution.
+        If pd.Series or pd.DataFrame, the index should match ``mu``.
+    index : pd.Index, optional, default = RangeIndex
+        time index for the distribution. If ``mu`` or ``sigma`` are pandas objects
+        with an index, this will be inferred from them.
+    columns : pd.Index, optional, default = RangeIndex
+        column index for multivariate case
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import pandas as pd
+    >>> from skpro.distributions.temporal_normal import TemporalNormal
+
+    Example 1: Time-varying mean with constant variance
+    >>> time_index = pd.date_range('2024-01-01', periods=10, freq='D')
+    >>> mu_t = pd.Series(np.linspace(0, 10, 10), index=time_index)
+    >>> dist = TemporalNormal(mu=mu_t, sigma=1.0)
+
+    Example 2: Both mean and variance varying over time
+    >>> mu_t = pd.Series([0, 1, 2, 3, 4], index=pd.RangeIndex(5))
+    >>> sigma_t = pd.Series([0.5, 0.7, 1.0, 1.2, 1.5], index=pd.RangeIndex(5))
+    >>> dist = TemporalNormal(mu=mu_t, sigma=sigma_t)
+
+    Example 3: Multivariate time-varying distribution
+    >>> time_index = pd.RangeIndex(5)
+    >>> mu_t = pd.DataFrame([[0, 1], [1, 2], [2, 3], [3, 4], [4, 5]], index=time_index)
+    >>> sigma_t = pd.DataFrame([[0.5, 0.6], [0.7, 0.8], [0.9, 1.0], [1.1, 1.2], [1.3, 1.4]], index=time_index)
+    >>> dist = TemporalNormal(mu=mu_t, sigma=sigma_t)
+
+    Example 4: Array-based specification (as in Normal)
+    >>> dist = TemporalNormal(mu=[[0, 1], [2, 3], [4, 5]], sigma=[[1, 1], [1.5, 1.5], [2, 2]])
+    """  # noqa E501
+
+    _tags = {
+        # packaging info
+        # --------------
+        "authors": ["arnavk23"],
+        # estimator tags
+        # --------------
+        "capabilities:approx": ["pdfnorm"],
+        "capabilities:exact": ["mean", "var", "energy", "pdf", "log_pdf", "cdf", "ppf"],
+        "distr:measuretype": "continuous",
+        "distr:paramtype": "parametric",
+        "broadcast_init": "on",
+    }
+
+    def __init__(self, mu, sigma, index=None, columns=None):
+        # Convert pandas Series to DataFrame for proper time-series orientation
+        # Series are typically treated as row vectors (1, n) but for time series
+        # we want column vectors (n, 1) where n is the number of time points
+        if isinstance(mu, pd.Series):
+            mu = mu.to_frame()
+        if isinstance(sigma, pd.Series):
+            sigma = sigma.to_frame()
+        
+        # Handle pandas DataFrame inputs with time index
+        if isinstance(mu, pd.DataFrame) and index is None:
+            index = mu.index
+        if isinstance(sigma, pd.DataFrame) and index is None:
+            index = sigma.index
+
+        # Call parent Normal class __init__
+        # This will handle all the broadcasting and parameter setup
+        super().__init__(mu=mu, sigma=sigma, index=index, columns=columns)
+
+    def mean_at_time(self, t):
+        """Return the mean at a specific time point.
+
+        Parameters
+        ----------
+        t : int or time index
+            Time point to query
+
+        Returns
+        -------
+        float or array
+            Mean value(s) at time t
+        """
+        if self.ndim == 0:
+            return self.mu
+        
+        # Get the broadcasted parameters
+        mu_bc = self._bc_params.get("mu", self.mu)
+        
+        if isinstance(self.index, pd.DatetimeIndex) or hasattr(self.index, 'get_loc'):
+            try:
+                loc = self.index.get_loc(t)
+                if isinstance(mu_bc, np.ndarray) and mu_bc.ndim >= 2:
+                    return mu_bc[loc, :]
+                elif hasattr(mu_bc, '__getitem__'):
+                    return mu_bc[loc]
+                else:
+                    return mu_bc
+            except (KeyError, TypeError):
+                raise ValueError(f"Time point {t} not found in distribution index")
+        else:
+            if isinstance(t, int) and 0 <= t < len(self.index):
+                if isinstance(mu_bc, np.ndarray) and mu_bc.ndim >= 2:
+                    return mu_bc[t, :]
+                elif hasattr(mu_bc, '__getitem__'):
+                    return mu_bc[t]
+                else:
+                    return mu_bc
+            else:
+                raise ValueError(f"Time index {t} out of range")
+
+    def var_at_time(self, t):
+        """Return the variance at a specific time point.
+
+        Parameters
+        ----------
+        t : int or time index
+            Time point to query
+
+        Returns
+        -------
+        float or array
+            Variance value(s) at time t
+        """
+        if self.ndim == 0:
+            return self.sigma ** 2
+        
+        # Get the broadcasted parameters
+        sigma_bc = self._bc_params.get("sigma", self.sigma)
+        
+        if isinstance(self.index, pd.DatetimeIndex) or hasattr(self.index, 'get_loc'):
+            try:
+                loc = self.index.get_loc(t)
+                if isinstance(sigma_bc, np.ndarray) and sigma_bc.ndim >= 2:
+                    sigma_t = sigma_bc[loc, :]
+                elif hasattr(sigma_bc, '__getitem__'):
+                    sigma_t = sigma_bc[loc]
+                else:
+                    sigma_t = sigma_bc
+                return sigma_t ** 2
+            except (KeyError, TypeError):
+                raise ValueError(f"Time point {t} not found in distribution index")
+        else:
+            if isinstance(t, int) and 0 <= t < len(self.index):
+                if isinstance(sigma_bc, np.ndarray) and sigma_bc.ndim >= 2:
+                    sigma_t = sigma_bc[t, :]
+                elif hasattr(sigma_bc, '__getitem__'):
+                    sigma_t = sigma_bc[t]
+                else:
+                    sigma_t = sigma_bc
+                return sigma_t ** 2
+            else:
+                raise ValueError(f"Time index {t} out of range")
+
+    def std_at_time(self, t):
+        """Return the standard deviation at a specific time point.
+
+        Parameters
+        ----------
+        t : int or time index
+            Time point to query
+
+        Returns
+        -------
+        float or array
+            Standard deviation value(s) at time t
+        """
+        if self.ndim == 0:
+            return self.sigma
+        
+        # Get the broadcasted parameters
+        sigma_bc = self._bc_params.get("sigma", self.sigma)
+        
+        if isinstance(self.index, pd.DatetimeIndex) or hasattr(self.index, 'get_loc'):
+            try:
+                loc = self.index.get_loc(t)
+                if isinstance(sigma_bc, np.ndarray) and sigma_bc.ndim >= 2:
+                    return sigma_bc[loc, :]
+                elif hasattr(sigma_bc, '__getitem__'):
+                    return sigma_bc[loc]
+                else:
+                    return sigma_bc
+            except (KeyError, TypeError):
+                raise ValueError(f"Time point {t} not found in distribution index")
+        else:
+            if isinstance(t, int) and 0 <= t < len(self.index):
+                if isinstance(sigma_bc, np.ndarray) and sigma_bc.ndim >= 2:
+                    return sigma_bc[t, :]
+                elif hasattr(sigma_bc, '__getitem__'):
+                    return sigma_bc[t]
+                else:
+                    return sigma_bc
+            else:
+                raise ValueError(f"Time index {t} out of range")
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator."""
+        # Time-series case with pandas index
+        params1 = {
+            "mu": pd.Series([0, 1, 2, 3, 4]),
+            "sigma": pd.Series([0.5, 0.7, 1.0, 1.2, 1.5]),
+        }
+        
+        # Array case with explicit time index
+        params2 = {
+            "mu": [[0, 1], [2, 3], [4, 5]],
+            "sigma": [[0.5, 0.6], [0.7, 0.8], [0.9, 1.0]],
+        }
+        
+        # Scalar variance with time-varying mean
+        params3 = {
+            "mu": pd.Series([0, 2, 4, 6], index=pd.date_range('2024-01-01', periods=4, freq='D')),
+            "sigma": 1.0,
+        }
+        
+        return [params1, params2, params3]

--- a/skpro/distributions/temporal_normal.py
+++ b/skpro/distributions/temporal_normal.py
@@ -88,23 +88,38 @@ class TemporalNormal(Normal):
     }
 
     def __init__(self, mu, sigma, index=None, columns=None):
+        self.mu = mu
+        self.sigma = sigma
+
         # Convert pandas Series to DataFrame for proper time-series orientation
         # Series are typically treated as row vectors (1, n) but for time series
         # we want column vectors (n, 1) where n is the number of time points
+        mu_inner = mu
+        sigma_inner = sigma
         if isinstance(mu, pd.Series):
-            mu = mu.to_frame()
+            mu_inner = mu.to_frame()
         if isinstance(sigma, pd.Series):
-            sigma = sigma.to_frame()
+            sigma_inner = sigma.to_frame()
+
+        self._mu_inner = mu_inner
+        self._sigma_inner = sigma_inner
 
         # Handle pandas DataFrame inputs with time index
-        if isinstance(mu, pd.DataFrame) and index is None:
-            index = mu.index
-        if isinstance(sigma, pd.DataFrame) and index is None:
-            index = sigma.index
+        if isinstance(mu_inner, pd.DataFrame) and index is None:
+            index = mu_inner.index
+        if isinstance(sigma_inner, pd.DataFrame) and index is None:
+            index = sigma_inner.index
 
         # Call parent Normal class __init__
         # This will handle all the broadcasting and parameter setup
-        super().__init__(mu=mu, sigma=sigma, index=index, columns=columns)
+        super().__init__(mu=mu_inner, sigma=sigma_inner, index=index, columns=columns)
+
+        self.mu = mu
+        self.sigma = sigma
+
+    def _get_dist_params(self):
+        """Return internal broadcast-ready distribution parameters."""
+        return {"mu": self._mu_inner, "sigma": self._sigma_inner}
 
     def mean_at_time(self, t):
         """Return the mean at a specific time point.

--- a/skpro/distributions/temporal_normal.py
+++ b/skpro/distributions/temporal_normal.py
@@ -141,7 +141,7 @@ class TemporalNormal(Normal):
         mu_bc = self._bc_params.get("mu", self.mu)
 
         if isinstance(self.index, pd.DatetimeIndex) or hasattr(self.index, "get_loc"):
-            try:
+            if t in self.index:
                 loc = self.index.get_loc(t)
                 if isinstance(mu_bc, np.ndarray) and mu_bc.ndim >= 2:
                     return mu_bc[loc, :]
@@ -149,7 +149,7 @@ class TemporalNormal(Normal):
                     return mu_bc[loc]
                 else:
                     return mu_bc
-            except (KeyError, TypeError):
+            else:
                 raise ValueError(f"Time point {t} not found in distribution index")
         else:
             if isinstance(t, int) and 0 <= t < len(self.index):
@@ -182,7 +182,7 @@ class TemporalNormal(Normal):
         sigma_bc = self._bc_params.get("sigma", self.sigma)
 
         if isinstance(self.index, pd.DatetimeIndex) or hasattr(self.index, "get_loc"):
-            try:
+            if t in self.index:
                 loc = self.index.get_loc(t)
                 if isinstance(sigma_bc, np.ndarray) and sigma_bc.ndim >= 2:
                     sigma_t = sigma_bc[loc, :]
@@ -191,7 +191,7 @@ class TemporalNormal(Normal):
                 else:
                     sigma_t = sigma_bc
                 return sigma_t**2
-            except (KeyError, TypeError):
+            else:
                 raise ValueError(f"Time point {t} not found in distribution index")
         else:
             if isinstance(t, int) and 0 <= t < len(self.index):
@@ -225,7 +225,7 @@ class TemporalNormal(Normal):
         sigma_bc = self._bc_params.get("sigma", self.sigma)
 
         if isinstance(self.index, pd.DatetimeIndex) or hasattr(self.index, "get_loc"):
-            try:
+            if t in self.index:
                 loc = self.index.get_loc(t)
                 if isinstance(sigma_bc, np.ndarray) and sigma_bc.ndim >= 2:
                     return sigma_bc[loc, :]
@@ -233,7 +233,7 @@ class TemporalNormal(Normal):
                     return sigma_bc[loc]
                 else:
                     return sigma_bc
-            except (KeyError, TypeError):
+            else:
                 raise ValueError(f"Time point {t} not found in distribution index")
         else:
             if isinstance(t, int) and 0 <= t < len(self.index):

--- a/skpro/distributions/tests/test_temporal_normal.py
+++ b/skpro/distributions/tests/test_temporal_normal.py
@@ -15,19 +15,19 @@ def test_temporal_normal_basic():
     # Test with time-varying mean and constant variance
     mu_t = pd.Series([0, 1, 2, 3, 4], index=pd.RangeIndex(5))
     dist = TemporalNormal(mu=mu_t, sigma=1.0)
-    
+
     assert dist.shape == (5, 1)
     assert len(dist) == 5
-    
+
     # Test mean and variance methods
     mean = dist.mean()
     var = dist.var()
-    
+
     assert mean.shape == (5, 1)
     assert var.shape == (5, 1)
-    
+
     # Verify mean matches input
-    np.testing.assert_allclose(mean.flatten(), mu_t.values, rtol=1e-10)
+    np.testing.assert_allclose(mean.values.flatten(), mu_t.values, rtol=1e-10)
 
 
 def test_temporal_normal_time_varying_both():
@@ -35,21 +35,21 @@ def test_temporal_normal_time_varying_both():
     mu_t = pd.Series([0, 1, 2, 3, 4], index=pd.RangeIndex(5))
     sigma_t = pd.Series([0.5, 0.7, 1.0, 1.2, 1.5], index=pd.RangeIndex(5))
     dist = TemporalNormal(mu=mu_t, sigma=sigma_t)
-    
+
     assert dist.shape == (5, 1)
-    
+
     # Test variance
     var = dist.var()
-    expected_var = sigma_t.values ** 2
-    np.testing.assert_allclose(var.flatten(), expected_var, rtol=1e-10)
+    expected_var = sigma_t.values**2
+    np.testing.assert_allclose(var.values.flatten(), expected_var, rtol=1e-10)
 
 
 def test_temporal_normal_datetime_index():
     """Test TemporalNormal with datetime index."""
-    time_index = pd.date_range('2024-01-01', periods=10, freq='D')
+    time_index = pd.date_range("2024-01-01", periods=10, freq="D")
     mu_t = pd.Series(np.linspace(0, 10, 10), index=time_index)
     dist = TemporalNormal(mu=mu_t, sigma=1.0)
-    
+
     assert isinstance(dist.index, pd.DatetimeIndex)
     assert len(dist.index) == 10
     assert dist.shape == (10, 1)
@@ -60,13 +60,12 @@ def test_temporal_normal_multivariate():
     time_index = pd.RangeIndex(5)
     mu_t = pd.DataFrame([[0, 1], [1, 2], [2, 3], [3, 4], [4, 5]], index=time_index)
     sigma_t = pd.DataFrame(
-        [[0.5, 0.6], [0.7, 0.8], [0.9, 1.0], [1.1, 1.2], [1.3, 1.4]],
-        index=time_index
+        [[0.5, 0.6], [0.7, 0.8], [0.9, 1.0], [1.1, 1.2], [1.3, 1.4]], index=time_index
     )
     dist = TemporalNormal(mu=mu_t, sigma=sigma_t)
-    
+
     assert dist.shape == (5, 2)
-    
+
     mean = dist.mean()
     assert mean.shape == (5, 2)
 
@@ -74,10 +73,9 @@ def test_temporal_normal_multivariate():
 def test_temporal_normal_array_input():
     """Test TemporalNormal with array inputs (like Normal)."""
     dist = TemporalNormal(
-        mu=[[0, 1], [2, 3], [4, 5]],
-        sigma=[[0.5, 0.6], [0.7, 0.8], [0.9, 1.0]]
+        mu=[[0, 1], [2, 3], [4, 5]], sigma=[[0.5, 0.6], [0.7, 0.8], [0.9, 1.0]]
     )
-    
+
     assert dist.shape == (3, 2)
 
 
@@ -86,12 +84,12 @@ def test_temporal_normal_mean_at_time():
     mu_t = pd.Series([0, 1, 2, 3, 4], index=pd.RangeIndex(5))
     sigma_t = pd.Series([0.5, 0.7, 1.0, 1.2, 1.5], index=pd.RangeIndex(5))
     dist = TemporalNormal(mu=mu_t, sigma=sigma_t)
-    
+
     # Test mean at specific time points
     mean_0 = dist.mean_at_time(0)
     mean_2 = dist.mean_at_time(2)
     mean_4 = dist.mean_at_time(4)
-    
+
     assert np.isclose(mean_0, 0.0)
     assert np.isclose(mean_2, 2.0)
     assert np.isclose(mean_4, 4.0)
@@ -102,12 +100,12 @@ def test_temporal_normal_var_at_time():
     mu_t = pd.Series([0, 1, 2, 3, 4], index=pd.RangeIndex(5))
     sigma_t = pd.Series([0.5, 0.7, 1.0, 1.2, 1.5], index=pd.RangeIndex(5))
     dist = TemporalNormal(mu=mu_t, sigma=sigma_t)
-    
+
     # Test variance at specific time points
     var_0 = dist.var_at_time(0)
     var_2 = dist.var_at_time(2)
     var_4 = dist.var_at_time(4)
-    
+
     assert np.isclose(var_0, 0.5**2)
     assert np.isclose(var_2, 1.0**2)
     assert np.isclose(var_4, 1.5**2)
@@ -118,12 +116,12 @@ def test_temporal_normal_std_at_time():
     mu_t = pd.Series([0, 1, 2, 3, 4], index=pd.RangeIndex(5))
     sigma_t = pd.Series([0.5, 0.7, 1.0, 1.2, 1.5], index=pd.RangeIndex(5))
     dist = TemporalNormal(mu=mu_t, sigma=sigma_t)
-    
+
     # Test standard deviation at specific time points
     std_0 = dist.std_at_time(0)
     std_2 = dist.std_at_time(2)
     std_4 = dist.std_at_time(4)
-    
+
     assert np.isclose(std_0, 0.5)
     assert np.isclose(std_2, 1.0)
     assert np.isclose(std_4, 1.5)
@@ -131,16 +129,16 @@ def test_temporal_normal_std_at_time():
 
 def test_temporal_normal_datetime_query():
     """Test querying with datetime index."""
-    time_index = pd.date_range('2024-01-01', periods=5, freq='D')
+    time_index = pd.date_range("2024-01-01", periods=5, freq="D")
     mu_t = pd.Series([0, 1, 2, 3, 4], index=time_index)
     sigma_t = pd.Series([0.5, 0.7, 1.0, 1.2, 1.5], index=time_index)
     dist = TemporalNormal(mu=mu_t, sigma=sigma_t)
-    
+
     # Query by datetime
-    query_date = pd.Timestamp('2024-01-03')
+    query_date = pd.Timestamp("2024-01-03")
     mean_at_date = dist.mean_at_time(query_date)
     var_at_date = dist.var_at_time(query_date)
-    
+
     assert np.isclose(mean_at_date, 2.0)
     assert np.isclose(var_at_date, 1.0**2)
 
@@ -149,11 +147,11 @@ def test_temporal_normal_invalid_time():
     """Test error handling for invalid time queries."""
     mu_t = pd.Series([0, 1, 2, 3, 4], index=pd.RangeIndex(5))
     dist = TemporalNormal(mu=mu_t, sigma=1.0)
-    
+
     # Test out of range index
     with pytest.raises(ValueError):
         dist.mean_at_time(10)
-    
+
     with pytest.raises(ValueError):
         dist.var_at_time(10)
 
@@ -163,13 +161,13 @@ def test_temporal_normal_pdf_cdf():
     mu_t = pd.Series([0, 1, 2], index=pd.RangeIndex(3))
     sigma_t = pd.Series([1.0, 1.0, 1.0], index=pd.RangeIndex(3))
     dist = TemporalNormal(mu=mu_t, sigma=sigma_t)
-    
+
     # Test pdf
     x = np.array([[0], [1], [2]])
     pdf = dist.pdf(x)
     assert pdf.shape == (3, 1)
     assert np.all(pdf > 0)
-    
+
     # Test cdf
     cdf = dist.cdf(x)
     assert cdf.shape == (3, 1)
@@ -182,36 +180,33 @@ def test_temporal_normal_sample():
     mu_t = pd.Series([0, 1, 2, 3, 4], index=pd.RangeIndex(5))
     sigma_t = pd.Series([0.5, 0.7, 1.0, 1.2, 1.5], index=pd.RangeIndex(5))
     dist = TemporalNormal(mu=mu_t, sigma=sigma_t)
-    
+
     # Test single sample
     sample = dist.sample()
     assert sample.shape == (5, 1)
-    
+
     # Test multiple samples
     samples = dist.sample(n_samples=100)
-    assert samples.shape[0] == 100
-    
+    assert samples.shape[0] == 100 * len(dist.index)
+
     # Check that sample means are roughly correct (with large tolerance)
     sample_means = samples.groupby(level=1).mean()
     # This is a stochastic test, so use loose tolerance
     np.testing.assert_allclose(
-        sample_means.values.flatten(), 
-        mu_t.values, 
-        rtol=0.5, 
-        atol=1.0
+        sample_means.values.flatten(), mu_t.values, rtol=0.5, atol=1.0
     )
 
 
 def test_temporal_normal_scalar():
     """Test TemporalNormal with scalar parameters."""
     dist = TemporalNormal(mu=0.0, sigma=1.0)
-    
+
     assert dist.shape == ()
     assert dist.ndim == 0
-    
+
     # These should work with scalar distribution
     mean = dist.mean()
     var = dist.var()
-    
+
     assert np.isclose(mean, 0.0)
     assert np.isclose(var, 1.0)

--- a/skpro/distributions/tests/test_temporal_normal.py
+++ b/skpro/distributions/tests/test_temporal_normal.py
@@ -1,0 +1,217 @@
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+"""Tests for TemporalNormal distribution."""
+
+__author__ = ["arnavk23"]
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from skpro.distributions.temporal_normal import TemporalNormal
+
+
+def test_temporal_normal_basic():
+    """Test basic functionality of TemporalNormal distribution."""
+    # Test with time-varying mean and constant variance
+    mu_t = pd.Series([0, 1, 2, 3, 4], index=pd.RangeIndex(5))
+    dist = TemporalNormal(mu=mu_t, sigma=1.0)
+    
+    assert dist.shape == (5, 1)
+    assert len(dist) == 5
+    
+    # Test mean and variance methods
+    mean = dist.mean()
+    var = dist.var()
+    
+    assert mean.shape == (5, 1)
+    assert var.shape == (5, 1)
+    
+    # Verify mean matches input
+    np.testing.assert_allclose(mean.flatten(), mu_t.values, rtol=1e-10)
+
+
+def test_temporal_normal_time_varying_both():
+    """Test TemporalNormal with both mean and variance varying over time."""
+    mu_t = pd.Series([0, 1, 2, 3, 4], index=pd.RangeIndex(5))
+    sigma_t = pd.Series([0.5, 0.7, 1.0, 1.2, 1.5], index=pd.RangeIndex(5))
+    dist = TemporalNormal(mu=mu_t, sigma=sigma_t)
+    
+    assert dist.shape == (5, 1)
+    
+    # Test variance
+    var = dist.var()
+    expected_var = sigma_t.values ** 2
+    np.testing.assert_allclose(var.flatten(), expected_var, rtol=1e-10)
+
+
+def test_temporal_normal_datetime_index():
+    """Test TemporalNormal with datetime index."""
+    time_index = pd.date_range('2024-01-01', periods=10, freq='D')
+    mu_t = pd.Series(np.linspace(0, 10, 10), index=time_index)
+    dist = TemporalNormal(mu=mu_t, sigma=1.0)
+    
+    assert isinstance(dist.index, pd.DatetimeIndex)
+    assert len(dist.index) == 10
+    assert dist.shape == (10, 1)
+
+
+def test_temporal_normal_multivariate():
+    """Test multivariate TemporalNormal distribution."""
+    time_index = pd.RangeIndex(5)
+    mu_t = pd.DataFrame([[0, 1], [1, 2], [2, 3], [3, 4], [4, 5]], index=time_index)
+    sigma_t = pd.DataFrame(
+        [[0.5, 0.6], [0.7, 0.8], [0.9, 1.0], [1.1, 1.2], [1.3, 1.4]],
+        index=time_index
+    )
+    dist = TemporalNormal(mu=mu_t, sigma=sigma_t)
+    
+    assert dist.shape == (5, 2)
+    
+    mean = dist.mean()
+    assert mean.shape == (5, 2)
+
+
+def test_temporal_normal_array_input():
+    """Test TemporalNormal with array inputs (like Normal)."""
+    dist = TemporalNormal(
+        mu=[[0, 1], [2, 3], [4, 5]],
+        sigma=[[0.5, 0.6], [0.7, 0.8], [0.9, 1.0]]
+    )
+    
+    assert dist.shape == (3, 2)
+
+
+def test_temporal_normal_mean_at_time():
+    """Test mean_at_time method."""
+    mu_t = pd.Series([0, 1, 2, 3, 4], index=pd.RangeIndex(5))
+    sigma_t = pd.Series([0.5, 0.7, 1.0, 1.2, 1.5], index=pd.RangeIndex(5))
+    dist = TemporalNormal(mu=mu_t, sigma=sigma_t)
+    
+    # Test mean at specific time points
+    mean_0 = dist.mean_at_time(0)
+    mean_2 = dist.mean_at_time(2)
+    mean_4 = dist.mean_at_time(4)
+    
+    assert np.isclose(mean_0, 0.0)
+    assert np.isclose(mean_2, 2.0)
+    assert np.isclose(mean_4, 4.0)
+
+
+def test_temporal_normal_var_at_time():
+    """Test var_at_time method."""
+    mu_t = pd.Series([0, 1, 2, 3, 4], index=pd.RangeIndex(5))
+    sigma_t = pd.Series([0.5, 0.7, 1.0, 1.2, 1.5], index=pd.RangeIndex(5))
+    dist = TemporalNormal(mu=mu_t, sigma=sigma_t)
+    
+    # Test variance at specific time points
+    var_0 = dist.var_at_time(0)
+    var_2 = dist.var_at_time(2)
+    var_4 = dist.var_at_time(4)
+    
+    assert np.isclose(var_0, 0.5**2)
+    assert np.isclose(var_2, 1.0**2)
+    assert np.isclose(var_4, 1.5**2)
+
+
+def test_temporal_normal_std_at_time():
+    """Test std_at_time method."""
+    mu_t = pd.Series([0, 1, 2, 3, 4], index=pd.RangeIndex(5))
+    sigma_t = pd.Series([0.5, 0.7, 1.0, 1.2, 1.5], index=pd.RangeIndex(5))
+    dist = TemporalNormal(mu=mu_t, sigma=sigma_t)
+    
+    # Test standard deviation at specific time points
+    std_0 = dist.std_at_time(0)
+    std_2 = dist.std_at_time(2)
+    std_4 = dist.std_at_time(4)
+    
+    assert np.isclose(std_0, 0.5)
+    assert np.isclose(std_2, 1.0)
+    assert np.isclose(std_4, 1.5)
+
+
+def test_temporal_normal_datetime_query():
+    """Test querying with datetime index."""
+    time_index = pd.date_range('2024-01-01', periods=5, freq='D')
+    mu_t = pd.Series([0, 1, 2, 3, 4], index=time_index)
+    sigma_t = pd.Series([0.5, 0.7, 1.0, 1.2, 1.5], index=time_index)
+    dist = TemporalNormal(mu=mu_t, sigma=sigma_t)
+    
+    # Query by datetime
+    query_date = pd.Timestamp('2024-01-03')
+    mean_at_date = dist.mean_at_time(query_date)
+    var_at_date = dist.var_at_time(query_date)
+    
+    assert np.isclose(mean_at_date, 2.0)
+    assert np.isclose(var_at_date, 1.0**2)
+
+
+def test_temporal_normal_invalid_time():
+    """Test error handling for invalid time queries."""
+    mu_t = pd.Series([0, 1, 2, 3, 4], index=pd.RangeIndex(5))
+    dist = TemporalNormal(mu=mu_t, sigma=1.0)
+    
+    # Test out of range index
+    with pytest.raises(ValueError):
+        dist.mean_at_time(10)
+    
+    with pytest.raises(ValueError):
+        dist.var_at_time(10)
+
+
+def test_temporal_normal_pdf_cdf():
+    """Test pdf and cdf methods work correctly."""
+    mu_t = pd.Series([0, 1, 2], index=pd.RangeIndex(3))
+    sigma_t = pd.Series([1.0, 1.0, 1.0], index=pd.RangeIndex(3))
+    dist = TemporalNormal(mu=mu_t, sigma=sigma_t)
+    
+    # Test pdf
+    x = np.array([[0], [1], [2]])
+    pdf = dist.pdf(x)
+    assert pdf.shape == (3, 1)
+    assert np.all(pdf > 0)
+    
+    # Test cdf
+    cdf = dist.cdf(x)
+    assert cdf.shape == (3, 1)
+    assert np.all(cdf >= 0)
+    assert np.all(cdf <= 1)
+
+
+def test_temporal_normal_sample():
+    """Test sampling from TemporalNormal distribution."""
+    mu_t = pd.Series([0, 1, 2, 3, 4], index=pd.RangeIndex(5))
+    sigma_t = pd.Series([0.5, 0.7, 1.0, 1.2, 1.5], index=pd.RangeIndex(5))
+    dist = TemporalNormal(mu=mu_t, sigma=sigma_t)
+    
+    # Test single sample
+    sample = dist.sample()
+    assert sample.shape == (5, 1)
+    
+    # Test multiple samples
+    samples = dist.sample(n_samples=100)
+    assert samples.shape[0] == 100
+    
+    # Check that sample means are roughly correct (with large tolerance)
+    sample_means = samples.groupby(level=1).mean()
+    # This is a stochastic test, so use loose tolerance
+    np.testing.assert_allclose(
+        sample_means.values.flatten(), 
+        mu_t.values, 
+        rtol=0.5, 
+        atol=1.0
+    )
+
+
+def test_temporal_normal_scalar():
+    """Test TemporalNormal with scalar parameters."""
+    dist = TemporalNormal(mu=0.0, sigma=1.0)
+    
+    assert dist.shape == ()
+    assert dist.ndim == 0
+    
+    # These should work with scalar distribution
+    mean = dist.mean()
+    var = dist.var()
+    
+    assert np.isclose(mean, 0.0)
+    assert np.isclose(var, 1.0)


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #231.

#### What does this implement/fix? Explain your changes.
This PR adds a new time-dependent Gaussian distribution `TemporalNormal` to `skpro.distributions`.
- Supports time-varying `mu` and `sigma` parameters.
- Supports pandas time-indexed inputs (e.g., `pd.Series`, `pd.DataFrame`) and array-like inputs.
- Adds convenience accessors:
  - `mean_at_time(t)`
  - `var_at_time(t)`
  - `std_at_time(t)`

#### Does your contribution introduce a new dependency? If yes, which one?
No. 

#### What should a reviewer concentrate their feedback on?
- Correctness of time-dependent parameter handling (`mu`, `sigma`) across scalar/univariate/multivariate inputs.
- Consistency with existing `BaseDistribution` and `Normal` broadcasting/index behavior.

#### Did you add any tests for the change?
Yes.

#### Any other comments?
**plan** - followup pr on temporal covariance/correlation across time points (correlated multivariate temporal normal).
Also **optional/future** - a fitting/estimation utility that learns time-varying parameters from data (the issue text mentions estimation ideas, but this is usually separate from the distribution class itself). Need recommendation or design ideas before proceeding.
Happy to adjust API details if maintainers prefer tighter alignment with the broader multivariate-normal roadmap discussed in #22.

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [x] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [x] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
