### PR TITLE
[BUG] Fix Pipeline._transform not chaining transformer outputs

### DIFF
--- a/skpro/regression/compose/_pipeline.py
+++ b/skpro/regression/compose/_pipeline.py
@@ -591,12 +591,12 @@ class Pipeline(_Pipeline):
 
         for _, _, transformer in self._iter_transformers():
             if self._has_y_arg(transformer.transform):
-                Xt = transformer.transform(X=X, y=y)
+                X = transformer.transform(X=X, y=y)
             else:
-                Xt = transformer.transform(X=X)
-            if not isinstance(Xt, pd.DataFrame):
-                Xt = pd.DataFrame(Xt, index=X.index)
-        return Xt
+                X = transformer.transform(X=X)
+            if not isinstance(X, pd.DataFrame):
+                X = pd.DataFrame(X, index=X.index)
+        return X
 
     def _has_y_arg(self, method):
         """Check if method has y argument."""


### PR DESCRIPTION
## Title

Fix `Pipeline._transform` to correctly chain transformer outputs during prediction

---

## Summary

This PR fixes a critical bug in `Pipeline._transform` where transformer outputs were not chained during inference.  

Previously, each transformer in the pipeline received the **original, untransformed `X`**, and only the last transformer's output (applied to raw input) was passed to the regressor.

This caused:

- Silent prediction corruption for pipelines with 2+ transformers  
- Incorrect probabilistic outputs (`predict_proba`, `predict_interval`, `predict_quantiles`, `predict_var`)  
- Invalid cross-validation and evaluation results  
- `UnboundLocalError` for regressor-only pipelines (0 transformers)

The fix mirrors the chaining logic already used in `_fit` by reassigning `X` inside the loop.

---

## Root Cause

In `_transform`, the output of each transformer was assigned to `Xt`, but `X` was never updated:

```python
Xt = transformer.transform(X=X)