### PR TITLE
[ENH] fix time_indep, add row_indep to Empirical distribution (#283)

### DIFF
--- a/skpro/distributions/empirical.py
+++ b/skpro/distributions/empirical.py
@@ -35,8 +35,23 @@ class Empirical(BaseDistribution):
     weights : pd.Series, with same index and length as spl, optional, default=None
         if not passed, ``spl`` is assumed to be unweighted
     time_indep : bool, optional, default=True
-        if True, ``sample`` will sample individual instance indices independently
-        if False, ``sample`` will sample entire instances from ``spl``
+        Applies to array (non-scalar) distributions only.
+        Controls whether different time steps (columns within a row) are sampled
+        independently from each other.
+        if True, each time step (column) independently draws its own sample index.
+        Thus, samples from different time steps within the same instance are
+        drawn independently, breaking time-correlations present in ``spl``.
+        if False, all time steps within an instance draw from the same sample
+        index, preserving time-correlations present in ``spl``.
+    row_indep : bool, optional, default=False
+        Applies to array (non-scalar) distributions only.
+        Controls whether different rows (instances) are sampled independently
+        from each other.
+        if True, each row (instance) independently draws its own sample index.
+        Thus, samples from different rows are drawn independently, breaking
+        cross-row correlations present in ``spl``.
+        if False, all rows share the same sample index draw, preserving
+        cross-row correlations present in ``spl``.
     skip_init_sorted : bool, optional, default=False
         if True, skips sorting of empirical samples on init and instead builds
         sorted caches lazily when cdf/ppf/energy are first called.
@@ -83,6 +98,7 @@ class Empirical(BaseDistribution):
         spl,
         weights=None,
         time_indep=True,
+        row_indep=False,
         skip_init_sorted=False,
         index=None,
         columns=None,
@@ -90,6 +106,7 @@ class Empirical(BaseDistribution):
         self.spl = spl
         self.weights = weights
         self.time_indep = time_indep
+        self.row_indep = row_indep
         self.skip_init_sorted = skip_init_sorted
 
         index, columns = self._init_index(index, columns)
@@ -327,6 +344,7 @@ class Empirical(BaseDistribution):
             spl_subset,
             weights=weights_subset,
             time_indep=self.time_indep,
+            row_indep=self.row_indep,
             index=subs_rowidx,
             columns=subs_colidx,
             skip_init_sorted=self.skip_init_sorted,
@@ -564,7 +582,58 @@ class Empirical(BaseDistribution):
         spl_values = self._get_spl_array()
         n_spl, n_instances, n_cols = spl_values.shape
 
-        if self.time_indep:
+        time_indep = self.time_indep
+        row_indep = self.row_indep
+
+        if row_indep and time_indep:
+            # Each (row, time-step) pair independently draws a sample index
+            # shape: (n_samples, n_instances)
+            if self.weights is None:
+                sample_indices = rng.integers(
+                    0, n_spl, size=(n_samples, n_instances)
+                )
+            else:
+                weights_arr = self._get_weights_array()
+                sample_indices = np.zeros((n_samples, n_instances), dtype=int)
+                for j in range(n_instances):
+                    w = np.nan_to_num(weights_arr[:, j], nan=0.0)
+                    w_sum = np.sum(w)
+                    w = w / w_sum if w_sum > 0 else None
+                    sample_indices[:, j] = rng.choice(
+                        n_spl, size=n_samples, replace=True, p=w
+                    )
+            instance_indices = np.arange(n_instances)[np.newaxis, :].repeat(
+                n_samples, axis=0
+            )
+            samples = spl_values[sample_indices, instance_indices, :]
+
+        elif row_indep and not time_indep:
+            # Each row independently draws a sample index,
+            # but all time-steps within that row share the same index
+            if self.weights is None:
+                sample_indices = rng.integers(
+                    0, n_spl, size=(n_samples, n_instances)
+                )
+            else:
+                weights_arr = self._get_weights_array()
+                sample_indices = np.zeros((n_samples, n_instances), dtype=int)
+                for j in range(n_instances):
+                    w = np.nan_to_num(weights_arr[:, j], nan=0.0)
+                    w_sum = np.sum(w)
+                    w = w / w_sum if w_sum > 0 else None
+                    sample_indices[:, j] = rng.choice(
+                        n_spl, size=n_samples, replace=True, p=w
+                    )
+            # samples[s, i] = spl_values[sample_indices[s, i], i, :]
+            samples = spl_values[
+                sample_indices,
+                np.arange(n_instances)[np.newaxis, :].repeat(n_samples, axis=0),
+                :,
+            ]
+
+        elif not row_indep and time_indep:
+            # All rows share the same sample-level draw, but each column
+            # (time-step) independently picks its own index within a row
             if self.weights is None:
                 sample_indices = rng.integers(0, n_spl, size=(n_samples, n_instances))
             else:
@@ -573,19 +642,18 @@ class Empirical(BaseDistribution):
                 for j in range(n_instances):
                     w = np.nan_to_num(weights_arr[:, j], nan=0.0)
                     w_sum = np.sum(w)
-                    if w_sum == 0:
-                        w = None
-                    else:
-                        w = w / w_sum
+                    w = w / w_sum if w_sum > 0 else None
                     sample_indices[:, j] = rng.choice(
                         n_spl, size=n_samples, replace=True, p=w
                     )
-
             instance_indices = np.arange(n_instances)[np.newaxis, :].repeat(
                 n_samples, axis=0
             )
             samples = spl_values[sample_indices, instance_indices, :]
+
         else:
+            # row_indep=False, time_indep=False:
+            # All rows and all time-steps share the same sample index
             if self.weights is None:
                 sample_indices = rng.integers(0, n_spl, size=n_samples)
             else:
@@ -635,6 +703,7 @@ class Empirical(BaseDistribution):
             "spl": spl,
             "weights": None,
             "time_indep": True,
+            "row_indep": False,
             "index": pd.RangeIndex(3),
             "columns": pd.Index(["a", "b"]),
         }
@@ -644,6 +713,7 @@ class Empirical(BaseDistribution):
             "spl": spl,
             "weights": pd.Series([0.5, 0.5, 0.5, 1, 1, 1.1], index=spl_idx),
             "time_indep": False,
+            "row_indep": False,
             "index": pd.RangeIndex(3),
             "columns": pd.Index(["a", "b"]),
         }
@@ -671,7 +741,35 @@ class Empirical(BaseDistribution):
         spl = pd.DataFrame(np.random.rand(12, 2), index=spl_idx)
         param6 = {"spl": spl, "weights": weights}
 
-        return [params1, params2, params3, params4, param5, param6]
+        # params7: row_indep=True, time_indep=True
+        spl_idx7 = pd.MultiIndex.from_product(
+            [[0, 1], [0, 1, 2]], names=["sample", "time"]
+        )
+        spl7 = pd.DataFrame(
+            [[0, 1], [2, 3], [10, 11], [6, 7], [8, 9], [4, 5]],
+            index=spl_idx7,
+            columns=["a", "b"],
+        )
+        params7 = {
+            "spl": spl7,
+            "weights": None,
+            "time_indep": True,
+            "row_indep": True,
+            "index": pd.RangeIndex(3),
+            "columns": pd.Index(["a", "b"]),
+        }
+
+        # params8: row_indep=True, time_indep=False
+        params8 = {
+            "spl": spl7,
+            "weights": None,
+            "time_indep": False,
+            "row_indep": True,
+            "index": pd.RangeIndex(3),
+            "columns": pd.Index(["a", "b"]),
+        }
+
+        return [params1, params2, params3, params4, param5, param6, params7, params8]
 
 
 def _energy_np(spl, x=None, weights=None, assume_sorted=False):

--- a/skpro/distributions/tests/test_empirical.py
+++ b/skpro/distributions/tests/test_empirical.py
@@ -65,3 +65,93 @@ def test_empirical_skip_init_sorted():
     assert emp_sorted_scalar.mean() == emp_lazy_scalar.mean()
     assert emp_sorted_scalar.var() == emp_lazy_scalar.var()
     assert emp_sorted_scalar.cdf(2.5) == emp_lazy_scalar.cdf(2.5)
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
+def test_empirical_time_indep():
+    """Test that time_indep controls independence across time steps (columns).
+
+    When time_indep=True, each time step independently draws a sample index.
+    When time_indep=False, all time steps share the same sample index.
+    Both modes should produce samples with the correct shape.
+    """
+    spl_idx = pd.MultiIndex.from_product(
+        [[0, 1, 2, 3, 4], [0, 1, 2]], names=["sample", "time"]
+    )
+    np.random.seed(42)
+    spl = pd.DataFrame(
+        np.random.randn(15, 2),
+        index=spl_idx,
+        columns=["a", "b"],
+    )
+
+    emp_ti = Empirical(spl, time_indep=True)
+    emp_notI = Empirical(spl, time_indep=False)
+
+    n_samples = 10
+    # Both should produce a DataFrame with correct multi-index shape
+    result_ti = emp_ti.sample(n_samples)
+    result_notI = emp_notI.sample(n_samples)
+
+    # Shape: (n_samples * n_instances, n_cols)
+    assert result_ti.shape == (n_samples * 3, 2)
+    assert result_notI.shape == (n_samples * 3, 2)
+
+    # Values must come from the original sample pool
+    all_spl_vals = set(spl.values.flatten().round(8))
+    for val in result_ti.values.flatten():
+        assert round(val, 8) in all_spl_vals
+    for val in result_notI.values.flatten():
+        assert round(val, 8) in all_spl_vals
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
+def test_empirical_row_indep():
+    """Test that row_indep controls independence across rows (instances).
+
+    Tests all 4 combinations of time_indep x row_indep and checks
+    that all return samples of the correct shape and with values drawn
+    from the original sample pool.
+    """
+    spl_idx = pd.MultiIndex.from_product(
+        [[0, 1, 2, 3], [0, 1, 2]], names=["sample", "time"]
+    )
+    np.random.seed(0)
+    spl = pd.DataFrame(
+        np.arange(24, dtype=float).reshape(12, 2),
+        index=spl_idx,
+        columns=["a", "b"],
+    )
+
+    n_samples = 5
+    all_spl_vals = set(spl.values.flatten())
+
+    for time_indep in [True, False]:
+        for row_indep in [True, False]:
+            emp = Empirical(spl, time_indep=time_indep, row_indep=row_indep)
+            result = emp.sample(n_samples)
+            # shape: (n_samples * n_instances, n_cols) = (5*3, 2) = (15, 2)
+            assert result.shape == (n_samples * 3, 2), (
+                f"Wrong shape for time_indep={time_indep}, row_indep={row_indep}: "
+                f"{result.shape}"
+            )
+            for val in result.values.flatten():
+                assert val in all_spl_vals, (
+                    f"Value {val} not in sample pool for "
+                    f"time_indep={time_indep}, row_indep={row_indep}"
+                )
+
+    # Single sample (n_samples_was_none=True path)
+    emp = Empirical(spl, time_indep=True, row_indep=True)
+    single = emp.sample()
+    assert single.shape == (3, 2)
+
+    emp2 = Empirical(spl, time_indep=False, row_indep=True)
+    single2 = emp2.sample()
+    assert single2.shape == (3, 2)


### PR DESCRIPTION
- Clarify and improve docstring for time_indep parameter: explains that it controls independence across time steps (columns) within each instance row when sampling
- Add new row_indep bool parameter (default False) to Empirical: if True, each row (instance) independently draws its own sample index if False (default), all rows share the same sample index draw
- Rewrite _sample to dispatch across all 4 combinations of time_indep x row_indep for consistent, well-defined semantics
- Propagate row_indep through _iloc for correct subsetting
- Add params7 and params8 to get_test_params for row_indep coverage
- Add tests: test_empirical_time_indep, test_empirical_row_indep

Resolves #283

<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skpro.readthedocs.io/en/latest/contribute.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new core dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core skpro package to a minimum.
-->

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
