### PR TITLE
[ENH] add Binomial family support to GLMRegressor, closes #7

### DIFF
--- a/skpro/regression/linear/_glm.py
+++ b/skpro/regression/linear/_glm.py
@@ -29,6 +29,7 @@ class GLMRegressor(BaseProbaRegressor):
         1."Normal"
         2."Poisson"
         3."Gamma"
+        4."Binomial"
     link : string, default : None
         This parameter is used to represent the link function to be
         used with the distribution.
@@ -39,6 +40,7 @@ class GLMRegressor(BaseProbaRegressor):
         ``Normal`` : "Identity", "Log", "InversePower";
         ``Poisson`` : "Log", "Identity", "Sqrt";
         ``Gamma`` : "InversePower", "Log", "Identity";
+        ``Binomial`` : "Logit", "Probit", "Log", "CLogLog";
     offset_var : string or int, default = None
         Pass the column name as a string or column number as an int in X.
         If string, then the exog or ``X`` passed while ``fit``-ting
@@ -57,6 +59,11 @@ class GLMRegressor(BaseProbaRegressor):
         in X with all the ``exposure_var`` values for predicting
         stored in the column for each row.
         If ``int`` it corresponding column number will be considered.
+    n_trials : int, default : 1
+        Number of binomial trials. Only used when ``family="Binomial"``.
+        Defaults to 1, which corresponds to a Bernoulli (binary) response.
+        When ``predict_proba`` is called, the returned ``Binomial`` distribution
+        will use this value as the ``n`` parameter.
     missing : str
         Available options are 'none', 'drop' and 'raise'. If 'none', no nan
         checking is done. If 'drop', any observations with nans are dropped.
@@ -208,18 +215,27 @@ class GLMRegressor(BaseProbaRegressor):
     def _str_to_sm_family(self, family, link):
         """Convert the string to a statsmodel object.
 
-        If the link function is also explcitly mentioned then include then
+        If the link function is also explicitly mentioned then include then
         that must be passed to the family/distribution object.
         """
         from warnings import warn
 
-        from statsmodels.genmod.families.family import Gamma, Gaussian, Poisson
-        from statsmodels.genmod.families.links import Identity, InversePower, Log, Sqrt
+        from statsmodels.genmod.families.family import Binomial, Gamma, Gaussian, Poisson
+        from statsmodels.genmod.families.links import (
+            CLogLog,
+            Identity,
+            InversePower,
+            Log,
+            Logit,
+            Probit,
+            Sqrt,
+        )
 
         sm_fmly = {
             "Normal": Gaussian,
             "Poisson": Poisson,
             "Gamma": Gamma,
+            "Binomial": Binomial,
         }
 
         links = {
@@ -227,6 +243,9 @@ class GLMRegressor(BaseProbaRegressor):
             "Identity": Identity,
             "InversePower": InversePower,
             "Sqrt": Sqrt,
+            "Logit": Logit,
+            "Probit": Probit,
+            "CLogLog": CLogLog,
         }
 
         if link in links:
@@ -243,6 +262,7 @@ class GLMRegressor(BaseProbaRegressor):
         self,
         family="Normal",
         link=None,
+        n_trials=1,
         offset_var=None,
         exposure_var=None,
         missing="none",
@@ -263,6 +283,7 @@ class GLMRegressor(BaseProbaRegressor):
 
         self.family = family
         self.link = link
+        self.n_trials = n_trials
         self.offset_var = offset_var
         self.exposure_var = exposure_var
         self.missing = missing
@@ -281,6 +302,7 @@ class GLMRegressor(BaseProbaRegressor):
 
         self._family = self.family
         self._link = self.link
+        self._n_trials = self.n_trials
         self._offset_var = self.offset_var
         self._exposure_var = self.exposure_var
         self._missing = self.missing
@@ -436,6 +458,7 @@ class GLMRegressor(BaseProbaRegressor):
 
     def _params_sm_to_skpro(self, y_predictions_df, index, columns, family):
         """Convert the statsmodels output to equivalent skpro distribution."""
+        from skpro.distributions.binomial import Binomial
         from skpro.distributions.gamma import Gamma
         from skpro.distributions.normal import Normal
         from skpro.distributions.poisson import Poisson
@@ -444,6 +467,7 @@ class GLMRegressor(BaseProbaRegressor):
             "Normal": Normal,
             "Poisson": Poisson,
             "Gamma": Gamma,
+            "Binomial": Binomial,
         }
 
         params = {}
@@ -472,6 +496,14 @@ class GLMRegressor(BaseProbaRegressor):
 
             params["alpha"] = y_alpha
             params["beta"] = y_beta
+        elif skp_dist == Binomial:
+            # statsmodels Binomial GLM predicts the probability p (the mean).
+            # The skpro Binomial distribution is parameterised by n and p.
+            # n_trials is configured at construction time (default 1 = Bernoulli).
+            y_p = y_predictions_df["mean"].rename("p").to_frame()
+            n_trials = self._n_trials
+            params["n"] = n_trials
+            params["p"] = y_p
 
         params["index"] = index
         params["columns"] = columns
@@ -612,5 +644,16 @@ class GLMRegressor(BaseProbaRegressor):
             "link": "Log",
             "add_constant": True,
         }
+        params7 = {
+            "family": "Binomial",
+            "link": "Logit",
+            "n_trials": 1,
+            "add_constant": True,
+        }
+        params8 = {
+            "family": "Binomial",
+            "n_trials": 1,
+            "add_constant": True,
+        }
 
-        return [params1, params2, params3, params4, params5, params6]
+        return [params1, params2, params3, params4, params5, params6, params7, params8]

--- a/skpro/regression/tests/test_glm.py
+++ b/skpro/regression/tests/test_glm.py
@@ -58,3 +58,42 @@ def test_glm_with_offset_exposure():
 
     assert y_pred.shape == y_test.shape
     assert y_pred_proba.shape == y_test.shape
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(GLMRegressor),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_glm_binomial():
+    """Test GLM regressor with Binomial family (Bernoulli / logistic-style)."""
+    import numpy as np
+    import pandas as pd
+    from sklearn.model_selection import train_test_split
+
+    from skpro.distributions.binomial import Binomial
+
+    rng = np.random.default_rng(42)
+    n_samples = 200
+    n_features = 5
+    X = pd.DataFrame(
+        rng.standard_normal((n_samples, n_features)),
+        columns=[f"x{i}" for i in range(n_features)],
+    )
+    # Binary response in {0, 1}
+    y = pd.DataFrame(
+        rng.integers(0, 2, size=(n_samples, 1)).astype(float), columns=["target"]
+    )
+
+    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+
+    glm_reg = GLMRegressor(family="Binomial", link="Logit", n_trials=1, add_constant=True)
+    glm_reg.fit(X_train, y_train)
+
+    y_pred = glm_reg.predict(X_test)
+    y_pred_proba = glm_reg.predict_proba(X_test)
+
+    assert y_pred.shape == y_test.shape
+    assert y_pred_proba.shape == y_test.shape
+    assert isinstance(y_pred_proba, Binomial), (
+        f"Expected Binomial distribution, got {type(y_pred_proba)}"
+    )


### PR DESCRIPTION
- Add Binomial family to _str_to_sm_family with Logit, Probit, CLogLog links
- Add n_trials parameter to GLMRegressor constructor (default=1, Bernoulli)
- Add Binomial branch in _params_sm_to_skpro: predicts p from GLM, wraps in Binomial dist
- Update docstring to document Binomial family and n_trials param
- Add two Binomial test param sets in get_test_params
- Add test_glm_binomial test covering fit/predict/predict_proba with Binomial family

<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skpro.readthedocs.io/en/latest/contribute.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new core dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core skpro package to a minimum.
-->

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
