### PR TITLE
[ENH] enhance Fisk distribution with closed-form mean/var/pdf/cdf/ppf…

### DIFF
--- a/skpro/distributions/fisk.py
+++ b/skpro/distributions/fisk.py
@@ -1,6 +1,7 @@
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 """Log-logistic aka Fisk probability distribution."""
 
+import numpy as np
 import pandas as pd
 from scipy.stats import fisk, rv_continuous
 
@@ -8,22 +9,49 @@ from skpro.distributions.adapters.scipy import _ScipyAdapter
 
 
 class Fisk(_ScipyAdapter):
-    r"""Fisk distribution, aka log-logistic distribution.
+    r"""Fisk distribution, also known as the log-logistic distribution.
 
     Most methods wrap ``scipy.stats.fisk``.
 
-    The Fisk distribution is parametrized by a scale parameter :math:`\alpha`
-    and a shape parameter :math:`\beta`, such that the cumulative distribution
-    function (CDF) is given by:
+    This distribution is univariate, without correlation between dimensions
+    for the array-valued case.
 
-    .. math:: F(x) = 1 - \left(1 + \frac{x}{\alpha}\right)^{-\beta}\right)^{-1}
+    The Fisk (log-logistic) distribution is parameterized by a scale
+    parameter :math:`\alpha > 0` and a shape parameter :math:`\beta > 0`,
+    such that the cumulative distribution function (CDF) is given by:
+
+    .. math:: F(x) = \frac{1}{1 + \left(\frac{x}{\alpha}\right)^{-\beta}}
+        = \frac{(x / \alpha)^{\beta}}{1 + (x / \alpha)^{\beta}}, \quad x \geq 0
+
+    The probability density function (PDF) is:
+
+    .. math::
+
+        f(x) = \frac{(\beta / \alpha)\,(x/\alpha)^{\beta-1}}
+                    {\left[1 + (x/\alpha)^{\beta}\right]^2}, \quad x \geq 0
+
+    The mean is defined only for :math:`\beta > 1` and is:
+
+    .. math:: \mathbb{E}[X] = \frac{\alpha \pi / \beta}{\sin(\pi / \beta)}
+
+    The variance is defined only for :math:`\beta > 2` and is:
+
+    .. math:: \mathrm{Var}[X] = \alpha^2 \left(
+            \frac{2\pi/\beta}{\sin(2\pi/\beta)}
+            - \frac{(\pi/\beta)^2}{\sin^2(\pi/\beta)}
+        \right)
+
+    The scale parameter :math:`\alpha` is represented by the parameter ``alpha``,
+    and the shape parameter :math:`\beta` by the parameter ``beta``.
 
     Parameters
     ----------
     alpha : float or array of float (1D or 2D), must be positive
-        scale parameter of the distribution
+        Scale parameter of the distribution.
     beta : float or array of float (1D or 2D), must be positive
-        shape parameter of the distribution
+        Shape parameter of the distribution.
+        Mean is defined only for ``beta > 1``.
+        Variance is defined only for ``beta > 2``.
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
 
@@ -61,6 +89,143 @@ class Fisk(_ScipyAdapter):
         beta = self._bc_params["beta"]
 
         return [], {"c": beta, "scale": alpha}
+
+    def _mean(self):
+        r"""Return expected value of the distribution.
+
+        The mean is defined only when :math:`\beta > 1` and equals:
+
+        .. math:: \mathbb{E}[X] = \frac{\alpha \pi / \beta}{\sin(\pi / \beta)}
+
+        Returns
+        -------
+        2D np.ndarray, same shape as ``self``
+            expected value of distribution (entry-wise)
+        """
+        alpha = self._bc_params["alpha"]
+        beta = self._bc_params["beta"]
+
+        # mean = alpha * (pi/beta) / sin(pi/beta)
+        pb = np.pi / beta
+        mean_arr = alpha * pb / np.sin(pb)
+        return mean_arr
+
+    def _var(self):
+        r"""Return element/entry-wise variance of the distribution.
+
+        The variance is defined only when :math:`\beta > 2` and equals:
+
+        .. math:: \mathrm{Var}[X] = \alpha^2 \left(
+                \frac{2\pi/\beta}{\sin(2\pi/\beta)}
+                - \frac{(\pi/\beta)^2}{\sin^2(\pi/\beta)}
+            \right)
+
+        Returns
+        -------
+        2D np.ndarray, same shape as ``self``
+            variance of distribution (entry-wise)
+        """
+        alpha = self._bc_params["alpha"]
+        beta = self._bc_params["beta"]
+
+        pb = np.pi / beta
+        two_pb = 2 * np.pi / beta
+        var_arr = alpha**2 * (two_pb / np.sin(two_pb) - (pb / np.sin(pb)) ** 2)
+        return var_arr
+
+    def _pdf(self, x):
+        """Probability density function.
+
+        Parameters
+        ----------
+        x : 2D np.ndarray, same shape as ``self``
+            values to evaluate the pdf at
+
+        Returns
+        -------
+        2D np.ndarray, same shape as ``self``
+            pdf values at the given points
+        """
+        alpha = self._bc_params["alpha"]
+        beta = self._bc_params["beta"]
+
+        u = x / alpha
+        pdf_arr = np.where(
+            x > 0,
+            (beta / alpha) * u ** (beta - 1) / (1 + u**beta) ** 2,
+            0.0,
+        )
+        return pdf_arr
+
+    def _log_pdf(self, x):
+        """Logarithmic probability density function.
+
+        Parameters
+        ----------
+        x : 2D np.ndarray, same shape as ``self``
+            values to evaluate the log-pdf at
+
+        Returns
+        -------
+        2D np.ndarray, same shape as ``self``
+            log-pdf values at the given points
+        """
+        alpha = self._bc_params["alpha"]
+        beta = self._bc_params["beta"]
+
+        u = x / alpha
+        log_pdf_arr = np.where(
+            x > 0,
+            np.log(beta / alpha)
+            + (beta - 1) * np.log(u)
+            - 2 * np.log(1 + u**beta),
+            -np.inf,
+        )
+        return log_pdf_arr
+
+    def _cdf(self, x):
+        """Cumulative distribution function.
+
+        Parameters
+        ----------
+        x : 2D np.ndarray, same shape as ``self``
+            values to evaluate the cdf at
+
+        Returns
+        -------
+        2D np.ndarray, same shape as ``self``
+            cdf values at the given points
+        """
+        alpha = self._bc_params["alpha"]
+        beta = self._bc_params["beta"]
+
+        u = x / alpha
+        cdf_arr = np.where(
+            x > 0,
+            u**beta / (1 + u**beta),
+            0.0,
+        )
+        return cdf_arr
+
+    def _ppf(self, p):
+        """Percent point function = quantile function = inverse cdf.
+
+        Parameters
+        ----------
+        p : 2D np.ndarray, same shape as ``self``
+            values to evaluate the ppf at
+
+        Returns
+        -------
+        2D np.ndarray, same shape as ``self``
+            ppf values at the given points
+        """
+        alpha = self._bc_params["alpha"]
+        beta = self._bc_params["beta"]
+
+        # Analytically: quantile = alpha * (p / (1 - p))^(1/beta)
+        ppf_arr = alpha * (p / (1 - p)) ** (1 / beta)
+        return ppf_arr
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/skpro/distributions/tests/test_fisk.py
+++ b/skpro/distributions/tests/test_fisk.py
@@ -1,0 +1,108 @@
+"""Tests for the Fisk (log-logistic) probability distribution."""
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+
+import numpy as np
+import pytest
+
+from skpro.distributions.fisk import Fisk
+from skpro.tests.test_switch import run_test_module_changed
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
+@pytest.mark.parametrize("params", Fisk.get_test_params())
+def test_fisk_basic(params):
+    """Test basic construction and method availability of Fisk distribution."""
+    d = Fisk(**params)
+
+    # Check that distribution is constructed
+    assert d is not None
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
+def test_fisk_mean_var():
+    """Test that mean and variance match the closed-form formulas."""
+    alpha, beta = 2.0, 4.0  # beta > 2 so both mean and var are defined
+
+    d = Fisk(alpha=alpha, beta=beta)
+
+    # expected mean = alpha * (pi/beta) / sin(pi/beta)
+    pb = np.pi / beta
+    expected_mean = alpha * pb / np.sin(pb)
+
+    # expected var = alpha^2 * (2pi/beta / sin(2pi/beta) - (pi/beta)^2/sin^2(pi/beta))
+    two_pb = 2 * np.pi / beta
+    expected_var = alpha**2 * (two_pb / np.sin(two_pb) - (pb / np.sin(pb)) ** 2)
+
+    mean_val = d.mean().values.flat[0]
+    var_val = d.var().values.flat[0]
+
+    np.testing.assert_allclose(mean_val, expected_mean, rtol=1e-6)
+    np.testing.assert_allclose(var_val, expected_var, rtol=1e-6)
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
+def test_fisk_pdf_cdf_ppf():
+    """Test pdf, cdf and ppf for known values; verify cdf(ppf(p)) ~ p."""
+    alpha, beta = 1.0, 3.0
+    d = Fisk(alpha=alpha, beta=beta)
+
+    # At x = alpha, CDF should be 0.5 (median = alpha for any beta)
+    cdf_at_alpha = d.cdf(alpha)
+    np.testing.assert_allclose(
+        np.asarray(cdf_at_alpha).flat[0], 0.5, atol=1e-8
+    )
+
+    # ppf(0.5) should return alpha (the median)
+    ppf_at_half = d.ppf(0.5)
+    np.testing.assert_allclose(
+        np.asarray(ppf_at_half).flat[0], alpha, atol=1e-8
+    )
+
+    # PDF > 0 for positive x
+    pdf_val = d.pdf(alpha)
+    assert np.asarray(pdf_val).flat[0] > 0
+
+    # PDF = 0 for x <= 0
+    pdf_neg = d.pdf(0.0)
+    np.testing.assert_allclose(np.asarray(pdf_neg).flat[0], 0.0, atol=1e-10)
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
+def test_fisk_log_pdf():
+    """Test that log_pdf is the log of pdf for positive x."""
+    alpha, beta = 2.0, 3.0
+    d = Fisk(alpha=alpha, beta=beta)
+
+    x = 1.5
+    log_pdf_val = np.asarray(d.log_pdf(x)).flat[0]
+    pdf_val = np.asarray(d.pdf(x)).flat[0]
+
+    np.testing.assert_allclose(log_pdf_val, np.log(pdf_val), rtol=1e-6)
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
+def test_fisk_cdf_ppf_roundtrip():
+    """Test that ppf(cdf(x)) ≈ x (round-trip consistency)."""
+    alpha, beta = 2.0, 4.0
+    d = Fisk(alpha=alpha, beta=beta)
+
+    x_vals = np.array([0.5, 1.0, 2.0, 5.0])
+    for x in x_vals:
+        p = np.asarray(d.cdf(x)).flat[0]
+        x_back = np.asarray(d.ppf(p)).flat[0]
+        np.testing.assert_allclose(x_back, x, rtol=1e-6, err_msg=f"Failed at x={x}")


### PR DESCRIPTION
…, fixes #22

- Fix docstring: correct CDF formula (removed malformed LaTeX, added proper formulas)
- Add explicit _mean: alpha*pi/beta / sin(pi/beta)   [defined for beta > 1]
- Add explicit _var: closed-form formula              [defined for beta > 2]
- Add explicit _pdf: (beta/alpha)*(x/alpha)^(beta-1) / (1 + (x/alpha)^beta)^2
- Add explicit _log_pdf: log of closed-form PDF
- Add explicit _cdf: (x/alpha)^beta / (1 + (x/alpha)^beta)
- Add explicit _ppf: alpha * (p/(1-p))^(1/beta)  -- analytical closed form
- Add full math documentation with LaTeX formulas in docstring
- Add dedicated test_fisk.py with mean/var/pdf/cdf/ppf/log_pdf correctness tests

<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skpro.readthedocs.io/en/latest/contribute.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new core dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core skpro package to a minimum.
-->

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
