### PR TITLE
[BUG] Fix missing raise before TypeError in Pipeline._check_steps

### DIFF
--- a/skpro/regression/compose/_pipeline.py
+++ b/skpro/regression/compose/_pipeline.py
@@ -108,7 +108,7 @@ class _Pipeline(BaseMetaEstimator, BaseProbaRegressor):
         regressor_ind = self._get_regressor_index(estimator_tuples)
 
         if not allow_postproc and regressor_ind != len(estimators) - 1:
-            TypeError(
+            raise TypeError(
                 f"in {self.name}, last estimator must be a regressor, "
                 f"but found a transformer"
             )


### PR DESCRIPTION
## Description 
---                                                                                                                                                                                                                                                                                                            I found a missing raise keyword in the pipeline validation logic that was silently allowing invalid configurations to pass through.     
                                                                                                                                                                        
In `skpro/regression/compose/_pipeline.py, line 111` was creating a TypeError but never raising it. This meant if someone built a pipeline with a transformer as the last step (when allow_postproc=False), the validation would just skip over the error instead of               failing.

## Fix
  Added raise before the TypeError on line 111. Now invalid pipelines properly raise an exception instead of silently succeeding and breaking later during fit/predict.

  It's a one-word fix that aligns with the two other validation checks in the same method which already use raise correctly. Pretty straightforward catch.      
