### PR TITLE
[DOC] Fix typo in docstrings: "logartihms" -> "logarithms"

### DIFF
--- a/skpro/distributions/base/_base.py
+++ b/skpro/distributions/base/_base.py
@@ -777,7 +777,7 @@ class BaseDistribution(BaseObject):
     def log_pdf(self, x):
         r"""Logarithmic probability density function.
 
-        Numerically more stable than calling pdf and then taking logartihms.
+        Numerically more stable than calling pdf and then taking logarithms.
 
         Let :math:`X` be a random variables with the distribution of ``self``,
         taking values in `(N, n)` ``DataFrame``-s
@@ -925,7 +925,7 @@ class BaseDistribution(BaseObject):
     def log_pmf(self, x):
         r"""Logarithmic probability mass function.
 
-        Numerically more stable than calling pmf and then taking logartihms.
+        Numerically more stable than calling pmf and then taking logarithms.
 
         Let :math:`X` be a random variables with the distribution of ``self``,
         taking values in `(N, n)` ``DataFrame``-s
@@ -1935,7 +1935,7 @@ class _BaseTFDistribution(BaseDistribution):
     def log_pdf(self, x):
         r"""Logarithmic probability density function.
 
-        Numerically more stable than calling pdf and then taking logartihms.
+        Numerically more stable than calling pdf and then taking logarithms.
 
         Let :math:`X` be a random variables with the distribution of `self`,
         taking values in `(N, n)` `DataFrame`-s


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #812

#### What does this implement/fix? Explain your changes.
Fixed a typo in the docstrings of distribution classes where "logartihms" was incorrectly spelled instead of "logarithms". This was corrected in two locations:
- Line 928: [log_pmf](cci:1://file:///c:/Users/mayan/skpro/skpro/distributions/base/_base.py:7:4-20:69) method docstring
- Line 1938: [log_pdf](cci:1://file:///c:/Users/mayan/skpro/skpro/distributions/base/_base.py:7:4-20:52) method docstring

#### Does your contribution introduce a new dependency? If yes, which one?
No, this is a documentation-only fix with no new dependencies.

#### What should a reviewer concentrate their feedback on?
* Verify that the spelling correction from "logartihms" to "logarithms" is correct
* Ensure no other similar typos exist in the same file
* Confirm the change maintains consistency with other docstrings in the codebase

#### Did you add any tests for the change?
No, this is a documentation-only typo fix that doesn't require additional tests.

#### Any other comments?
This is a minor documentation fix that improves the professionalism and quality of the codebase. The change only affects docstrings and has no impact on code functionality.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).