### PR TITLE
[BUG] fix Beta distribution missing _log_pdf implementation

### DIFF
--- a/skpro/distributions/beta.py
+++ b/skpro/distributions/beta.py
@@ -4,6 +4,7 @@
 import numpy as np
 import pandas as pd
 from scipy.integrate import quad
+from scipy.special import betaln
 from scipy.stats import beta, rv_continuous
 
 from skpro.distributions.adapters.scipy import _ScipyAdapter
@@ -72,6 +73,34 @@ class Beta(_ScipyAdapter):
         beta = self._bc_params["beta"]
 
         return [], {"a": alpha, "b": beta}
+
+    def _log_pdf(self, x):
+        r"""Logarithm of the probability density function.
+
+        For Beta(alpha, beta), the log-pdf is:
+
+        .. math::
+            \log f(x) = (\alpha-1)\log x + (\beta-1)\log(1-x)
+                        - \log B(\alpha, \beta)
+
+        for :math:`0 < x < 1`, and :math:`-\infty` otherwise.
+
+        Uses ``scipy.special.betaln`` for numerical stability, avoiding
+        ``RuntimeWarning: divide by zero`` from the base class fallback
+        ``np.log(self.pdf(x))``.
+        """
+        alpha = self._bc_params["alpha"]
+        beta_param = self._bc_params["beta"]
+
+        in_support = (x > 0) & (x < 1)
+        # Compute log-pdf only where in support; use 0.5 as safe fallback value
+        x_safe = np.where(in_support, x, 0.5)
+        log_pdf_val = (
+            (alpha - 1) * np.log(x_safe)
+            + (beta_param - 1) * np.log(1 - x_safe)
+            - betaln(alpha, beta_param)
+        )
+        return np.where(in_support, log_pdf_val, -np.inf)
 
     def _energy_self(self):
         r"""Energy of self, w.r.t. self.


### PR DESCRIPTION
## Summary

Closes #811

The Beta distribution declared "log_pdf" in capabilities:exact but had no _log_pdf method. The base class fallback computes np.log(self.pdf(x)), which emits RuntimeWarning: divide by zero encountered in log for out-of-bounds values (where pdf(x)=0).

## Fix

Added direct _log_pdf implementation using scipy.special.betaln for numerical stability:

```python
log f(x) = (alpha-1)*log(x) + (beta-1)*log(1-x) - log_B(alpha, beta)
```

Returns -np.inf for x ≤ 0 or x ≥ 1 via np.where — no log(0) ever computed.

## Verification

- No RuntimeWarning raised for x=-0.5, x=1.5 (returns -inf) ✓
- Values exactly match scipy.stats.beta.logpdf for in-support points ✓
- All 18 Beta pytest tests pass ✓

## Reproducer (before fix)

```python
import warnings
from skpro.distributions import Beta
b = Beta(alpha=2, beta=3)
x_out = pd.DataFrame([[-0.5, 1.5]])
with warnings.catch_warnings(record=True) as w:
    warnings.simplefilter("always")
    b._log_pdf(x_out)
    # Before fix: RuntimeWarning: divide by zero encountered in log
    # After fix: returns [[-inf, -inf]] with no warning
```