### PR TITLE
[BUG] add input type validation to to_percent

### DIFF
--- a/skpro/utils/utils.py
+++ b/skpro/utils/utils.py
@@ -1,0 +1,74 @@
+# LEGACY MODULE - TODO: remove or refactor
+
+
+def not_existing(f):
+    """
+    Decorates an interface method to declare it theoretically non existent
+
+    Parameters
+    ----------
+    f   Method to decorate
+
+    Returns
+    -------
+    Decorated method
+    """
+    f.not_existing = True
+
+    return f
+
+
+def ensure_existence(f):
+    """Ensures that method is not marked as non_existent
+
+    Parameters
+    ----------
+    f  Method
+
+    Raises
+    ------
+    NotImplementedError if the method is marked as non existent
+
+    Returns
+    -------
+    Method f
+    """
+    if getattr(f, "not_existing", False):
+        raise NotImplementedError(
+            "The distribution has no " + f.__name__ + " function. "
+            "You may use an adapter that supports its approximation."
+        )
+
+    return f
+
+
+def to_percent(value, return_float=True):
+    """Converts values into a percent representation
+
+    Args:
+        value: int/float
+            Number representing a percentage
+        return_float: bool
+            If true, float representing the percentage is returned
+
+    Returns: int/float
+        A percentage
+    """
+    # validate input type
+    # validate input type
+    if not isinstance(value, (int, float)):
+     raise TypeError("value must be int or float")
+    
+    def percent(p):
+        if return_float:
+            return float(p)
+        else:
+            return int(round(p * 100))
+
+    if isinstance(value, int):
+        value = float(value) / 100.0
+
+    if value <= 0:
+        return percent(0)
+    else:
+        return percent(value)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #825


#### What does this implement/fix? Explain your changes.
This PR adds input type validation to the `to_percent()` function in `skpro/utils/utils.py`.

Previously, passing a non-numeric value (for example a string or `None`) caused a Python internal error during comparison operations:
`TypeError: '<=' not supported between instances of 'str' and 'int'`.

This change adds a validation check at the beginning of the function to ensure that the input value is either an `int` or `float`. If an invalid type is provided, a clear `TypeError` is raised.


#### Does your contribution introduce a new dependency? If yes, which one?
No.


#### What should a reviewer concentrate their feedback on?
* Correctness of the input validation logic.
* Whether the validation is placed appropriately within the `to_percent()` function.


#### Did you add any tests for the change?
No.


#### Any other comments?
None.


##### For all contributions
- [X] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [X] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
