### PR TITLE
[BUG] Improve code readability in base regressor input validation

### DIFF
--- a/skpro/regression/base/_base.py
+++ b/skpro/regression/base/_base.py
@@ -683,7 +683,7 @@ class BaseProbaRegressor(BaseEstimator):
         len_y = y_metadata["n_instances"]
 
         # input check X vs y
-        if len_X != "NA" and len_y != "NA" and not len_X == len_y:
+        if len_X != "NA" and len_y != "NA" and len_X != len_y:
             raise ValueError(
                 f"X and y in fit of {self} must have same number of rows, "
                 f"but X had {len_X} rows, and y had {len_y} rows"
@@ -696,7 +696,7 @@ class BaseProbaRegressor(BaseEstimator):
         if capa_surv and C is not None:
             C_inner, C_metadata = self._check_C(C)
             len_C = C_metadata["n_instances"]
-            if len_C != "NA" and not len_C == len_y:
+            if len_C != "NA" and len_C != len_y:
                 raise ValueError(
                     f"X, y, C in fit of {self} must have same number of rows, "
                     f"but C had {len_C} rows, and y had {len_y} rows"


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #830

#### What does this implement/fix? Explain your changes.
improve code readability in base regressor input validation where `not len_X == len_y` was used instead of `len_X != len_y`. This improves code readability and follows Python best practices.

**Changes made:**
- Line 686: `not len_X == len_y` → `len_X != len_y`
- Line 699: `not len_C == len_y` → `len_C != len_y`

#### Does your contribution introduce a new dependency? If yes, which one?
No, this is a logic fix with no new dependencies.

#### What should a reviewer concentrate their feedback on?
* Verify that the logic change is correct and maintains the same validation behavior
* Ensure no other similar logic errors exist in the same file
* Test that input validation still works correctly for mismatched lengths

#### Did you add any tests for the change?
No, this is a logic fix that maintains the same functional behavior, just with cleaner syntax.

#### Any other comments?
This is a subtle but important fix that improves code readability and follows Python conventions. The functional behavior remains the same, but the code is now more idiomatic.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).