### PR TITLE
[MNT] Replace assert with ValueError in Hurdle.__init__

### DIFF
--- a/skpro/distributions/hurdle.py
+++ b/skpro/distributions/hurdle.py
@@ -69,9 +69,11 @@ class Hurdle(BaseDistribution):
         if isinstance(p, np.ndarray) and p.ndim == 1:
             raise ValueError("p must be a scalar or a 2D array.")
         elif isinstance(p, np.ndarray) and p.ndim == 2:
-            assert (
-                p.shape[0] == distribution.shape[0]
-            ), "If p is a 2D array, it must match the shape of the distribution."
+            if p.shape[0] != distribution.shape[0]:
+                raise ValueError(
+                    "If p is a 2D array, it must match the shape of the "
+                    "distribution."
+                )
 
         self.p = p
         self.distribution = distribution


### PR DESCRIPTION
Reference Issues/PRs:

Fixes #732.
 
What does this implement/fix? Explain your changes.

Replaces the `assert` statement in `Hurdle.__init__` with a proper `ValueError` raise. The `assert` was used to validate that a 2D `p` array matches the shape of the distribution, but `assert` statements are stripped when Python runs with optimizations (`-O` flag), silently disabling this validation.

 Changes

- Modified: `skpro/distributions/hurdle.py` - replaced `assert` on line 72-74 with `if/raise ValueError`

 Does your contribution introduce a new dependency? If yes, which one?

No.

 What should a reviewer concentrate their feedback on?

This is a one-line behavioral change- the error message is preserved as-is.

 Did you add any tests for the change?

The existing `test_hurdle.py` tests cover the Hurdle distribution. This change only affects the error-raising path for invalid inputs.

 PR checklist

 For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
