### PR TITLE
[ENH] Add direct _cdf and _ppf implementations to Beta distribution

### DIFF
--- a/skpro/distributions/beta.py
+++ b/skpro/distributions/beta.py
@@ -73,6 +73,55 @@ class Beta(_ScipyAdapter):
 
         return [], {"a": alpha, "b": beta}
 
+    def _cdf(self, x):
+        """Cumulative distribution function.
+
+        Parameters
+        ----------
+        x : 2D np.ndarray, same shape as ``self``
+            values to evaluate the cdf at
+
+        Returns
+        -------
+        2D np.ndarray, same shape as ``self``
+            cdf values at the given points
+        """
+        from scipy.special import betainc
+
+        alpha = self._bc_params["alpha"]
+        beta_param = self._bc_params["beta"]
+
+        # Clip x to valid range [0, 1] for Beta distribution
+        x_clipped = np.clip(x, 0, 1)
+        cdf_arr = betainc(alpha, beta_param, x_clipped)
+
+        # Handle out-of-bounds: x < 0 -> 0, x > 1 -> 1
+        cdf_arr = np.where(x < 0, 0, cdf_arr)
+        cdf_arr = np.where(x > 1, 1, cdf_arr)
+
+        return cdf_arr
+
+    def _ppf(self, p):
+        """Quantile function = percent point function = inverse cdf.
+
+        Parameters
+        ----------
+        p : 2D np.ndarray, same shape as ``self``
+            values to evaluate the ppf at
+
+        Returns
+        -------
+        2D np.ndarray, same shape as ``self``
+            ppf values at the given points
+        """
+        from scipy.special import betaincinv
+
+        alpha = self._bc_params["alpha"]
+        beta_param = self._bc_params["beta"]
+
+        ppf_arr = betaincinv(alpha, beta_param, p)
+        return ppf_arr
+
     def _energy_self(self):
         r"""Energy of self, w.r.t. self.
 


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #821 


#### What does this implement/fix? Explain your changes.

This PR adds direct implementations of `_cdf` and `_ppf` methods to the Beta distribution, replacing the scipy adapter fallback with explicit implementations.

**Changes:**
- Implements `_cdf` using `scipy.special.betainc` (regularized incomplete beta function)
- Implements `_ppf` using `scipy.special.betaincinv` (inverse of regularized incomplete beta)
- Handles boundary conditions correctly (x<0 returns 0, x>1 returns 1 for CDF)
- Improves performance by avoiding scipy adapter overhead
- Maintains consistency with other distributions (Normal, Laplace, Uniform)

**Benefits:**
- More explicit and maintainable code
- Faster execution by eliminating adapter overhead
- Aligns Beta with the pattern used by other distributions in the codebase
- All tests pass and match scipy.stats.beta accuracy

#### Does your contribution introduce a new dependency? If yes, which one?

No, this uses existing scipy dependencies (scipy.special) that are already part of skpro's core dependencies.

#### What should a reviewer concentrate their feedback on?

- Correctness of boundary condition handling in `_cdf`
- Numerical accuracy compared to scipy.stats.beta
- Code style and docstring formatting

#### Did you add any tests for the change?

All existing Beta distribution tests pass without modification. The implementation was validated against scipy.stats.beta for accuracy using comprehensive test cases including:
- In-bounds and out-of-bounds values
- Boundary conditions (x=0, x=1)
- Monotonicity of CDF
- PPF/CDF inverse relationship

#### Any other comments?

This follows the same pattern as other distributions in the codebase and fulfills the "exact" capability already declared in the Beta distribution's tags.

