### PR TITLE
[BUG]  in `ResidualDouble.predict_proba`, fix in place mutation of `distr_params`

### DIFF
--- a/skpro/regression/residual.py
+++ b/skpro/regression/residual.py
@@ -351,7 +351,7 @@ class ResidualDouble(BaseProbaRegressor):
 
         # collate all parameters for the distribution constructor
         # distribution params, if passed
-        params = distr_params
+        params = dict(distr_params)
         # row/column index
         ix = {"index": X.index, "columns": self._y_cols}
         params.update(ix)


### PR DESCRIPTION
## Fix in place mutation of distr_params in ResidualDouble._predict_proba

This fixes a bug where `distr_params` was assigned by reference and later modified using `update`.  
Because of this the original constructor parameter dictionary was mutated during `predict_proba`.

This could cause failures when calling `predict_proba` multiple times and could also break cloning or cross validation workflows.

The fix creates a shallow copy using `dict(distr_params)` so updates only affect the local parameters used to construct the distribution.