### PR TITLE
[ENH] Add numerically stable log_cdf method to BaseDistribution (#866)

### DIFF
--- a/skpro/distributions/adapters/scipy/_distribution.py
+++ b/skpro/distributions/adapters/scipy/_distribution.py
@@ -5,6 +5,7 @@ __author__ = ["malikrafsan"]
 
 from typing import Union
 
+import numpy as np
 import pandas as pd
 from scipy.stats import rv_continuous, rv_discrete
 
@@ -71,6 +72,14 @@ class _ScipyAdapter(BaseDistribution):
         obj: Union[rv_continuous, rv_discrete] = getattr(self, self._distribution_attr)
         args, kwds = self._get_scipy_param()
         return obj.cdf(x, *args, **kwds)
+
+    def _log_cdf(self, x: pd.DataFrame):
+        obj: Union[rv_continuous, rv_discrete] = getattr(self, self._distribution_attr)
+        args, kwds = self._get_scipy_param()
+        if hasattr(obj, "logcdf"):
+            return obj.logcdf(x, *args, **kwds)
+        # fallback if logcdf not available
+        return np.log(obj.cdf(x, *args, **kwds))
 
     def _ppf(self, p: pd.DataFrame):
         obj: Union[rv_continuous, rv_discrete] = getattr(self, self._distribution_attr)

--- a/skpro/distributions/base/_base.py
+++ b/skpro/distributions/base/_base.py
@@ -1023,6 +1023,49 @@ class BaseDistribution(BaseObject):
         spl = sply <= splx
         return self._sample_mean(spl)
 
+    def log_cdf(self, x):
+        r"""Logarithm of the cumulative distribution function.
+
+        Numerically more stable than calling cdf and then taking logarithms.
+
+        Let X be a random variable with the distribution of ``self``.
+        Returns log(F_X(x)), where F_X is the cumulative distribution function.
+
+        Parameters
+        ----------
+        x : pandas.DataFrame or 2D np.ndarray
+            values at which to evaluate the log-CDF
+
+        Returns
+        -------
+        pd.DataFrame with same index and columns as self
+            containing log(F_X(x))
+        """
+        return self._boilerplate("_log_cdf", x=x)
+
+    def _log_cdf(self, x):
+        """Logarithm of the cumulative distribution function.
+
+        Private method, to be implemented by subclasses.
+        """
+        self_has_cdf = self._has_implementation_of("cdf")
+        self_has_cdf = self_has_cdf or self._has_implementation_of("_cdf")
+
+        if self_has_cdf:
+            approx_method = (
+                "by taking the logarithm of the output returned by the cdf method, "
+                "this may be numerically unstable"
+            )
+            warn(self._method_error_msg("log_cdf", fill_in=approx_method))
+
+            x = self._coerce_to_self_index_df(x, flatten=False)
+            res = self.cdf(x)
+            if isinstance(res, pd.DataFrame):
+                res = res.values
+            return np.log(res)
+
+        raise NotImplementedError(self._method_error_msg("log_cdf", "error"))
+
     def surv(self, x):
         r"""Survival function.
 

--- a/skpro/distributions/tests/test_all_distrs.py
+++ b/skpro/distributions/tests/test_all_distrs.py
@@ -50,7 +50,7 @@ def _has_capability(distr, method):
 
 METHODS_SCALAR = ["mean", "var", "energy", "pdfnorm"]
 METHODS_SCALAR_POS = ["var", "energy", "pdfnorm"]  # result always non-negative?
-METHODS_X = ["energy", "pdf", "log_pdf", "pmf", "log_pmf", "cdf"]
+METHODS_X = ["energy", "pdf", "log_pdf", "pmf", "log_pmf", "cdf", "log_cdf"]
 METHODS_X_POS = ["energy", "pdf", "pmf", "cdf", "surv", "haz"]  # result non-negative?
 METHODS_P = ["ppf"]
 METHODS_ROWWISE = ["energy"]  # results in one column
@@ -259,6 +259,20 @@ class TestAllDistributions(PackageConfig, DistributionFixtureGenerator, QuickTes
         pmf = d.pmf(x)
         log_pmf = d.log_pmf(x)
         assert np.allclose(np.log(pmf), log_pmf)
+
+    def test_log_cdf_and_cdf(self, object_instance):
+        """Test that log_cdf matches log(cdf) when exact implementation exists."""
+        d = object_instance
+        capabilities_exact = d.get_tags()["capabilities:exact"]
+
+        if "log_cdf" not in capabilities_exact or "cdf" not in capabilities_exact:
+            return
+
+        x = d.sample()
+        cdf = d.cdf(x)
+        log_cdf = d.log_cdf(x)
+
+        assert np.allclose(np.log(cdf), log_cdf)
 
     def test_ppf_and_cdf(self, object_instance):
         """Test that the ppf is the inverse of the cdf."""


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skpro.readthedocs.io/en/latest/contribute.html
-->

#### Reference Issues/PRs
Fixes #866

#### What does this implement/fix? Explain your changes.

This PR adds a `log_cdf` method to the `BaseDistribution` API.

Currently, users must compute `np.log(dist.cdf(x))` manually if they require the logarithm of the cumulative distribution function. This can lead to numerical instability when the CDF value is extremely small (e.g., in tail probability computations), due to floating-point underflow.

Changes introduced in this PR:
- Added a public `log_cdf` method to `BaseDistribution`
- Added a private `_log_cdf` method that can be overridden by subclasses for numerically stable implementations
- Default implementation falls back to `np.log(self.cdf(x))`
- SciPy-backed distributions use the underlying `scipy.stats` `logcdf` implementation when available
- Updated the distribution test suite to include `log_cdf`

This improves numerical stability and makes the API more consistent with the existing `pdf` / `log_pdf` method pair.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Correctness of the `log_cdf` implementation in `BaseDistribution`
- Consistency with the current distribution API design
- Compatibility with existing distribution implementations

#### Did you add any tests for the change?

Yes. The distribution API tests were extended to include `log_cdf` to ensure the method works consistently across distributions and behaves similarly to `np.log(cdf(x))`.

#### Any other comments?

All existing tests pass locally after introducing this change.

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
