### PR TITLE
[DOC] Fix broken sktime governance link in governance.rst

### DIFF
--- a/docs/source/about/governance.rst
+++ b/docs/source/about/governance.rst
@@ -9,6 +9,6 @@ Governance
     The ``skpro`` repository and community is currently to be considered part of
     ``sktime``, and not a separate entity. It is maintained by the ``sktime`` team.
     It is THEREFORE subject to rules and provisions of ``sktime``,
-    see `sktime governance <http://www.sktime.net/en/latest/about/governance.html>`_.
+    see `sktime governance <https://www.sktime.net/en/stable/get_involved/governance.html>`_.
     The below are draft documents for a potentially later stage, copied from ``sktime``.
     In case of discrepancy, ``sktime`` documents apply.


### PR DESCRIPTION
Description
Reference Issues/PRs
Fixes #871.

What does this implement/fix? Explain your changes.
This PR fixes a 404 error on the Governance page as reported in #871. I have updated the outdated link in docs/source/about/governance.rst to point to the current stable sktime governance page: https://www.sktime.net/en/stable/get_involved/governance.html.

Does your contribution introduce a new dependency? If yes, which one?
No.

What should a reviewer concentrate their feedback on?
Verification that the new URL is the preferred stable link for the governance documentation.

Did you add any tests for the change?
N/A (Documentation-only fix). I have manually verified the link is active and correct.

Any other comments?
This is my first contribution to skpro as part of my preparation for GSoC 2026. I have cleaned the branch history to ensure only this specific file is changed.

PR checklist
For all contributions
[] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) with the doc badge.

[x] The PR title starts with [DOC].