### PR TITLE
[MNT] Replace blanket UserWarning suppression with targeted filters i…

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,9 +20,14 @@ addopts =
     --only_changed_modules True
     -n auto
 filterwarnings =
-    ignore::UserWarning
     ignore:numpy.dtype size changed
     ignore:numpy.ufunc size changed
+    ignore::DeprecationWarning:sklearn
+    ignore::DeprecationWarning:scipy
+    ignore::PendingDeprecationWarning:sklearn
+    ignore:A column-vector y was passed:sklearn.exceptions.DataConversionWarning
+    ignore:The InversePower link function:statsmodels.tools.sm_exceptions.DomainWarning
+    ignore:The total space of parameters:UserWarning:sklearn
 
 [flake8]
 # Default flake8 3.5 ignored flags


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #869

#### What does this implement/fix? Explain your changes.

`setup.cfg` had a blanket `ignore::UserWarning` filter that 
silently suppressed ALL UserWarnings during test runs — including 
legitimate warnings raised by skpro's own code. This made bugs 
harder to detect in CI.

Replaced the blanket suppression with targeted filters for known 
third-party warnings only:

- `ignore::DeprecationWarning:sklearn`
- `ignore::DeprecationWarning:scipy`
- `ignore::PendingDeprecationWarning:sklearn`
- `ignore:A column-vector y was passed:sklearn.exceptions.DataConversionWarning`
- `ignore:The InversePower link function:statsmodels.tools.sm_exceptions.DomainWarning`
- `ignore:The total space of parameters:UserWarning:sklearn`

skpro's own UserWarnings are now visible during testing.

#### Does your contribution introduce a new dependency? If yes, which one?

No new dependencies introduced.

#### What should a reviewer concentrate their feedback on?

- The updated `filterwarnings` section in `setup.cfg` (lines 22-30)
- Whether any legitimate third-party UserWarnings are missing 
  from the targeted list and need to be added

#### Did you add any tests for the change?

No new tests added — this is a CI configuration change. 
The existing test suite passing with the new filters is 
the verification.

#### Any other comments?

This makes the CI stricter and more transparent — skpro's 
own warnings will now surface during test runs rather than 
being silently swallowed.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with [MNT] — this is a maintenance/CI fix.


<img width="1815" height="418" alt="Screenshot 2026-03-11 204920" src="https://github.com/user-attachments/assets/3fd557ff-7820-4a4f-9017-6007a82e6ab7" />