### PR TITLE
Fix RuntimeWarning on out-of-bounds evaluation in QPD_S._cdf()

### DIFF
--- a/skpro/distributions/qpd.py
+++ b/skpro/distributions/qpd.py
@@ -324,9 +324,21 @@ class QPD_S(BaseDistribution):
 
         phi = self.phi
 
-        in_arcsinh = np.log((x - lower) / theta) / kappa
+        # Only compute cdf for x > lower
+        valid_mask = x > lower
+        
+        cdf_arr = np.zeros_like(x, dtype=float)
+
+        if not np.any(valid_mask):
+            return cdf_arr
+
+        x_valid = np.where(valid_mask, (x - lower) / theta, 1.0)
+        
+        in_arcsinh = np.log(x_valid) / kappa
         in_sinh = np.arcsinh(in_arcsinh) - np.arcsinh(n * c * delta)
-        cdf_arr = phi.cdf(np.sinh(in_sinh) / delta)
+        cdf_valid = phi.cdf(np.sinh(in_sinh) / delta)
+        
+        cdf_arr = np.where(valid_mask, cdf_valid, 0.0)
 
         return cdf_arr
 

--- a/skpro/distributions/tests/test_qpd.py
+++ b/skpro/distributions/tests/test_qpd.py
@@ -76,3 +76,40 @@ def test_qpd_u_simple_use():
     )
 
     qpd.mean()
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(QPD_S),
+    reason="run test only if softdeps are present and incrementally (if requested)",
+)
+def test_qpd_s_bounds():
+    """Test QPD_S behavior at or below the lower bound avoids RuntimeWarnings."""
+    import warnings
+
+    qpd = QPD_S(
+        alpha=0.2,
+        qv_low=[-0.3],
+        qv_median=[0.0],
+        qv_high=[0.3],
+        lower=-0.5,
+    )
+    
+    # Test values below or exactly at the lower bound
+    import pandas as pd
+    x = pd.DataFrame([[-1.0], [-0.5], [0.1]])
+    
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        
+        pdf_res = qpd.pdf(x)
+        cdf_res = qpd.cdf(x)
+        
+        # Verify no RuntimeWarning was raised (specifically division by zero or invalid log)
+        warning_messages = [str(warn.message) for warn in w]
+        assert len(warning_messages) == 0, f"Warnings raised: {warning_messages}"
+        
+        # Verify correct outputs for out-of-bounds values
+        assert pdf_res.iloc[0, 0] == 0.0
+        assert pdf_res.iloc[1, 0] == 0.0
+        assert cdf_res.iloc[0, 0] == 0.0
+        assert cdf_res.iloc[1, 0] == 0.0


### PR DESCRIPTION

**Description:**
This fixes a bug in the **QPD_S** (Johnson Quantile-Parameterized Distribution, semi-bounded mode) distribution where `np.log()` was being blindly called across the entire input array, even for values outside the valid support bound ($X \le \text{lower}$).

Evaluating the CDF at or below the theoretical support bound previously triggered` RuntimeWarning: invalid value encountered in log` because negative values and 0 were being passed straight into `np.log`.

The fix conditionally masks the np.log and np.arcsinh operations so they only apply to the valid support. Out-of-bounds indices now safely and immediately return 0.0 without complaining.

**Changes made:**

- Updated `QPD_S._cdf(x)` in **qpd.py** to use a valid_mask (x > lower), bypassing negative/zero calculations entirely.
- Added  `test_qpd_s_bounds()` in **test_qpd.py** to explicitly test bounds and ensure no warnings are thrown.

**Testing**
Ran the skpro/distributions test suites. test_qpd_s_bounds ensures no mathematically unstable operations are called on the boundaries.

Fixes #885 