### PR TITLE
[ENH] add log_cdf method to BaseDistribution and scipy adapter

### DIFF
--- a/skpro/distributions/adapters/scipy/_distribution.py
+++ b/skpro/distributions/adapters/scipy/_distribution.py
@@ -67,6 +67,11 @@ class _ScipyAdapter(BaseDistribution):
         args, kwds = self._get_scipy_param()
         return obj.logpdf(x, *args, **kwds)
 
+    def _log_cdf(self, x: pd.DataFrame):
+        obj: Union[rv_continuous, rv_discrete] = getattr(self, self._distribution_attr)
+        args, kwds = self._get_scipy_param()
+        return obj.logcdf(x, *args, **kwds)
+
     def _cdf(self, x: pd.DataFrame):
         obj: Union[rv_continuous, rv_discrete] = getattr(self, self._distribution_attr)
         args, kwds = self._get_scipy_param()

--- a/skpro/distributions/alpha.py
+++ b/skpro/distributions/alpha.py
@@ -50,7 +50,7 @@ class Alpha(_ScipyAdapter):
         # estimator tags
         # --------------
         "capabilities:approx": ["pdfnorm"],
-        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
+        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "log_cdf", "ppf"],
         "distr:measuretype": "continuous",
         "distr:paramtype": "parametric",
         "broadcast_init": "on",

--- a/skpro/distributions/base/_base.py
+++ b/skpro/distributions/base/_base.py
@@ -1023,6 +1023,51 @@ class BaseDistribution(BaseObject):
         spl = sply <= splx
         return self._sample_mean(spl)
 
+    def log_cdf(self, x):
+        r"""Logarithmic cumulative distribution function.
+
+        Numerically more stable than calling cdf and then taking logarithms,
+        in particular for tail probabilities close to zero.
+
+        Let :math:`X` be a random variables with the distribution of ``self``,
+        taking values in `(N, n)` ``DataFrame``-s
+        Let :math:`x\in \mathbb{R}^{N\times n}`.
+        By :math:`F_{X_{ij}}`, denote the marginal cdf of :math:`X` at the
+        :math:`(i,j)`-th entry.
+
+        The output of this method, for input ``x`` representing :math:`x`,
+        is a ``DataFrame`` with same columns and indices as ``self``,
+        and entries :math:`\log F_{X_{ij}}(x_{ij})`.
+
+        Parameters
+        ----------
+        x : ``pandas.DataFrame`` or 2D ``np.ndarray``
+            representing :math:`x`, as above
+
+        Returns
+        -------
+        ``pd.DataFrame`` with same columns and index as ``self``
+            containing :math:`\log F_{X_{ij}}(x_{ij})`, as above
+        """
+        return self._boilerplate("_log_cdf", x=x)
+
+    def _log_cdf(self, x):
+        """Logarithmic cumulative distribution function.
+
+        Private method, to be implemented by subclasses.
+        """
+        approx_method = (
+            "by taking the logarithm of the output returned by the cdf method, "
+            "this may be numerically unstable for tail probabilities close to zero"
+        )
+        warn(self._method_error_msg("log_cdf", fill_in=approx_method))
+
+        x = self._coerce_to_self_index_df(x, flatten=False)
+        res = self.cdf(x=x)
+        if isinstance(res, pd.DataFrame):
+            res = res.values
+        return np.log(res)
+
     def surv(self, x):
         r"""Survival function.
 

--- a/skpro/distributions/burr_iii.py
+++ b/skpro/distributions/burr_iii.py
@@ -27,7 +27,7 @@ class BurrIII(_ScipyAdapter):
     _tags = {
         "authors": ["arnavk23"],
         "distr:measuretype": "continuous",
-        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
+        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "log_cdf", "ppf"],
         "broadcast_init": "on",
     }
 

--- a/skpro/distributions/burr_xii.py
+++ b/skpro/distributions/burr_xii.py
@@ -29,7 +29,7 @@ class BurrXII(_ScipyAdapter):
     _tags = {
         "authors": ["arnavk23"],
         "distr:measuretype": "continuous",
-        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
+        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "log_cdf", "ppf"],
         "broadcast_init": "on",
     }
 

--- a/skpro/distributions/erlang.py
+++ b/skpro/distributions/erlang.py
@@ -42,7 +42,7 @@ class Erlang(_ScipyAdapter):
         # estimator tags
         # --------------
         "capabilities:approx": ["energy", "pdfnorm"],
-        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
+        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "log_cdf", "ppf"],
         "distr:measuretype": "continuous",
         "distr:paramtype": "parametric",
         "broadcast_init": "on",

--- a/skpro/distributions/f_dist.py
+++ b/skpro/distributions/f_dist.py
@@ -32,7 +32,7 @@ class FDist(_ScipyAdapter):
     _tags = {
         "authors": ["arnavk23"],
         "distr:measuretype": "continuous",
-        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
+        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "log_cdf", "ppf"],
         "broadcast_init": "on",
     }
 

--- a/skpro/distributions/fatigue_life.py
+++ b/skpro/distributions/fatigue_life.py
@@ -30,7 +30,7 @@ class FatigueLife(_ScipyAdapter):
     _tags = {
         "authors": ["arnavk23"],
         "distr:measuretype": "continuous",
-        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
+        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "log_cdf", "ppf"],
         "broadcast_init": "on",
     }
 

--- a/skpro/distributions/fisk.py
+++ b/skpro/distributions/fisk.py
@@ -41,7 +41,7 @@ class Fisk(_ScipyAdapter):
         # estimator tags
         # --------------
         "capabilities:approx": ["energy", "pdfnorm"],
-        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
+        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "log_cdf", "ppf"],
         "distr:measuretype": "continuous",
         "distr:paramtype": "parametric",
         "broadcast_init": "on",

--- a/skpro/distributions/gumbel_l.py
+++ b/skpro/distributions/gumbel_l.py
@@ -43,7 +43,7 @@ class GumbelL(_ScipyAdapter):
     _tags = {
         "authors": ["an1k3sh"],
         "distr:measuretype": "continuous",
-        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
+        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "log_cdf", "ppf"],
         "broadcast_init": "on",
     }
 

--- a/skpro/distributions/gumbel_r.py
+++ b/skpro/distributions/gumbel_r.py
@@ -43,7 +43,7 @@ class GumbelR(_ScipyAdapter):
     _tags = {
         "authors": ["an1k3sh"],
         "distr:measuretype": "continuous",
-        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
+        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "log_cdf", "ppf"],
         "broadcast_init": "on",
     }
 

--- a/skpro/distributions/halfcauchy.py
+++ b/skpro/distributions/halfcauchy.py
@@ -51,7 +51,7 @@ class HalfCauchy(_ScipyAdapter):
         # estimator tags
         # --------------
         "capabilities:approx": ["pdfnorm"],
-        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
+        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "log_cdf", "ppf"],
         "distr:measuretype": "continuous",
         "distr:paramtype": "parametric",
         "broadcast_init": "on",

--- a/skpro/distributions/halflogistic.py
+++ b/skpro/distributions/halflogistic.py
@@ -52,7 +52,7 @@ class HalfLogistic(_ScipyAdapter):
         # estimator tags
         # --------------
         "capabilities:approx": ["pdfnorm"],
-        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
+        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "log_cdf", "ppf"],
         "distr:measuretype": "continuous",
         "distr:paramtype": "parametric",
         "broadcast_init": "on",

--- a/skpro/distributions/halfnormal.py
+++ b/skpro/distributions/halfnormal.py
@@ -47,7 +47,7 @@ class HalfNormal(_ScipyAdapter):
         # estimator tags
         # --------------
         "capabilities:approx": ["pdfnorm"],
-        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
+        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "log_cdf", "ppf"],
         "distr:measuretype": "continuous",
         "distr:paramtype": "parametric",
         "broadcast_init": "on",

--- a/skpro/distributions/inversegamma.py
+++ b/skpro/distributions/inversegamma.py
@@ -43,7 +43,7 @@ class InverseGamma(_ScipyAdapter):
         # estimator tags
         # --------------
         "capabilities:approx": ["energy", "pdfnorm"],
-        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
+        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "log_cdf", "ppf"],
         "distr:measuretype": "continuous",
         "distr:paramtype": "parametric",
         "broadcast_init": "on",

--- a/skpro/distributions/inversegaussian.py
+++ b/skpro/distributions/inversegaussian.py
@@ -46,7 +46,7 @@ class InverseGaussian(_ScipyAdapter):
         # estimator tags
         # --------------
         "capabilities:approx": ["energy", "pdfnorm"],
-        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
+        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "log_cdf", "ppf"],
         "distr:measuretype": "continuous",
         "distr:paramtype": "parametric",
         "broadcast_init": "on",

--- a/skpro/distributions/levy.py
+++ b/skpro/distributions/levy.py
@@ -35,7 +35,7 @@ class Levy(_ScipyAdapter):
     _tags = {
         "authors": ["direkkakkar319-ops", "arnavk23", "fkiraly"],
         "distr:measuretype": "continuous",
-        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
+        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "log_cdf", "ppf"],
         "broadcast_init": "on",
     }
 

--- a/skpro/distributions/loggamma.py
+++ b/skpro/distributions/loggamma.py
@@ -46,7 +46,7 @@ class LogGamma(_ScipyAdapter):
         # estimator tags
         # --------------
         "capabilities:approx": ["energy", "pdfnorm"],
-        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
+        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "log_cdf", "ppf"],
         "distr:measuretype": "continuous",
         "distr:paramtype": "parametric",
         "broadcast_init": "on",

--- a/skpro/distributions/loglaplace.py
+++ b/skpro/distributions/loglaplace.py
@@ -51,7 +51,7 @@ class LogLaplace(_ScipyAdapter):
         # estimator tags
         # --------------
         "capabilities:approx": ["pdfnorm"],
-        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
+        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "log_cdf", "ppf"],
         "distr:measuretype": "continuous",
         "distr:paramtype": "parametric",
         "broadcast_init": "on",

--- a/skpro/distributions/normal.py
+++ b/skpro/distributions/normal.py
@@ -3,7 +3,7 @@
 
 import numpy as np
 import pandas as pd
-from scipy.special import erf, erfinv
+from scipy.special import erf, erfinv, log_ndtr
 
 from skpro.distributions.base import BaseDistribution
 
@@ -45,7 +45,7 @@ class Normal(BaseDistribution):
         # estimator tags
         # --------------
         "capabilities:approx": ["pdfnorm"],
-        "capabilities:exact": ["mean", "var", "energy", "pdf", "log_pdf", "cdf", "ppf"],
+        "capabilities:exact": ["mean", "var", "energy", "pdf", "log_pdf", "cdf", "log_cdf", "ppf"],
         "distr:measuretype": "continuous",
         "distr:paramtype": "parametric",
         "broadcast_init": "on",
@@ -181,6 +181,23 @@ class Normal(BaseDistribution):
 
         cdf_arr = 0.5 + 0.5 * erf((x - mu) / (sigma * np.sqrt(2)))
         return cdf_arr
+
+    def _log_cdf(self, x):
+        """Logarithmic cumulative distribution function.
+
+        Parameters
+        ----------
+        x : 2D np.ndarray, same shape as ``self``
+            values to evaluate the log cdf at
+
+        Returns
+        -------
+        2D np.ndarray, same shape as ``self``
+            log cdf values at the given points
+        """
+        mu = self._bc_params["mu"]
+        sigma = self._bc_params["sigma"]
+        return log_ndtr((x - mu) / sigma)
 
     def _ppf(self, p):
         """Quantile function = percent point function = inverse cdf.

--- a/skpro/distributions/skew_normal.py
+++ b/skpro/distributions/skew_normal.py
@@ -50,7 +50,7 @@ class SkewNormal(_ScipyAdapter):
         "python_dependencies": ["scipy"],
         "distr:measuretype": "continuous",
         "capabilities:approx": ["energy"],
-        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
+        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "log_cdf", "ppf"],
         "broadcast_init": "on",
     }
 

--- a/skpro/distributions/truncated_normal.py
+++ b/skpro/distributions/truncated_normal.py
@@ -50,7 +50,7 @@ class TruncatedNormal(_ScipyAdapter):
         # estimator tags
         # --------------
         "capabilities:approx": ["energy", "pdfnorm"],
-        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
+        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "log_cdf", "ppf"],
         "distr:measuretype": "continuous",
         "distr:paramtype": "parametric",
         "broadcast_init": "on",


### PR DESCRIPTION
#### Reference Issues/PRs
Closes #866.

#### What does this implement/fix? Explain your changes.

Adds `log_cdf` / `_log_cdf` to `BaseDistribution`, mirroring the
existing `log_pdf` / `_log_pdf` pair.

- `BaseDistribution.log_cdf` — public method, delegates to `_log_cdf`
  via `_boilerplate`
- `BaseDistribution._log_cdf` — default fallback, computes
  `np.log(self.cdf(x))` with a warning that it may be numerically
  unstable
- `_ScipyAdapter._log_cdf` — exact override using `scipy`'s `logcdf`,
  numerically stable for tail probabilities
- `Normal._log_cdf` — exact override using `scipy.special.log_ndtr`
- `log_cdf` added to `capabilities:exact` for all distributions that
  now have an exact implementation

#### Does your contribution introduce a new dependency? If yes, which one?

No. `scipy.special.log_ndtr` is already available via the existing
`scipy` dependency.

#### What should a reviewer concentrate their feedback on?

The `_log_cdf` fallback in `BaseDistribution` and the `_ScipyAdapter`
override.

#### Did you add any tests for the change?

The existing `TestAllDistributions` suite covers `log_cdf` via the
`capabilities:exact` tag. All 6212 tests pass.