### PR TITLE
[ENH] move testing of `mapie` based classes to own vm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ dependencies = [
 all_extras = [
     "distfit; python_version < '3.13'",
     "lifelines<0.31.0; python_version < '3.13'",
-    "mapie; python_version < '3.13'",
     "matplotlib>=3.3.2",
     "ngboost<0.6.0; python_version < '3.13'",
     "polars<1.37.0",

--- a/skpro/regression/conformal/_mapie_cqr.py
+++ b/skpro/regression/conformal/_mapie_cqr.py
@@ -49,6 +49,7 @@ class MapieConformalizedQuantileRegressor(BaseProbaRegressor):
         "maintainers": ["fkiraly", "Omswastik-11"],
         "python_dependencies": ["MAPIE>=1.0"],
         "capability:missing": True,
+        "tests:vm": True,
     }
 
     def __init__(

--- a/skpro/regression/conformal/_mapie_cross_conformal.py
+++ b/skpro/regression/conformal/_mapie_cross_conformal.py
@@ -44,6 +44,7 @@ class MapieCrossConformalRegressor(BaseProbaRegressor):
         "maintainers": ["fkiraly", "Omswastik-11"],
         "python_dependencies": ["MAPIE>=1.0"],
         "capability:missing": True,
+        "tests:vm": True,
     }
 
     def __init__(

--- a/skpro/regression/conformal/_mapie_split_conformal.py
+++ b/skpro/regression/conformal/_mapie_split_conformal.py
@@ -45,6 +45,7 @@ class MapieSplitConformalRegressor(BaseProbaRegressor):
         "maintainers": ["fkiraly", "Omswastik-11"],
         "python_dependencies": ["MAPIE>=1.0"],
         "capability:missing": True,
+        "tests:vm": True,
     }
 
     def __init__(

--- a/skpro/regression/jackknife/_mapie_jackknife.py
+++ b/skpro/regression/jackknife/_mapie_jackknife.py
@@ -47,6 +47,7 @@ class MapieJackknifeAfterBootstrapRegressor(BaseProbaRegressor):
         "maintainers": ["fkiraly", "Omswastik-11"],
         "python_dependencies": ["MAPIE>=1.0"],
         "capability:missing": True,
+        "tests:vm": True,
     }
 
     def __init__(

--- a/skpro/regression/mapie.py
+++ b/skpro/regression/mapie.py
@@ -18,7 +18,10 @@ class MapieRegressor(BaseProbaRegressor):
 
     NOTE: only for the "all-in-one" regressor present in ``mapie<1.0``. Later
     ``mapie`` versions have a more modular interface, this class is not
-    compatible with ``MAPIE>=1.0``.
+    compatible with ``MAPIE>=1.0``. For ``MAPIE>=1.0``, use the more specific conformal
+    regression classes ``MapieSplitConformalRegressor``,
+    ``MapieCrossConformalRegressor``, ``MapieConformalizedQuantileRegressor``, and
+    ``MapieJackknifeAfterBootstrapRegressor``.
 
     Uses jackknife+ to estimate prediction intervals on a per-sample basis.
 
@@ -175,6 +178,7 @@ class MapieRegressor(BaseProbaRegressor):
         # estimator tags
         # --------------
         "capability:missing": True,
+        "tests:vm": True,
     }
 
     def __init__(


### PR DESCRIPTION
This PR moves testing of `mapie` based classes to its own vm and removes `mapie` as a soft dependency in `all_extras`.