### PR TITLE
[ENH] move testing of `ngboost` based classes to own vm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ all_extras = [
     "lifelines<0.31.0; python_version < '3.13'",
     "mapie; python_version < '3.13'",
     "matplotlib>=3.3.2",
-    "ngboost<0.6.0; python_version < '3.13'",
     "polars<1.37.0",
     "pymc; python_version < '3.13'",
     "statsmodels>=0.12.1",

--- a/skpro/regression/ensemble/_ngboost.py
+++ b/skpro/regression/ensemble/_ngboost.py
@@ -92,6 +92,7 @@ class NGBoostRegressor(BaseProbaRegressor, NGBoostAdapter):
         "authors": ["ShreeshaM07"],
         "maintainers": ["ShreeshaM07"],
         "python_dependencies": "ngboost",
+        "tests:vm": True,
     }
 
     def __init__(

--- a/skpro/survival/ensemble/_ngboost_surv.py
+++ b/skpro/survival/ensemble/_ngboost_surv.py
@@ -62,6 +62,7 @@ class NGBoostSurvival(BaseSurvReg, NGBoostAdapter):
         "authors": ["ShreeshaM07"],
         "maintainers": ["ShreeshaM07"],
         "python_dependencies": "ngboost",
+        "tests:vm": True,
     }
 
     def __init__(


### PR DESCRIPTION
This PR moves testing of `ngboost` based classes to its own vm and removes `ngboost` as a soft dependency in `all_extras`.