### PR TITLE
[MNT] skip `test_discrete_pmf_plotting` until fixed

### DIFF
--- a/skpro/distributions/tests/test_proba_basic.py
+++ b/skpro/distributions/tests/test_proba_basic.py
@@ -144,6 +144,9 @@ def test_proba_plotting(fun):
     assert isinstance(ax, Axes)
 
 
+@pytest.mark.skip(
+    reason="Undiagnosed failure. Skipping until resolved. See #918."
+)
 @pytest.mark.skipif(
     not _check_soft_dependencies("matplotlib", severity="none"),
     reason="skip if matplotlib is not available",


### PR DESCRIPTION
skips `test_discrete_pmf_plotting` until it is fixed.
See https://github.com/sktime/skpro/issues/918