### PR TITLE
[MNT] in release workflow, require `check_tag` before releasing

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -32,6 +32,7 @@ jobs:
           fi
 
   build_wheels:
+    needs: check_tag
     name: Build wheels
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
in the release workflow, changes conditions to require `check_tag` before releasing, i.e., running any other steps. Currently, the step runs but does not stops a release under an incorrect tag when it fails.