### PR TITLE
[ENH] add `test_non_state_changing_method_contract` for `predict` methods being non-mutating, to `TestAllRegressors`

### DIFF
--- a/skpro/model_selection/_tuning.py
+++ b/skpro/model_selection/_tuning.py
@@ -191,9 +191,11 @@ class BaseGridSearch(_DelegatedProbaRegressor):
         self.best_index_ = results.loc[:, f"rank_{scoring_name}"].argmin()
         # Raise error if all fits in evaluate failed because all score values are NaN.
         if self.best_index_ == -1:
-            raise RuntimeError(f"""All fits of estimator failed,
+            raise RuntimeError(
+                f"""All fits of estimator failed,
                 set error_score='raise' to see the exceptions.
-                Failed estimator: {self.estimator}""")
+                Failed estimator: {self.estimator}"""
+            )
         self.best_score_ = results.loc[self.best_index_, f"mean_{scoring_name}"]
         self.best_params_ = results.loc[self.best_index_, "params"]
         self.best_estimator_ = self.estimator.clone().set_params(**self.best_params_)

--- a/skpro/model_selection/_tuning.py
+++ b/skpro/model_selection/_tuning.py
@@ -18,6 +18,9 @@ class BaseGridSearch(_DelegatedProbaRegressor):
         "estimator_type": "regressor",
         "capability:multioutput": True,
         "capability:missing": True,
+        "tests:skip_by_name": [
+            "test_non_state_changing_method_contract"
+        ],  # TODO: fix in #922
     }
 
     def __init__(
@@ -188,11 +191,9 @@ class BaseGridSearch(_DelegatedProbaRegressor):
         self.best_index_ = results.loc[:, f"rank_{scoring_name}"].argmin()
         # Raise error if all fits in evaluate failed because all score values are NaN.
         if self.best_index_ == -1:
-            raise RuntimeError(
-                f"""All fits of estimator failed,
+            raise RuntimeError(f"""All fits of estimator failed,
                 set error_score='raise' to see the exceptions.
-                Failed estimator: {self.estimator}"""
-            )
+                Failed estimator: {self.estimator}""")
         self.best_score_ = results.loc[self.best_index_, f"mean_{scoring_name}"]
         self.best_params_ = results.loc[self.best_index_, "params"]
         self.best_estimator_ = self.estimator.clone().set_params(**self.best_params_)

--- a/skpro/regression/adapters/sklearn/_sklearn_proba.py
+++ b/skpro/regression/adapters/sklearn/_sklearn_proba.py
@@ -31,6 +31,9 @@ class SklearnProbaReg(BaseProbaRegressor):
     _tags = {
         "capability:multioutput": False,
         "capability:missing": True,
+        "tests:skip_by_name": [
+            "test_non_state_changing_method_contract"
+        ],  # TODO: fix in #922
     }
 
     def __init__(self, estimator, inner_type="pd.DataFrame"):

--- a/skpro/regression/binned/_sklearn_bin_regressor.py
+++ b/skpro/regression/binned/_sklearn_bin_regressor.py
@@ -73,6 +73,9 @@ class HistBinnedProbaRegressor(BaseProbaRegressor):
         "maintainers": ["ShreeshaM07"],
         "capability:multioutput": False,
         "capability:missing": True,
+        "tests:skip_by_name": [
+            "test_non_state_changing_method_contract"
+        ],  # TODO: fix in #922
     }
 
     def __init__(self, clf, bins=10):

--- a/skpro/regression/bootstrap.py
+++ b/skpro/regression/bootstrap.py
@@ -71,7 +71,13 @@ class BootstrapRegressor(BaseProbaRegressor):
     >>> y_pred = reg_proba.predict_proba(X_test)
     """
 
-    _tags = {"authors": "fkiraly", "capability:missing": True}
+    _tags = {
+        "authors": "fkiraly",
+        "capability:missing": True,
+        "tests:skip_by_name": [
+            "test_non_state_changing_method_contract"
+        ],  # TODO: fix in #922
+    }
 
     def __init__(
         self,

--- a/skpro/regression/compose/_pipeline.py
+++ b/skpro/regression/compose/_pipeline.py
@@ -1,4 +1,5 @@
 """Implements pipelines for probabilistic supervised regression."""
+
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 # based on sktime pipelines
 
@@ -328,6 +329,9 @@ class Pipeline(_Pipeline):
     _tags = {
         "capability:multioutput": True,
         "capability:missing": True,
+        "tests:skip_by_name": [
+            "test_non_state_changing_method_contract"
+        ],  # TODO: fix in #922
     }
 
     def __init__(self, steps):

--- a/skpro/regression/compose/_ttr.py
+++ b/skpro/regression/compose/_ttr.py
@@ -1,4 +1,5 @@
 """Implements transformed target regressor for probabilistic supervised regression."""
+
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 
 __author__ = ["fkiraly"]
@@ -75,6 +76,9 @@ class TransformedTargetRegressor(BaseProbaRegressor):
     _tags = {
         "capability:multioutput": True,
         "capability:missing": True,
+        "tests:skip_by_name": [
+            "test_non_state_changing_method_contract"
+        ],  # TODO: fix in #922
     }
 
     def __init__(self, regressor, transformer=None):

--- a/skpro/regression/delta.py
+++ b/skpro/regression/delta.py
@@ -48,7 +48,13 @@ class DeltaPointRegressor(BaseProbaRegressor):
     >>> y_pred = reg_proba.predict_proba(X_test)
     """
 
-    _tags = {"authors": "fkiraly", "capability:missing": True}
+    _tags = {
+        "authors": "fkiraly",
+        "capability:missing": True,
+        "tests:skip_by_name": [
+            "test_non_state_changing_method_contract"
+        ],  # TODO: fix in #922
+    }
 
     def __init__(self, estimator):
         self.estimator = estimator

--- a/skpro/regression/enbpi.py
+++ b/skpro/regression/enbpi.py
@@ -104,6 +104,9 @@ class EnbpiRegressor(BaseProbaRegressor):
     _tags = {
         "authors": ["fkiraly", "hamrel-cxu"],
         "capability:missing": True,
+        "tests:skip_by_name": [
+            "test_non_state_changing_method_contract"
+        ],  # TODO: fix in #922
     }
 
     def __init__(

--- a/skpro/regression/ensemble/_bagging.py
+++ b/skpro/regression/ensemble/_bagging.py
@@ -78,6 +78,9 @@ class BaggingRegressor(BaseProbaRegressor):
     _tags = {
         "capability:missing": True,
         "capability:survival": True,
+        "tests:skip_by_name": [
+            "test_non_state_changing_method_contract"
+        ],  # TODO: fix in #922
     }
 
     def __init__(

--- a/skpro/regression/multiquantile.py
+++ b/skpro/regression/multiquantile.py
@@ -103,6 +103,9 @@ class MultipleQuantileRegressor(BaseProbaRegressor):
         # --------------
         "capability:missing": False,
         "capability:multioutput": False,
+        "tests:skip_by_name": [
+            "test_non_state_changing_method_contract"
+        ],  # TODO: fix in #922
     }
 
     def __init__(

--- a/skpro/regression/online/_dont_refit.py
+++ b/skpro/regression/online/_dont_refit.py
@@ -26,7 +26,12 @@ class OnlineDontRefit(_DelegatedProbaRegressor):
         clone of the regressor passed in the constructor, fitted on all data
     """
 
-    _tags = {"capability:update": False}
+    _tags = {
+        "capability:update": False,
+        "tests:skip_by_name": [
+            "test_non_state_changing_method_contract"
+        ],  # TODO: fix in #922
+    }
 
     def __init__(self, estimator):
         self.estimator = estimator

--- a/skpro/regression/online/_refit.py
+++ b/skpro/regression/online/_refit.py
@@ -28,7 +28,12 @@ class OnlineRefit(_DelegatedProbaRegressor):
         clone of the regressor passed in the constructor, fitted on all data
     """
 
-    _tags = {"capability:update": True}
+    _tags = {
+        "capability:update": True,
+        "tests:skip_by_name": [
+            "test_non_state_changing_method_contract"
+        ],  # TODO: fix in #922
+    }
 
     def __init__(self, estimator):
         self.estimator = estimator

--- a/skpro/regression/online/_refit_every.py
+++ b/skpro/regression/online/_refit_every.py
@@ -33,7 +33,12 @@ class OnlineRefitEveryN(_DelegatedProbaRegressor):
         clone of the regressor passed in the constructor, fitted on all data
     """
 
-    _tags = {"capability:update": True}
+    _tags = {
+        "capability:update": True,
+        "tests:skip_by_name": [
+            "test_non_state_changing_method_contract"
+        ],  # TODO: fix in #922
+    }
 
     def __init__(self, estimator, N=1):
         self.estimator = estimator

--- a/skpro/regression/residual.py
+++ b/skpro/regression/residual.py
@@ -1,4 +1,5 @@
 """Residual regression - one regressor for mean, one for scale."""
+
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 
 __author__ = ["fkiraly"]
@@ -123,7 +124,12 @@ class ResidualDouble(BaseProbaRegressor):
     >>> y_pred_proba = reg_proba.predict_proba(X)
     """
 
-    _tags = {"capability:missing": True}
+    _tags = {
+        "capability:missing": True,
+        "tests:skip_by_name": [
+            "test_non_state_changing_method_contract"
+        ],  # TODO: fix in #922
+    }
 
     def __init__(
         self,

--- a/skpro/regression/tests/test_all_regressors.py
+++ b/skpro/regression/tests/test_all_regressors.py
@@ -210,50 +210,6 @@ class TestAllRegressors(PackageConfig, BaseFixtureGenerator, QuickTester):
         assert (y_pred_test.index == X_test.index).all()
         assert (y_pred_test.columns == y_fit.columns).all()
 
-    def test_predict_proba_no_param_mutation(self, object_instance):
-        """Test that predict_proba does not mutate constructor parameters."""
-        import pandas as pd
-        from sklearn.datasets import load_diabetes
-        from sklearn.model_selection import train_test_split
-
-        X, y = load_diabetes(return_X_y=True, as_frame=True)
-        X = X.iloc[:50]
-        y = y.iloc[:50]
-        y = pd.DataFrame(y)
-
-        X_train, X_test, y_train, _ = train_test_split(X, y, random_state=42)
-
-        regressor = object_instance
-        regressor.fit(X_train, y_train)
-
-        params_before = copy.deepcopy(regressor.get_params())
-
-        regressor.predict_proba(X_test)
-        regressor.predict_proba(X_test[:5])
-
-        # constructor params must be unchanged after predict_proba calls
-        params_after = regressor.get_params()
-
-        for key in params_before:
-            before_val = params_before[key]
-            after_val = params_after[key]
-
-            # skip estimator objects - they have fitted state attrs
-            if hasattr(before_val, "fit"):
-                continue
-
-            assert type(before_val) == type(after_val), (  # noqa: E721
-                f"Parameter '{key}' type changed after predict_proba: "
-                f"before={type(before_val)}, after={type(after_val)}"
-            )
-            # We use repr() to compare values because they might contain estimators
-            #  which fail `==` checks after being deepcopied.
-
-            assert repr(before_val) == repr(after_val), (
-                f"Parameter '{key}' was mutated by predict_proba: "
-                f"before={before_val}, after={after_val}"
-            )
-
     @pytest.mark.parametrize(
         "method",
         [

--- a/skpro/regression/tests/test_all_regressors.py
+++ b/skpro/regression/tests/test_all_regressors.py
@@ -253,3 +253,41 @@ class TestAllRegressors(PackageConfig, BaseFixtureGenerator, QuickTester):
                 f"Parameter '{key}' was mutated by predict_proba: "
                 f"before={before_val}, after={after_val}"
             )
+
+    @pytest.mark.parametrize(
+        "method",
+        ["predict", "predict_proba", "predict_interval", "predict_quantiles", "predict_var"],
+    )
+    def test_non_state_changing_method_contract(self, object_instance, method):
+        """Test that predict methods do not mutate constructor parameters.
+
+        Checks this for all predict methods, and for parameters that are
+        component estimators, i.e., parameters inside parameters that are estimators.
+        """
+        from sklearn.datasets import load_diabetes
+        from sklearn.model_selection import train_test_split
+
+        from skpro.utils.deep_equals import deep_equals
+
+        X, y = load_diabetes(return_X_y=True, as_frame=True)
+        X = X.iloc[:50]
+        y = y.iloc[:50]
+        y = pd.DataFrame(y)
+
+        X_train, X_test, y_train, _ = train_test_split(X, y, random_state=42)
+
+        regressor = object_instance
+        regressor.fit(X_train, y_train)
+
+        params_before = copy.deepcopy(regressor.get_params(deep=True))
+
+        getattr(regressor, method)(X_test)
+        getattr(regressor, method)(X_test[:5])
+
+        params_after = regressor.get_params(deep=True)
+
+        is_equal, msg = deep_equals(params_before, params_after, return_msg=True)
+        assert is_equal, (
+            f"Parameter mutation detected after calling {method}. "
+            f"Reason: {msg}"
+        )

--- a/skpro/regression/tests/test_all_regressors.py
+++ b/skpro/regression/tests/test_all_regressors.py
@@ -256,7 +256,13 @@ class TestAllRegressors(PackageConfig, BaseFixtureGenerator, QuickTester):
 
     @pytest.mark.parametrize(
         "method",
-        ["predict", "predict_proba", "predict_interval", "predict_quantiles", "predict_var"],
+        [
+            "predict",
+            "predict_proba",
+            "predict_interval",
+            "predict_quantiles",
+            "predict_var",
+        ],
     )
     def test_non_state_changing_method_contract(self, object_instance, method):
         """Test that predict methods do not mutate constructor parameters.
@@ -288,6 +294,5 @@ class TestAllRegressors(PackageConfig, BaseFixtureGenerator, QuickTester):
 
         is_equal, msg = deep_equals(params_before, params_after, return_msg=True)
         assert is_equal, (
-            f"Parameter mutation detected after calling {method}. "
-            f"Reason: {msg}"
+            f"Parameter mutation detected after calling {method}. " f"Reason: {msg}"
         )

--- a/skpro/survival/compose/_reduce_cond_unc.py
+++ b/skpro/survival/compose/_reduce_cond_unc.py
@@ -32,7 +32,12 @@ class ConditionUncensored(BaseProbaRegressor):
         fitted probabilistic regressor, clone of ``regressor``
     """
 
-    _tags = {"capability:survival": True}
+    _tags = {
+        "capability:survival": True,
+        "tests:skip_by_name": [
+            "test_non_state_changing_method_contract"
+        ],  # TODO: fix in #922
+    }
 
     def __init__(self, estimator):
         self.estimator = estimator

--- a/skpro/survival/compose/_reduce_uncensored.py
+++ b/skpro/survival/compose/_reduce_uncensored.py
@@ -28,7 +28,12 @@ class FitUncensored(_DelegatedProbaRegressor):
         clone of estimator
     """
 
-    _tags = {"capability:survival": True}
+    _tags = {
+        "capability:survival": True,
+        "tests:skip_by_name": [
+            "test_non_state_changing_method_contract"
+        ],  # TODO: fix in #922
+    }
 
     _delegate_name = "estimator_"
 

--- a/skpro/tests/_config.py
+++ b/skpro/tests/_config.py
@@ -16,25 +16,6 @@ EXCLUDE_ESTIMATORS = [
     "ClassName",  # exclude classes from extension templates
 ]
 
-
-EXCLUDED_TESTS = {
-    # BUG: component estimator fitted state mutates constructor params
-    # see issue #922
-    "BaggingRegressor": ["test_non_state_changing_method_contract"],
-    "BootstrapRegressor": ["test_non_state_changing_method_contract"],
-    "ConditionUncensored": ["test_non_state_changing_method_contract"],
-    "DeltaPointRegressor": ["test_non_state_changing_method_contract"],
-    "EnbpiRegressor": ["test_non_state_changing_method_contract"],
-    "FitUncensored": ["test_non_state_changing_method_contract"],
-    "GridSearchCV": ["test_non_state_changing_method_contract"],
-    "HistBinnedProbaRegressor": ["test_non_state_changing_method_contract"],
-    "MultipleQuantileRegressor": ["test_non_state_changing_method_contract"],
-    "OnlineDontRefit": ["test_non_state_changing_method_contract"],
-    "OnlineRefit": ["test_non_state_changing_method_contract"],
-    "OnlineRefitEveryN": ["test_non_state_changing_method_contract"],
-    "Pipeline": ["test_non_state_changing_method_contract"],
-    "RandomizedSearchCV": ["test_non_state_changing_method_contract"],
-    "ResidualDouble": ["test_non_state_changing_method_contract"],
-    "SklearnProbaReg": ["test_non_state_changing_method_contract"],
-    "TransformedTargetRegressor": ["test_non_state_changing_method_contract"],
-}
+# do not add skips here, instead use the "tests:skip_by_name" tag on the estimator class
+# see skpro/registry/_tags.py for tag reference
+EXCLUDED_TESTS = {}

--- a/skpro/tests/_config.py
+++ b/skpro/tests/_config.py
@@ -17,4 +17,24 @@ EXCLUDE_ESTIMATORS = [
 ]
 
 
-EXCLUDED_TESTS = {}
+EXCLUDED_TESTS = {
+    # BUG: component estimator fitted state mutates constructor params
+    # see issue #922
+    "BaggingRegressor": ["test_non_state_changing_method_contract"],
+    "BootstrapRegressor": ["test_non_state_changing_method_contract"],
+    "ConditionUncensored": ["test_non_state_changing_method_contract"],
+    "DeltaPointRegressor": ["test_non_state_changing_method_contract"],
+    "EnbpiRegressor": ["test_non_state_changing_method_contract"],
+    "FitUncensored": ["test_non_state_changing_method_contract"],
+    "GridSearchCV": ["test_non_state_changing_method_contract"],
+    "HistBinnedProbaRegressor": ["test_non_state_changing_method_contract"],
+    "MultipleQuantileRegressor": ["test_non_state_changing_method_contract"],
+    "OnlineDontRefit": ["test_non_state_changing_method_contract"],
+    "OnlineRefit": ["test_non_state_changing_method_contract"],
+    "OnlineRefitEveryN": ["test_non_state_changing_method_contract"],
+    "Pipeline": ["test_non_state_changing_method_contract"],
+    "RandomizedSearchCV": ["test_non_state_changing_method_contract"],
+    "ResidualDouble": ["test_non_state_changing_method_contract"],
+    "SklearnProbaReg": ["test_non_state_changing_method_contract"],
+    "TransformedTargetRegressor": ["test_non_state_changing_method_contract"],
+}

--- a/skpro/tests/test_all_estimators.py
+++ b/skpro/tests/test_all_estimators.py
@@ -1,4 +1,5 @@
 """Automated tests based on the skbase test suite template."""
+
 import numbers
 import types
 from copy import deepcopy
@@ -162,6 +163,23 @@ class BaseFixtureGenerator(_BaseFixtureGenerator):
         # comment out to run the full test suite with new scenarios
         if not scenario.get_tag("is_enabled", False, raise_error=False):
             return True
+
+        return False
+
+    def is_excluded(self, test_name, est):
+        """Shorthand to check whether test_name is excluded for estimator est.
+
+        Extends the base class check to also consider the ``tests:skip_by_name``
+        tag on the estimator class.
+        """
+        # check excluded_tests dict via super (skbase base class behaviour)
+        if super().is_excluded(test_name, est):
+            return True
+
+        # additionally check tests:skip_by_name tag on the estimator class
+        skip_by_name = est.get_class_tag("tests:skip_by_name", None)
+        if skip_by_name is not None:
+            return test_name in skip_by_name
 
         return False
 


### PR DESCRIPTION


#### Reference Issues/PRs

Fixes #896. See also #872.

#### What does this implement/fix? Explain your changes.

Adds `test_non_state_changing_method_contract` to `TestAllRegressors`, parametrized over all five predict methods: `predict`, `predict_proba`, `predict_interval`, `predict_quantiles`, and `predict_var`.

The existing `test_predict_proba_no_param_mutation` (from #872) only checked `predict_proba`, skipped component estimators entirely via `hasattr(before_val, "fit")`, and used `repr()` for comparison. The new test uses `get_params(deep=True)` and `deep_equals` to also catch parameter mutations in nested component estimators across all predict methods.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- The use of `get_params(deep=True)` + `deep_equals` vs the existing `repr()` approach
- The new test reveals pre-existing mutations in wrapper/compositor estimators where sklearn sub-estimators are fitted in-place. These will be skipped via `tests:skip_by_name` with a linked issue in a follow-up commit.

#### Did you add any tests for the change?

Yes, added `test_non_state_changing_method_contract` in `skpro/regression/tests/test_all_regressors.py`.

#### Any other comments?

The new test exposes a pre-existing bug in wrapper/compositor estimators, tracked in a separate issue to be opened and linked here. Failing estimators will be added to `tests:skip_by_name` before this PR is marked ready.

#### PR checklist

##### For all contributions

- [ ] I've added myself to the [[list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md)](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].