### PR TITLE
[BUG] Fix incorrect handling of negative n in BaseDistribution.head()

### DIFF
--- a/skpro/distributions/base/_base.py
+++ b/skpro/distributions/base/_base.py
@@ -196,7 +196,7 @@ class BaseDistribution(BaseObject):
         assert isinstance(n, int)
         N = len(self)
         if n < 0:
-            n = N - n
+            n = N + n
         n = min(n, N)
         return self.iloc[range(n)]
 

--- a/skpro/distributions/tests/test_base_default_methods.py
+++ b/skpro/distributions/tests/test_base_default_methods.py
@@ -189,6 +189,7 @@ def test_base_default_minimal_cdf():
     minimal_n = _DistrDefaultMethodTesterOnlySample(mu=0, sigma=1)
     assert minimal_n.cdf(0) < minimal_n.cdf(100)
 
+
 @pytest.mark.skipif(
     not run_test_module_changed("skpro.distributions"),
     reason="run only if skpro.distributions has been changed",

--- a/skpro/distributions/tests/test_base_default_methods.py
+++ b/skpro/distributions/tests/test_base_default_methods.py
@@ -188,3 +188,25 @@ def test_base_default_minimal_cdf():
     """Test default cdf method."""
     minimal_n = _DistrDefaultMethodTesterOnlySample(mu=0, sigma=1)
     assert minimal_n.cdf(0) < minimal_n.cdf(100)
+
+@pytest.mark.skipif(
+    not_run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
+def test_head_negative_n():
+    """Test that head(-k) returns all rows except last k."""
+    import pandas as pd
+
+    from skpro.distributions.normal import Normal
+
+    idx = pd.RangeIndex(10)
+
+    mu = pd.Series(range(10), index=idx)
+    sigma = pd.Series([1] * 10, index=idx)
+
+    d = Normal(mu=mu, sigma=sigma)
+
+    result = d.head(-2)
+
+    assert len(result) == max(len(d) - 2, 0)
+    

--- a/skpro/distributions/tests/test_base_default_methods.py
+++ b/skpro/distributions/tests/test_base_default_methods.py
@@ -190,7 +190,7 @@ def test_base_default_minimal_cdf():
     assert minimal_n.cdf(0) < minimal_n.cdf(100)
 
 @pytest.mark.skipif(
-    not_run_test_module_changed("skpro.distributions"),
+    not run_test_module_changed("skpro.distributions"),
     reason="run only if skpro.distributions has been changed",
 )
 def test_head_negative_n():
@@ -209,4 +209,3 @@ def test_head_negative_n():
     result = d.head(-2)
 
     assert len(result) == max(len(d) - 2, 0)
-    


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #894

#### What does this implement/fix? Explain your changes.
This PR fixes incorrect handling of negative values of `n` in `BaseDistribution.head()`.

The current implementation uses:

    n = N - n

When `n` is negative, this produces incorrect results.

Example:
If N = 10 and n = -2, the current logic computes:

    n = 10 - (-2) = 12

This value is then clipped to 10 and returns all rows instead of returning
all rows except the last two.

The documented behavior states:
"For negative n, returns all rows except the last n."

This PR updates the logic to:

    n = N + n

which correctly computes the intended number of rows.

#### Does your contribution introduce a new dependency? If yes, which one?
No new dependencies were introduced.

#### What should a reviewer concentrate their feedback on?
- Correctness of the updated logic in `BaseDistribution.head()`
- Whether the behavior matches the documented behavior for negative `n`

#### Did you add any tests for the change?
No new tests were added. Existing tests pass successfully.

#### Any other comments?
All existing tests pass locally after this change.

#### PR checklist
- [x] Code builds successfully
- [x] Tests pass locally
- [x] No new dependencies added

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
