### PR TITLE
[ENH] distribution fitters - framework and first examples

### DIFF
--- a/extension_templates/distfitter.py
+++ b/extension_templates/distfitter.py
@@ -1,0 +1,191 @@
+"""Extension template for distribution fitters.
+
+Purpose of this implementation template:
+    quick implementation of new estimators following the template
+    NOT a concrete class to import! This is NOT a base class or concrete class!
+    This is to be used as a "fill-in" coding template.
+
+How to use this implementation template to implement a new distribution fitter:
+- make a copy of the template in a suitable location, give it a descriptive name.
+- work through all the "todo" comments below
+- fill in code for mandatory methods, and optionally for optional methods
+- do not write to reserved attributes: is_fitted, _is_fitted, _X_metadata,
+  _tags, _tags_dynamic, _config, _config_dynamic
+- you can add more private methods, but do not override BaseEstimator's private methods
+    an easy way to be safe is to prefix your methods with "_custom"
+- change docstrings for functions and the file
+- ensure interface compatibility by skpro.utils.estimator_checks.check_estimator
+- once complete: use as a local library, or contribute to skpro via PR
+- more details:
+  https://www.sktime.net/en/stable/developer_guide/add_estimators.html
+
+Mandatory methods to implement:
+    fitting              - _fit(self, X, C=None)
+    returning the dist   - _proba(self)
+
+Testing - required for test framework and check_estimator usage:
+    get default parameters for test instance(s) - get_test_params()
+"""
+# todo: write an informative docstring for the file or module, remove the above
+# todo: add an appropriate copyright notice for your estimator
+#       estimators contributed to skpro should have the copyright notice at the top
+#       estimators of your own do not need to have permissive or BSD-3 copyright
+
+from skpro.distfitter.base import BaseDistFitter
+
+# todo: add any necessary imports here
+
+# todo: for imports of skpro soft dependencies:
+# make sure to fill in the "python_dependencies" tag with the package import name
+# import soft dependencies only inside methods of the class, not at the top of the file
+
+
+# todo: change class name and write docstring
+class ClassName(BaseDistFitter):
+    """Custom distribution fitter. todo: write docstring.
+
+    todo: describe your custom distribution fitter here
+
+    Parameters
+    ----------
+    parama : int
+        descriptive explanation of parama
+    paramb : string, optional (default='default')
+        descriptive explanation of paramb
+    and so on
+    """
+
+    # todo: fill out estimator tags here
+    #  tags are inherited from parent class if they are not set
+    # tags inherited from base are "safe defaults" which can usually be left as-is
+    _tags = {
+        # packaging info
+        # --------------
+        "authors": ["author1", "author2"],  # authors, GitHub handles
+        "maintainers": ["maintainer1", "maintainer2"],  # maintainers, GitHub handles
+        # author = significant contribution to code at some point
+        # maintainer = algorithm maintainer role, "owner"
+        # specify one or multiple authors and maintainers, only for skpro contribution
+        # remove maintainer tag if maintained by skpro/sktime core team
+        #
+        "python_version": None,  # PEP 440 python version specifier to limit versions
+        "python_dependencies": None,  # PEP 440 python dependencies specifier,
+        # e.g., "numba>0.53", or a list, e.g., ["numba>0.53", "numpy>=1.19.0"]
+        # delete if no python dependencies or version limitations
+        #
+        # estimator tags
+        # --------------
+        "capability:survival": False,  # can the fitter use censoring information?
+        "X_inner_mtype": "pd_DataFrame_Table",  # type seen in internal _fit
+    }
+
+    # todo: fill init
+    # params should be written to self and never changed
+    # super call must not be removed, change class name
+    # parameter checks can go after super call
+    def __init__(self, paramname, paramname2="paramname2default"):
+        # todo: write any hyper-parameters and components to self
+        self.paramname = paramname
+        self.paramname2 = paramname2
+
+        # leave this as is
+        super().__init__()
+
+        # todo: optional, parameter checking logic (if applicable) should happen here
+        # if writes derived values to self, should *not* overwrite self.parama etc
+        # instead, write to self._parama, self._newparam (starting with _)
+
+    # todo: implement this, mandatory
+    def _fit(self, X, C=None):
+        """Fit distribution to data.
+
+        Writes to self:
+            Sets fitted model attributes ending in "_".
+
+        Parameters
+        ----------
+        X : pandas DataFrame
+            Data to fit the distribution to.
+        C : pandas DataFrame, optional (default=None)
+            Censoring indicator for survival analysis.
+            Only passed if ``capability:survival`` tag is True.
+
+        Returns
+        -------
+        self : reference to self
+        """
+        # insert logic for fitting distribution parameters here
+        # fitted parameters should be written to attributes ending in underscore
+        # e.g., self.mu_ = X.values.mean()
+
+        # self must be returned at the end
+        return self
+
+    # todo: implement this, mandatory
+    def _proba(self):
+        """Return fitted scalar distribution.
+
+        State required:
+            Requires state to be "fitted" = self.is_fitted=True
+
+        Accesses in self:
+            Fitted model attributes ending in "_"
+
+        Returns
+        -------
+        dist : skpro BaseDistribution (scalar)
+            Distribution fitted to data passed in ``fit``.
+        """
+        # construct and return a scalar distribution from fitted parameters
+        # example:
+        #
+        # from skpro.distributions.normal import Normal
+        # return Normal(mu=self.mu_, sigma=self.sigma_)
+
+        raise NotImplementedError("todo: implement _proba")
+
+    # todo: return default parameters, so that a test instance can be created
+    #   required for automated unit and integration testing of estimator
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            ``MyClass(**params)`` or ``MyClass(**params[i])`` creates a valid test
+            instance.
+            ``create_test_instance`` uses the first (or only) dictionary in ``params``.
+        """
+        # todo: set the testing parameters for the estimator
+        # Testing parameters can be dictionary or list of dictionaries
+        #
+        # this can, if required, use:
+        #   class properties (e.g., inherited); parent class test case
+        #   imported objects such as distributions from skpro
+        # important: all such imports should be *inside get_test_params*, not at the top
+        #            since imports are used only at testing time
+        #
+        # A good parameter set should primarily satisfy two criteria,
+        #   1. Chosen set of parameters should have a low testing time,
+        #      ideally in the magnitude of few seconds for the entire test suite.
+        #   2. There should be a minimum two such parameter sets with different
+        #      sets of values to ensure a wide range of code coverage is provided.
+        #
+        # example 1: specify params as dictionary
+        # params = {"parama": value1, "paramb": value2}
+        #
+        # example 2: specify params as list of dictionary
+        # params = [{"parama": value1, "paramb": value2},
+        #           {"parama": value3, "paramb": value4}]
+        #
+        # return params
+        pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "numpy>=1.21.0,<2.5",
     "pandas>=1.1.0,<3.1.0",
     "packaging",
-    "scikit-base>=0.6.1,<1.1.0",
+    "scikit-base>=1.0.1,<1.1.0",
     "scikit-learn>=0.24.0,<1.8.0",
     "scipy<2.0.0,>=1.2.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "numpy>=1.21.0,<2.5",
     "pandas>=1.1.0,<3.1.0",
     "packaging",
-    "scikit-base>=1.0.1,<1.1.0",
+    "scikit-base>=0.6.1,<1.1.0",
     "scikit-learn>=0.24.0,<1.8.0",
     "scipy<2.0.0,>=1.2.0",
 ]

--- a/skpro/distfitter/__init__.py
+++ b/skpro/distfitter/__init__.py
@@ -1,0 +1,10 @@
+"""Distribution fitter estimators."""
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+
+from skpro.distfitter._momfitter import MOMFitter
+from skpro.distfitter._normalfitter import NormalFitter
+
+__all__ = [
+    "NormalFitter",
+    "MOMFitter",
+]

--- a/skpro/distfitter/_momfitter.py
+++ b/skpro/distfitter/_momfitter.py
@@ -183,6 +183,10 @@ class MOMFitter(BaseDistFitter):
             "std_name": "sigma",
             "dist_params": {"df": 5},
         }
-        params5 = {"dist": Laplace(mu=0.0, scale=1.0)}
-        params6 = {"dist": TDistribution(df=5), "mean_name": "mu", "std_name": "sigma"}
+        params5 = {"dist": Laplace(mu=0.0, scale=1.0), "mean_name": "mu"}
+        params6 = {
+            "dist": TDistribution(df=5, mu=0.0, sigma=1.0),
+            "mean_name": "mu",
+            "std_name": "sigma",
+        }
         return [params1, params2, params3, params4, params5, params6]

--- a/skpro/distfitter/_momfitter.py
+++ b/skpro/distfitter/_momfitter.py
@@ -182,8 +182,8 @@ class MOMFitter(BaseDistFitter):
             "mean_name": "mu",
             "std_name": "sigma",
             "dist_params": {"df": 5},
-        }
-        params5 = {"dist": Laplace(mu=0.0, scale=1.0), "mean_name": "mu"}
+        },
+        params5 = {"dist": Laplace(mu=0.0, scale=1.0), "mean_name": "mu"},
         params6 = {
             "dist": TDistribution(df=5, mu=0.0, sigma=1.0),
             "mean_name": "mu",

--- a/skpro/distfitter/_momfitter.py
+++ b/skpro/distfitter/_momfitter.py
@@ -18,8 +18,8 @@ class MOMFitter(BaseDistFitter):
 
     Parameters
     ----------
-    dist_cls : class
-        A distribution class from ``skpro.distributions``.
+    dist : skpro distribution instance or class
+        A distribution instance or class from ``skpro.distributions``.
         Must accept keyword arguments for location and scale parameters.
     mean_name : str, optional (default="mu")
         Name of the distribution parameter that corresponds to the mean.
@@ -27,7 +27,7 @@ class MOMFitter(BaseDistFitter):
         Name of the distribution parameter that corresponds to the
         standard deviation. If None, auto-detects by looking for
         ``"sigma"`` or ``"scale"`` in the ``__init__`` signature of
-        ``dist_cls``.
+        ``dist``.
     dist_params : dict or None, optional (default=None)
         Additional fixed parameters to pass to the distribution constructor.
         These are merged with the estimated mean and std parameters when
@@ -42,7 +42,7 @@ class MOMFitter(BaseDistFitter):
     >>> from skpro.distfitter import MOMFitter
     >>> from skpro.distributions.normal import Normal
     >>> X = pd.DataFrame([1.0, 2.0, 3.0, 4.0, 5.0])
-    >>> fitter = MOMFitter(dist_cls=Normal, mean_name="mu", std_name="sigma")
+    >>> fitter = MOMFitter(dist=Normal, mean_name="mu", std_name="sigma")
     >>> fitter.fit(X)
     MOMFitter(...)
     >>> dist = fitter.proba()
@@ -50,7 +50,7 @@ class MOMFitter(BaseDistFitter):
     Using Laplace distribution (uses "scale" instead of "sigma"):
 
     >>> from skpro.distributions.laplace import Laplace
-    >>> fitter = MOMFitter(dist_cls=Laplace, mean_name="mu", std_name="scale")
+    >>> fitter = MOMFitter(dist=Laplace, mean_name="mu", std_name="scale")
     >>> fitter.fit(X)
     MOMFitter(...)
 
@@ -58,7 +58,7 @@ class MOMFitter(BaseDistFitter):
 
     >>> from skpro.distributions.t import TDistribution
     >>> fitter = MOMFitter(
-    ...     dist_cls=TDistribution, mean_name="mu", std_name="sigma",
+    ...     dist=TDistribution, mean_name="mu", std_name="sigma",
     ...     dist_params={"df": 5},
     ... )
     >>> fitter.fit(X)
@@ -67,16 +67,26 @@ class MOMFitter(BaseDistFitter):
 
     _tags = {
         "authors": ["patelchaitany"],
-        "reserved_params": ["dist_cls"],
+        "reserved_params": ["dist"],
     }
 
-    def __init__(self, dist_cls, mean_name="mu", std_name=None, dist_params=None):
-        self.dist_cls = dist_cls
+    def __init__(self, dist, mean_name="mu", std_name=None, dist_params=None):
+        self.dist = dist
         self.mean_name = mean_name
         self.std_name = std_name
         self.dist_params = dist_params
 
         super().__init__()
+
+        if dist_params is None:
+            _dist_params = {}
+        else:
+            _dist_params = dist_params
+
+        if inspect.isclass(dist):
+            self._dist = dist(**_dist_params)
+        else:
+            self._dist = dist
 
     def _fit(self, X, C=None):
         """Fit distribution parameters using method of moments.
@@ -118,8 +128,7 @@ class MOMFitter(BaseDistFitter):
         ValueError
             If no known standard deviation parameter is found.
         """
-        sig = inspect.signature(self.dist_cls.__init__)
-        param_names = list(sig.parameters.keys())
+        param_names = self._dist.get_param_names()  # list(sig.parameters.keys())
 
         candidates = ["sigma", "scale"]
         for candidate in candidates:
@@ -128,7 +137,7 @@ class MOMFitter(BaseDistFitter):
 
         raise ValueError(
             f"Could not auto-detect standard deviation parameter for "
-            f"{self.dist_cls.__name__}. Signature has parameters "
+            f"{self._dist.__class__.__name__}. Signature has parameters "
             f"{param_names}. Please set std_name explicitly to one of "
             f"these."
         )
@@ -144,9 +153,9 @@ class MOMFitter(BaseDistFitter):
             self.mean_name: self.mean_,
             self._std_name_resolved: self.std_,
         }
-        if self.dist_params is not None:
-            params.update(self.dist_params)
-        return self.dist_cls(**params)
+        dist_with_params = self._dist.clone()
+        dist_with_params.set_params(**params)
+        return dist_with_params
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
@@ -166,13 +175,15 @@ class MOMFitter(BaseDistFitter):
         from skpro.distributions.normal import Normal
         from skpro.distributions.t import TDistribution
 
-        params1 = {"dist_cls": Normal, "mean_name": "mu", "std_name": "sigma"}
-        params2 = {"dist_cls": Laplace, "mean_name": "mu", "std_name": "scale"}
-        params3 = {"dist_cls": Laplace, "mean_name": "mu"}
+        params1 = {"dist": Normal, "mean_name": "mu", "std_name": "sigma"}
+        params2 = {"dist": Laplace, "mean_name": "mu", "std_name": "scale"}
+        params3 = {"dist": Laplace, "mean_name": "mu"}
         params4 = {
-            "dist_cls": TDistribution,
+            "dist": TDistribution,
             "mean_name": "mu",
             "std_name": "sigma",
             "dist_params": {"df": 5},
         }
-        return [params1, params2, params3, params4]
+        params5 = {"dist": Laplace(), "mean_name": "mu"}
+        params6 = {"dist": TDistribution(df=5), "mean_name": "mu", "std_name": "sigma"}
+        return [params1, params2, params3, params4, params5, params6]

--- a/skpro/distfitter/_momfitter.py
+++ b/skpro/distfitter/_momfitter.py
@@ -182,8 +182,8 @@ class MOMFitter(BaseDistFitter):
             "mean_name": "mu",
             "std_name": "sigma",
             "dist_params": {"df": 5},
-        },
-        params5 = {"dist": Laplace(mu=0.0, scale=1.0), "mean_name": "mu"},
+        }
+        params5 = {"dist": Laplace(mu=0.0, scale=1.0), "mean_name": "mu"}
         params6 = {
             "dist": TDistribution(df=5, mu=0.0, sigma=1.0),
             "mean_name": "mu",

--- a/skpro/distfitter/_momfitter.py
+++ b/skpro/distfitter/_momfitter.py
@@ -183,6 +183,6 @@ class MOMFitter(BaseDistFitter):
             "std_name": "sigma",
             "dist_params": {"df": 5},
         }
-        params5 = {"dist": Laplace(), "mean_name": "mu"}
+        params5 = {"dist": Laplace(mu=0.0, scale=1.0)}
         params6 = {"dist": TDistribution(df=5), "mean_name": "mu", "std_name": "sigma"}
         return [params1, params2, params3, params4, params5, params6]

--- a/skpro/distfitter/_momfitter.py
+++ b/skpro/distfitter/_momfitter.py
@@ -122,7 +122,7 @@ class MOMFitter(BaseDistFitter):
         ValueError
             If no known standard deviation parameter is found.
         """
-        param_names = self._dist.get_param_names()  # list(sig.parameters.keys())
+        param_names = self.dist.get_param_names()  # list(sig.parameters.keys())
 
         candidates = ["sigma", "scale"]
         for candidate in candidates:

--- a/skpro/distfitter/_momfitter.py
+++ b/skpro/distfitter/_momfitter.py
@@ -78,35 +78,6 @@ class MOMFitter(BaseDistFitter):
 
         super().__init__()
 
-    def get_params(self, deep=True):
-        """Get parameters for this estimator.
-
-        Overrides base ``get_params`` to prevent deep recursion into
-        ``dist_cls``, which is a class (not an instance) and would cause
-        ``get_params`` to fail when called on it.
-
-        Parameters
-        ----------
-        deep : bool, default=True
-            If True, returns parameters of sub-objects that are estimators.
-
-        Returns
-        -------
-        params : dict
-            Parameter names mapped to their values.
-        """
-        return super().get_params(deep=False)
-
-    def _repr_html_(self):
-        """HTML representation, overridden to avoid recursion into dist_cls."""
-        return (
-            f"<pre>{self.__class__.__name__}"
-            f"(dist_cls={self.dist_cls.__name__}, "
-            f"mean_name={self.mean_name!r}, "
-            f"std_name={self.std_name!r}, "
-            f"dist_params={self.dist_params!r})</pre>"
-        )
-
     def _fit(self, X, C=None):
         """Fit distribution parameters using method of moments.
 

--- a/skpro/distfitter/_momfitter.py
+++ b/skpro/distfitter/_momfitter.py
@@ -1,0 +1,207 @@
+"""Method of Moments distribution fitter."""
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+
+import inspect
+
+import numpy as np
+
+from skpro.distfitter.base import BaseDistFitter
+
+
+class MOMFitter(BaseDistFitter):
+    """Fit a distribution using method of moments (mean and standard deviation).
+
+    Computes the sample mean and standard deviation from the data, then
+    constructs the distribution given by ``dist_cls`` by plugging the mean
+    into the parameter named ``mean_name`` and the standard deviation into
+    the parameter named ``std_name``.
+
+    Parameters
+    ----------
+    dist_cls : class
+        A distribution class from ``skpro.distributions``.
+        Must accept keyword arguments for location and scale parameters.
+    mean_name : str, optional (default="mu")
+        Name of the distribution parameter that corresponds to the mean.
+    std_name : str or None, optional (default=None)
+        Name of the distribution parameter that corresponds to the
+        standard deviation. If None, auto-detects by looking for
+        ``"sigma"`` or ``"scale"`` in the ``__init__`` signature of
+        ``dist_cls``.
+    dist_params : dict or None, optional (default=None)
+        Additional fixed parameters to pass to the distribution constructor.
+        These are merged with the estimated mean and std parameters when
+        constructing the distribution in ``proba()``. Useful for distributions
+        that require extra parameters beyond location and scale, e.g.,
+        ``{"l_trunc": -3.0, "r_trunc": 3.0}`` for ``TruncatedNormal``,
+        or ``{"df": 5}`` for ``Student-t``.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from skpro.distfitter import MOMFitter
+    >>> from skpro.distributions.normal import Normal
+    >>> X = pd.DataFrame([1.0, 2.0, 3.0, 4.0, 5.0])
+    >>> fitter = MOMFitter(dist_cls=Normal, mean_name="mu", std_name="sigma")
+    >>> fitter.fit(X)
+    MOMFitter(...)
+    >>> dist = fitter.proba()
+
+    Using Laplace distribution (uses "scale" instead of "sigma"):
+
+    >>> from skpro.distributions.laplace import Laplace
+    >>> fitter = MOMFitter(dist_cls=Laplace, mean_name="mu", std_name="scale")
+    >>> fitter.fit(X)
+    MOMFitter(...)
+
+    Using Student-t with extra parameters via dist_params:
+
+    >>> from skpro.distributions.t import TDistribution
+    >>> fitter = MOMFitter(
+    ...     dist_cls=TDistribution, mean_name="mu", std_name="sigma",
+    ...     dist_params={"df": 5},
+    ... )
+    >>> fitter.fit(X)
+    MOMFitter(...)
+    """
+
+    _tags = {
+        "authors": ["patelchaitany"],
+        "reserved_params": ["dist_cls"],
+    }
+
+    def __init__(self, dist_cls, mean_name="mu", std_name=None, dist_params=None):
+        self.dist_cls = dist_cls
+        self.mean_name = mean_name
+        self.std_name = std_name
+        self.dist_params = dist_params
+
+        super().__init__()
+
+    def get_params(self, deep=True):
+        """Get parameters for this estimator.
+
+        Overrides base ``get_params`` to prevent deep recursion into
+        ``dist_cls``, which is a class (not an instance) and would cause
+        ``get_params`` to fail when called on it.
+
+        Parameters
+        ----------
+        deep : bool, default=True
+            If True, returns parameters of sub-objects that are estimators.
+
+        Returns
+        -------
+        params : dict
+            Parameter names mapped to their values.
+        """
+        return super().get_params(deep=False)
+
+    def _repr_html_(self):
+        """HTML representation, overridden to avoid recursion into dist_cls."""
+        return (
+            f"<pre>{self.__class__.__name__}"
+            f"(dist_cls={self.dist_cls.__name__}, "
+            f"mean_name={self.mean_name!r}, "
+            f"std_name={self.std_name!r}, "
+            f"dist_params={self.dist_params!r})</pre>"
+        )
+
+    def _fit(self, X, C=None):
+        """Fit distribution parameters using method of moments.
+
+        Parameters
+        ----------
+        X : pandas DataFrame
+            Data to fit the distribution to.
+        C : ignored
+
+        Returns
+        -------
+        self : reference to self
+        """
+        vals = X.values.ravel()
+        self.mean_ = float(np.mean(vals))
+        self.std_ = float(np.std(vals, ddof=1))
+
+        if self.std_name is not None:
+            self._std_name_resolved = self.std_name
+        else:
+            self._std_name_resolved = self._resolve_std_name()
+
+        return self
+
+    def _resolve_std_name(self):
+        """Auto-detect the standard deviation parameter name from dist_cls.
+
+        Inspects the ``__init__`` signature of ``dist_cls`` and looks for
+        known parameter names: ``"sigma"``, ``"scale"``.
+
+        Returns
+        -------
+        str
+            Resolved parameter name.
+
+        Raises
+        ------
+        ValueError
+            If no known standard deviation parameter is found.
+        """
+        sig = inspect.signature(self.dist_cls.__init__)
+        param_names = list(sig.parameters.keys())
+
+        candidates = ["sigma", "scale"]
+        for candidate in candidates:
+            if candidate in param_names:
+                return candidate
+
+        raise ValueError(
+            f"Could not auto-detect standard deviation parameter for "
+            f"{self.dist_cls.__name__}. Signature has parameters "
+            f"{param_names}. Please set std_name explicitly to one of "
+            f"these."
+        )
+
+    def _proba(self):
+        """Return fitted distribution.
+
+        Returns
+        -------
+        dist : skpro BaseDistribution (scalar)
+        """
+        params = {
+            self.mean_name: self.mean_,
+            self._std_name_resolved: self.std_,
+        }
+        if self.dist_params is not None:
+            params.update(self.dist_params)
+        return self.dist_cls(**params)
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return.
+
+        Returns
+        -------
+        params : dict or list of dict
+            Parameters to create testing instances of the class.
+        """
+        from skpro.distributions.laplace import Laplace
+        from skpro.distributions.normal import Normal
+        from skpro.distributions.t import TDistribution
+
+        params1 = {"dist_cls": Normal, "mean_name": "mu", "std_name": "sigma"}
+        params2 = {"dist_cls": Laplace, "mean_name": "mu", "std_name": "scale"}
+        params3 = {"dist_cls": Laplace, "mean_name": "mu"}
+        params4 = {
+            "dist_cls": TDistribution,
+            "mean_name": "mu",
+            "std_name": "sigma",
+            "dist_params": {"df": 5},
+        }
+        return [params1, params2, params3, params4]

--- a/skpro/distfitter/_momfitter.py
+++ b/skpro/distfitter/_momfitter.py
@@ -26,8 +26,7 @@ class MOMFitter(BaseDistFitter):
     std_name : str or None, optional (default=None)
         Name of the distribution parameter that corresponds to the
         standard deviation. If None, auto-detects by looking for
-        ``"sigma"`` or ``"scale"`` in the ``__init__`` signature of
-        ``dist``.
+        ``"sigma"`` or ``"scale"`` in the ``__init__`` signature of ``dist``.
     dist_params : dict or None, optional (default=None)
         Additional fixed parameters to pass to the distribution constructor.
         These are merged with the estimated mean and std parameters when

--- a/skpro/distfitter/_momfitter.py
+++ b/skpro/distfitter/_momfitter.py
@@ -78,14 +78,9 @@ class MOMFitter(BaseDistFitter):
         super().__init__()
 
         if dist_params is None:
-            _dist_params = {}
+            self._dist_params = {}
         else:
-            _dist_params = dist_params
-
-        if inspect.isclass(dist):
-            self._dist = dist(**_dist_params)
-        else:
-            self._dist = dist
+            self._dist_params = dist_params
 
     def _fit(self, X, C=None):
         """Fit distribution parameters using method of moments.
@@ -152,8 +147,13 @@ class MOMFitter(BaseDistFitter):
             self.mean_name: self.mean_,
             self._std_name_resolved: self.std_,
         }
-        dist_with_params = self._dist.clone()
-        dist_with_params.set_params(**params)
+        params.update(self._dist_params)
+
+        if inspect.isclass(self.dist):
+            dist_with_params = self.dist(**params)
+        else:
+            dist_with_params = self.dist.clone().set_params(**params)
+
         return dist_with_params
 
     @classmethod

--- a/skpro/distfitter/_normalfitter.py
+++ b/skpro/distfitter/_normalfitter.py
@@ -1,0 +1,148 @@
+"""Normal distribution fitter."""
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+
+import numpy as np
+
+from skpro.distfitter.base import BaseDistFitter
+
+
+class NormalFitter(BaseDistFitter):
+    r"""Fit a Normal distribution using sample mean and standard deviation.
+
+    Estimates the parameters :math:`\mu` and :math:`\sigma` of a Normal
+    distribution from the sample mean and sample standard deviation of the
+    data passed to ``fit``.
+
+    Parameters
+    ----------
+    method : str, optional (default="unbiased")
+        Estimation method for the standard deviation:
+
+        - ``"unbiased"`` : sample standard deviation with Bessel's correction
+          (denominator :math:`N - 1`).
+        - ``"MLE"`` : maximum likelihood estimate (denominator :math:`N`).
+        - ``"shrinkage"`` : linear shrinkage of the sample variance towards
+          ``shrinkage_target``. The shrinkage intensity is controlled by
+          ``shrinkage_alpha``.
+
+    shrinkage_target : float, optional (default=1.0)
+        Target value for the variance when ``method="shrinkage"``.
+        Ignored for other methods.
+    shrinkage_alpha : float, optional (default=0.5)
+        Shrinkage intensity in :math:`[0, 1]`. The shrunk variance is computed
+        as :math:`(1 - \alpha) \cdot s^2 + \alpha \cdot \text{target}`, where
+        :math:`s^2` is the unbiased sample variance. ``0`` means no shrinkage
+        (equivalent to ``"unbiased"``), ``1`` means full shrinkage to target.
+        Ignored for other methods.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from skpro.distfitter import NormalFitter
+    >>> X = pd.DataFrame([1.0, 2.0, 3.0, 4.0, 5.0])
+
+    Unbiased estimator (default, denominator N-1):
+
+    >>> fitter = NormalFitter()
+    >>> fitter.fit(X)
+    NormalFitter()
+    >>> dist = fitter.proba()
+
+    Maximum likelihood estimator (denominator N):
+
+    >>> fitter_mle = NormalFitter(method="MLE")
+    >>> fitter_mle.fit(X)
+    NormalFitter(method='MLE')
+    >>> dist_mle = fitter_mle.proba()
+
+    Shrinkage estimator (shrink variance towards target):
+
+    >>> fitter_shr = NormalFitter(
+    ...     method="shrinkage", shrinkage_target=1.0, shrinkage_alpha=0.3,
+    ... )
+    >>> fitter_shr.fit(X)
+    NormalFitter(method='shrinkage', shrinkage_alpha=0.3)
+    >>> dist_shr = fitter_shr.proba()
+    """
+
+    _tags = {
+        "authors": ["patelchaitany"],
+    }
+
+    VALID_METHODS = ("unbiased", "MLE", "shrinkage")
+
+    def __init__(self, method="unbiased", shrinkage_target=1.0, shrinkage_alpha=0.5):
+        self.method = method
+        self.shrinkage_target = shrinkage_target
+        self.shrinkage_alpha = shrinkage_alpha
+
+        super().__init__()
+
+    def _fit(self, X, C=None):
+        """Fit Normal distribution parameters from data.
+
+        Parameters
+        ----------
+        X : pandas DataFrame
+            Data to fit the distribution to.
+        C : ignored
+
+        Returns
+        -------
+        self : reference to self
+        """
+        method = self.method
+        if method not in self.VALID_METHODS:
+            raise ValueError(
+                f"Unknown method {method!r}. Must be one of {self.VALID_METHODS}."
+            )
+
+        vals = X.values.ravel()
+        self.mu_ = float(np.mean(vals))
+
+        if method == "unbiased":
+            self.sigma_ = float(np.std(vals, ddof=1))
+        elif method == "MLE":
+            self.sigma_ = float(np.std(vals, ddof=0))
+        elif method == "shrinkage":
+            alpha = self.shrinkage_alpha
+            target = self.shrinkage_target
+            sample_var = float(np.var(vals, ddof=1))
+            shrunk_var = (1 - alpha) * sample_var + alpha * target
+            self.sigma_ = float(np.sqrt(shrunk_var))
+
+        return self
+
+    def _proba(self):
+        """Return fitted Normal distribution.
+
+        Returns
+        -------
+        dist : skpro Normal distribution (scalar)
+        """
+        from skpro.distributions.normal import Normal
+
+        return Normal(mu=self.mu_, sigma=self.sigma_)
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return.
+
+        Returns
+        -------
+        params : dict or list of dict
+            Parameters to create testing instances of the class.
+        """
+        params1 = {"method": "unbiased"}
+        params2 = {"method": "MLE"}
+        params3 = {
+            "method": "shrinkage",
+            "shrinkage_target": 2.0,
+            "shrinkage_alpha": 0.3,
+        }
+        return [params1, params2, params3]

--- a/skpro/distfitter/base/__init__.py
+++ b/skpro/distfitter/base/__init__.py
@@ -1,0 +1,6 @@
+"""Base classes for distribution fitters."""
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+
+__all__ = ["BaseDistFitter"]
+
+from skpro.distfitter.base._base import BaseDistFitter

--- a/skpro/distfitter/base/_base.py
+++ b/skpro/distfitter/base/_base.py
@@ -1,0 +1,214 @@
+"""Base class for distribution fitters."""
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+
+from skbase.utils.dependencies import _check_estimator_deps, _check_soft_dependencies
+
+from skpro.base import BaseEstimator
+from skpro.datatypes import check_is_error_msg, check_is_mtype, convert
+
+__author__ = ["patelchaitany"]
+
+__all__ = ["BaseDistFitter"]
+
+ALLOWED_MTYPES = [
+    "pd_DataFrame_Table",
+    "pd_Series_Table",
+    "numpy1D",
+    "numpy2D",
+]
+if _check_soft_dependencies(["polars", "pyarrow"], severity="none"):
+    ALLOWED_MTYPES.append("polars_eager_table")
+
+
+class BaseDistFitter(BaseEstimator):
+    """Base class for distribution fitters.
+
+    A distribution fitter produces a single scalar distribution for a
+    tabular dataset. It estimates distribution parameters from data
+    and returns a fitted scalar distribution object.
+
+    Concrete implementations must implement ``_fit`` and ``_proba``.
+    """
+
+    _tags = {
+        "object_type": "distfitter",
+        "estimator_type": "distfitter",
+        "capability:survival": False,
+        "X_inner_mtype": "pd_DataFrame_Table",
+        "C_inner_mtype": "pd_DataFrame_Table",
+    }
+
+    def __init__(self):
+        super().__init__()
+        _check_estimator_deps(self)
+
+        self._X_converter_store = {}
+        self._C_converter_store = {}
+
+    def fit(self, X, C=None):
+        """Fit distribution to data.
+
+        Writes to self:
+            Sets fitted model attributes ending in "_".
+
+        Changes state to "fitted" = sets is_fitted flag to True.
+
+        Parameters
+        ----------
+        X : pandas DataFrame, pandas Series, or numpy array
+            Data to fit the distribution to.
+        C : pandas DataFrame, optional (default=None)
+            Censoring indicator for survival analysis.
+            Ignored unless ``capability:survival`` tag is True.
+
+        Returns
+        -------
+        self : reference to self
+        """
+        capa_surv = self.get_tag("capability:survival")
+
+        X_inner, X_metadata = self._check_X(X, return_metadata=True)
+
+        self._X_metadata = X_metadata
+
+        if capa_surv and C is not None:
+            C_inner, C_metadata = self._check_C(C)
+            self._C_metadata = C_metadata
+        else:
+            C_inner = None
+
+        self._is_fitted = True
+
+        if not capa_surv or C_inner is None:
+            return self._fit(X_inner)
+        else:
+            return self._fit(X_inner, C=C_inner)
+
+    def _fit(self, X, C=None):
+        """Fit distribution to data (inner method).
+
+        Writes to self:
+            Sets fitted model attributes ending in "_".
+
+        Parameters
+        ----------
+        X : pandas DataFrame
+            Data to fit the distribution to.
+        C : pandas DataFrame, optional (default=None)
+            Censoring indicator.
+
+        Returns
+        -------
+        self : reference to self
+        """
+        raise NotImplementedError
+
+    def proba(self):
+        """Return scalar distribution fitted to data seen in ``fit``.
+
+        State required:
+            Requires state to be "fitted".
+
+        Returns
+        -------
+        dist : skpro BaseDistribution
+            Scalar distribution fitted to data passed in ``fit``.
+        """
+        self.check_is_fitted()
+        return self._proba()
+
+    def _proba(self):
+        """Return scalar distribution fitted to data (inner method).
+
+        Returns
+        -------
+        dist : skpro BaseDistribution
+            Scalar distribution fitted to data passed in ``fit``.
+        """
+        raise NotImplementedError
+
+    def _check_X(self, X, return_metadata=False):
+        """Check and convert X to inner mtype.
+
+        Parameters
+        ----------
+        X : object
+            Data to check and convert.
+        return_metadata : bool, optional, default=False
+            Whether to return metadata.
+
+        Returns
+        -------
+        X_inner : pandas DataFrame
+            X converted to X_inner_mtype.
+        X_metadata : dict, only returned if return_metadata=True
+            Metadata of X.
+        """
+        if return_metadata:
+            req_metadata = ["n_instances", "feature_names"]
+        else:
+            req_metadata = ["feature_names"]
+
+        valid, msg, X_metadata = check_is_mtype(
+            X,
+            ALLOWED_MTYPES,
+            "Table",
+            return_metadata=req_metadata,
+            var_name="X",
+            msg_return_dict="list",
+        )
+
+        if not valid:
+            check_is_error_msg(msg, var_name="X", raise_exception=True)
+
+        X_inner_mtype = self.get_tag("X_inner_mtype")
+        X_inner = convert(
+            obj=X,
+            from_type=X_metadata["mtype"],
+            to_type=X_inner_mtype,
+            as_scitype="Table",
+            store=self._X_converter_store,
+        )
+
+        if return_metadata:
+            return X_inner, X_metadata
+        else:
+            return X_inner
+
+    def _check_C(self, C):
+        """Check and convert censoring indicator C to inner mtype.
+
+        Parameters
+        ----------
+        C : object
+            Censoring indicator to check and convert.
+
+        Returns
+        -------
+        C_inner : pandas DataFrame
+            C converted to C_inner_mtype.
+        C_metadata : dict
+            Metadata of C.
+        """
+        valid, msg, metadata = check_is_mtype(
+            C,
+            ALLOWED_MTYPES,
+            "Table",
+            return_metadata=["n_instances"],
+            var_name="C",
+            msg_return_dict="list",
+        )
+
+        if not valid:
+            check_is_error_msg(msg, var_name="C", raise_exception=True)
+
+        C_inner_mtype = self.get_tag("C_inner_mtype")
+        C_inner = convert(
+            obj=C,
+            from_type=metadata["mtype"],
+            to_type=C_inner_mtype,
+            as_scitype="Table",
+            store=self._C_converter_store,
+        )
+
+        return C_inner, metadata

--- a/skpro/distfitter/tests/__init__.py
+++ b/skpro/distfitter/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for skpro distribution fitters."""

--- a/skpro/distfitter/tests/test_all_distfitters.py
+++ b/skpro/distfitter/tests/test_all_distfitters.py
@@ -1,0 +1,47 @@
+"""Automated tests based on the skbase test suite template."""
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+
+import numpy as np
+import pandas as pd
+from skbase.testing import QuickTester
+
+from skpro.distributions.base import BaseDistribution
+from skpro.tests.test_all_estimators import BaseFixtureGenerator, PackageConfig
+
+
+class TestAllDistFitters(PackageConfig, BaseFixtureGenerator, QuickTester):
+    """Generic tests for all distribution fitters in skpro."""
+
+    object_type_filter = "distfitter"
+
+    def test_input_output_contract(self, object_instance):
+        """Test that fit/proba follow the expected contract."""
+        X = pd.DataFrame(np.random.RandomState(42).randn(50, 1))
+
+        fitter = object_instance
+        fitter.fit(X)
+
+        dist = fitter.proba()
+
+        assert isinstance(
+            dist, BaseDistribution
+        ), f"proba() must return a BaseDistribution, got {type(dist)}"
+        assert (
+            dist.ndim == 0
+        ), f"proba() must return a scalar distribution (ndim==0), got ndim={dist.ndim}"
+
+    def test_proba_has_mean_var(self, object_instance):
+        """Test that the returned distribution supports mean() and var()."""
+        X = pd.DataFrame(np.random.RandomState(42).randn(50, 1))
+
+        fitter = object_instance
+        fitter.fit(X)
+
+        dist = fitter.proba()
+
+        mean_val = dist.mean()
+        var_val = dist.var()
+
+        assert np.isfinite(mean_val), f"mean() returned non-finite value: {mean_val}"
+        assert np.isfinite(var_val), f"var() returned non-finite value: {var_val}"
+        assert var_val >= 0, f"var() returned negative value: {var_val}"

--- a/skpro/distfitter/tests/test_all_distfitters.py
+++ b/skpro/distfitter/tests/test_all_distfitters.py
@@ -5,9 +5,7 @@ import numpy as np
 import pandas as pd
 from skbase.testing import QuickTester
 
-from skpro.distfitter import MOMFitter
 from skpro.distributions.base import BaseDistribution
-from skpro.distributions.normal import Normal
 from skpro.tests.test_all_estimators import BaseFixtureGenerator, PackageConfig
 
 
@@ -47,14 +45,3 @@ class TestAllDistFitters(PackageConfig, BaseFixtureGenerator, QuickTester):
         assert np.isfinite(mean_val), f"mean() returned non-finite value: {mean_val}"
         assert np.isfinite(var_val), f"var() returned non-finite value: {var_val}"
         assert var_val >= 0, f"var() returned negative value: {var_val}"
-
-    def test_get_params_deep_with_dist_cls(self):
-        """get_params(deep=True) works when dist_cls is a distribution class.
-
-        Requires scikit-base>=1.0.1 (sktime/skbase#559).
-        """
-        fitter = MOMFitter(dist_cls=Normal, mean_name="mu", std_name="sigma")
-        params = fitter.get_params(deep=True)
-
-        assert params["dist_cls"] is Normal
-        assert "dist_cls__" not in params

--- a/skpro/distfitter/tests/test_all_distfitters.py
+++ b/skpro/distfitter/tests/test_all_distfitters.py
@@ -5,7 +5,9 @@ import numpy as np
 import pandas as pd
 from skbase.testing import QuickTester
 
+from skpro.distfitter import MOMFitter
 from skpro.distributions.base import BaseDistribution
+from skpro.distributions.normal import Normal
 from skpro.tests.test_all_estimators import BaseFixtureGenerator, PackageConfig
 
 
@@ -45,3 +47,14 @@ class TestAllDistFitters(PackageConfig, BaseFixtureGenerator, QuickTester):
         assert np.isfinite(mean_val), f"mean() returned non-finite value: {mean_val}"
         assert np.isfinite(var_val), f"var() returned non-finite value: {var_val}"
         assert var_val >= 0, f"var() returned negative value: {var_val}"
+
+    def test_get_params_deep_with_dist_cls(self):
+        """get_params(deep=True) works when dist_cls is a distribution class.
+
+        Requires scikit-base>=1.0.1 (sktime/skbase#559).
+        """
+        fitter = MOMFitter(dist_cls=Normal, mean_name="mu", std_name="sigma")
+        params = fitter.get_params(deep=True)
+
+        assert params["dist_cls"] is Normal
+        assert "dist_cls__" not in params

--- a/skpro/distfitter/tests/test_distfitter.py
+++ b/skpro/distfitter/tests/test_distfitter.py
@@ -12,5 +12,5 @@ def test_get_params_deep_with_dist_cls():
     fitter = MOMFitter(dist=Normal, mean_name="mu", std_name="sigma")
     params = fitter.get_params(deep=True)
 
-    assert params["dist_cls"] is Normal
-    assert "dist_cls__" not in params
+    assert params["dist"] is Normal
+    assert "dist__" not in params

--- a/skpro/distfitter/tests/test_distfitter.py
+++ b/skpro/distfitter/tests/test_distfitter.py
@@ -1,0 +1,15 @@
+"""Tests for the distfitter module."""
+
+from skpro.distfitter import MOMFitter
+from skpro.distributions.normal import Normal
+
+def test_get_params_deep_with_dist_cls(self):
+    """get_params(deep=True) works when dist_cls is a distribution class.
+
+    Requires scikit-base>=1.0.1 (sktime/skbase#559).
+    """
+    fitter = MOMFitter(dist=Normal, mean_name="mu", std_name="sigma")
+    params = fitter.get_params(deep=True)
+
+    assert params["dist_cls"] is Normal
+    assert "dist_cls__" not in params

--- a/skpro/distfitter/tests/test_distfitter.py
+++ b/skpro/distfitter/tests/test_distfitter.py
@@ -4,8 +4,8 @@ from skpro.distfitter import MOMFitter
 from skpro.distributions.normal import Normal
 
 
-def test_get_params_deep_with_dist_cls(self):
-    """get_params(deep=True) works when dist_cls is a distribution class.
+def test_get_params_deep_with_dist_cls():
+    """get_params(deep=True) works when dist is a distribution class.
 
     Requires scikit-base>=1.0.1 (sktime/skbase#559).
     """

--- a/skpro/distfitter/tests/test_distfitter.py
+++ b/skpro/distfitter/tests/test_distfitter.py
@@ -3,6 +3,7 @@
 from skpro.distfitter import MOMFitter
 from skpro.distributions.normal import Normal
 
+
 def test_get_params_deep_with_dist_cls(self):
     """get_params(deep=True) works when dist_cls is a distribution class.
 

--- a/skpro/registry/_tags.py
+++ b/skpro/registry/_tags.py
@@ -235,7 +235,7 @@ class capability__survival(_BaseTag):
 
     _tags = {
         "tag_name": "capability:survival",
-        "parent_type": ["regressor_proba", "metric"],
+        "parent_type": ["regressor_proba", "metric", "distfitter"],
         "tag_type": "bool",
         "short_descr": "whether estimator can use censoring information,"
         " for survival analysis",
@@ -280,7 +280,7 @@ class X_inner_mtype(_BaseTag):
 
     _tags = {
         "tag_name": "X_inner_mtype",
-        "parent_type": "regressor_proba",
+        "parent_type": ["regressor_proba", "distfitter"],
         "tag_type": ("list", "str"),
         "short_descr": "which machine type(s) is the"
         " internal _fit/_predict able to deal with?",
@@ -304,7 +304,7 @@ class C_inner_mtype(_BaseTag):
 
     _tags = {
         "tag_name": "C_inner_mtype",
-        "parent_type": "regressor_proba",
+        "parent_type": ["regressor_proba", "distfitter"],
         "tag_type": ("list", "str"),
         "short_descr": "which machine type(s) is the "
         "internal _fit/_predict able to deal with?",


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #897 

#### What does this implement/fix? Explain your changes.

Below is the major changes which this PR introduce.

1. _base.py : Implemented BaseDistFitter which follows the same template-method pattern as BaseProbaRegressor. The public fit() method handles input validation and mytype conversion via _check_X/_check_C ,delegates to _fit() same for the proba() it also delegates to _proba(). Support for the censoring  via the "capability:survival" tag.

2. Two example of fitters : 

    1. _normalfitter.py :  NormalFitter, always fits a Normal distribution using sample mean and std
    2. _momfitter.py : MOMFitter, generic method-of-moments fitter. Accepts any distribution class (dist_cls), auto-detects "sigma" or "scale" parameter names, and supports a dist_params dict for passing extra fixed parameters (like truncation bounds or degrees of freedom.)

3. Tags : _tags.py added "distfitter" to the capability:survival tag's parent types, added X_inner_mtype and C_inner_mtype tag classes scoped to the "distfitter" scitype


#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new core dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core skpro package to a minimum.
-->

No

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

Yes

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [X] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [X] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
