### PR TITLE
fix: add check_is_fitted() to predict and predict_proba

### DIFF
--- a/skpro/regression/base/_base.py
+++ b/skpro/regression/base/_base.py
@@ -223,6 +223,8 @@ class BaseProbaRegressor(BaseEstimator):
         y : pandas DataFrame, same length as `X`
             labels predicted for `X`
         """
+        self.check_is_fitted()
+
         X = self._check_X(X)
 
         y_pred = self._predict(X)
@@ -289,6 +291,8 @@ class BaseProbaRegressor(BaseEstimator):
         y : skpro BaseDistribution, same length as `X`
             labels predicted for `X`
         """
+        self.check_is_fitted()
+
         X = self._check_X(X)
 
         y_pred = self._predict_proba(X)


### PR DESCRIPTION
## SUMMARY

This PR adds a missing fitted state check to `predict()` and `predict_proba()` in `skpro/regression/base/_base.py`. Without this check, calling these methods on an unfitted estimator raises an `AttributeError` instead of the expected `NotFittedError`.
The change makes their behavior consistent with other prediction methods.

---

## FIX

**Before**

```python
def predict(self, X):
    X = self._check_X(X)
```

**After**

```python
def predict(self, X):
    self.check_is_fitted()
    X = self._check_X(X)
```

---

## VERIFICATION

**Steps**

```python
reg = ResidualDouble(LinearRegression())
reg.predict(X)
```

**Expected**

Raises `NotFittedError` instead of `AttributeError`.
