### PR TITLE
[Bug] Fix plotting test bug in discrete pmf.

### DIFF
--- a/skpro/distributions/tests/test_proba_basic.py
+++ b/skpro/distributions/tests/test_proba_basic.py
@@ -144,9 +144,6 @@ def test_proba_plotting(fun):
     assert isinstance(ax, Axes)
 
 
-# @pytest.mark.skip(
-#     reason="Undiagnosed failure. Skipping until resolved. See #918."
-# )
 @pytest.mark.skipif(
     not _check_soft_dependencies("matplotlib", severity="none"),
     reason="skip if matplotlib is not available",
@@ -154,12 +151,13 @@ def test_proba_plotting(fun):
 def test_discrete_pmf_plotting():
     """Test that discrete PMF plotting uses stem plots."""
     from matplotlib.axes import Axes
+    from matplotlib.container import StemContainer
 
     from skpro.distributions.binomial import Binomial
 
     # Test Binomial PMF plotting
     n = Binomial(n=10, p=0.5)
-    ax = n.plot(fun="pmf")
+    ax = n.plot(fun="pmf", x_bounds=(0, n.n))
     assert isinstance(ax, Axes)
 
     # Check that stem plot was used (should have containers)
@@ -168,12 +166,14 @@ def test_discrete_pmf_plotting():
     # For small distributions, check that all support points are plotted
     # Binomial(n=10) has support [0,1,2,...,10] = 11 points
     # The stem plot should have evaluated at these points
-    if hasattr(ax.containers[0], "markerline"):
-        # A StemContainer has a markerline, stemlines, and baseline
-        # We check the number of markers to verify multiple points are plotted
-        assert (
-            len(ax.containers[0].markerline.get_xdata()) > 5
-        ), "Should plot at multiple support points"
+    assert isinstance(ax.containers[0], StemContainer)
+    # A StemContainer has a markerline, stemlines, and baseline
+    # We check the number of markers to verify multiple points are plotted
+    x_data = ax.containers[0].markerline.get_xdata()
+    assert len(x_data) == n.n + 1, "Should plot at all support points"
+    assert all(
+        x_data == np.arange(n.n + 1)
+    ), "Stem plot x_data should cover full support [0,...,n]"
 
 
 def test_to_df_parametric():

--- a/skpro/distributions/tests/test_proba_basic.py
+++ b/skpro/distributions/tests/test_proba_basic.py
@@ -144,9 +144,9 @@ def test_proba_plotting(fun):
     assert isinstance(ax, Axes)
 
 
-@pytest.mark.skip(
-    reason="Undiagnosed failure. Skipping until resolved. See #918."
-)
+# @pytest.mark.skip(
+#     reason="Undiagnosed failure. Skipping until resolved. See #918."
+# )
 @pytest.mark.skipif(
     not _check_soft_dependencies("matplotlib", severity="none"),
     reason="skip if matplotlib is not available",
@@ -168,10 +168,11 @@ def test_discrete_pmf_plotting():
     # For small distributions, check that all support points are plotted
     # Binomial(n=10) has support [0,1,2,...,10] = 11 points
     # The stem plot should have evaluated at these points
-    if hasattr(ax.containers[0], "get_children"):
-        # This is a rough check - the stem plot should have multiple elements
+    if hasattr(ax.containers[0], "markerline"):
+        # A StemContainer has a markerline, stemlines, and baseline
+        # We check the number of markers to verify multiple points are plotted
         assert (
-            len(ax.containers[0].get_children()) > 5
+            len(ax.containers[0].markerline.get_xdata()) > 5
         ), "Should plot at multiple support points"
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skpro.readthedocs.io/en/latest/contribute.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/sktime/skpro/issues/918

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
The old code was checking for data point using `get_children()` function.
```python
    if hasattr(ax.containers[0], "get_children"):
        # This is a rough check - the stem plot should have multiple elements
          assert (
            len(ax.containers[0].get_children() > 5),
            "Should plot at multiple support points"
          )
```
This always return 3 (markerline, baseline, stemlines).
This can be fixed by getting the plotted data itself using:
```python
    if hasattr(ax.containers[0], "get_children"):
          assert (
             len(ax.containers[0].markerline.get_xdata()) > 5),
             "Should plot at multiple support points"
          )
```
