### PR TITLE
MNT: Fix CRLF line endings in lognormal.py and zeroinflated.py (#929)

### DIFF
--- a/skpro/distributions/lognormal.py
+++ b/skpro/distributions/lognormal.py
@@ -1,4 +1,4 @@
-# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+﻿# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
 """Log-Normal probability distribution."""
 
 import numpy as np

--- a/skpro/distributions/zeroinflated.py
+++ b/skpro/distributions/zeroinflated.py
@@ -1,4 +1,4 @@
-"""Zero-Inflated distribution."""
+﻿"""Zero-Inflated distribution."""
 
 import numpy as np
 from numpy.typing import ArrayLike


### PR DESCRIPTION
Fixes #929

## What this PR does
Converts Windows CRLF (`\r\n`) line endings to Unix LF (`\n`) in two
distribution files that were committed with CRLF:

- `skpro/distributions/lognormal.py`
- `skpro/distributions/zeroinflated.py`

## Verification
Confirmed with `git ls-files --eol` before and after:

Before: `i/crlf` on both files
After:  `i/crlf w/lf` on both files 
