### PR TITLE
&MayankSharma-2812 [BUG] Use `pdf` instead of `log_pdf` in `SquaredDistrLoss`

### DIFF
--- a/skpro/metrics/_classes.py
+++ b/skpro/metrics/_classes.py
@@ -655,7 +655,7 @@ class SquaredDistrLoss(BaseDistrMetric):
         super().__init__(multioutput=multioutput)
 
     def _evaluate_by_index(self, y_true, y_pred, **kwargs):
-        res = -2 * y_pred.log_pdf(y_true) + y_pred.pdfnorm(a=2)
+        res = -2 * y_pred.pdf(y_true) + y_pred.pdfnorm(a=2)
         # replace this by multivariate log_pdf once distr implements
         # i.e., pass multivariate on to log_pdf
         if self.multivariate:


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #934

#### What does this implement/fix? Explain your changes.

This PR fixes an implementation issue in `SquaredDistrLoss` where `log_pdf` was used instead of `pdf` when computing the squared distribution loss.

The squared distribution loss is defined as:

L(y, d) = -2 · p_d(y) + ||p_d||²

where `p_d(y)` is the probability density function.

The previous implementation used:

`-2 * y_pred.log_pdf(y_true) + y_pred.pdfnorm(a=2)`

Using `log_pdf` changes the magnitude and sign of the loss.
This PR replaces `log_pdf` with `pdf` so the computation follows the correct mathematical definition.

#### Does your contribution introduce a new dependency? If yes, which one?

No. This change does not introduce any new dependencies.

#### What should a reviewer concentrate their feedback on?

* Correctness of replacing `log_pdf` with `pdf` in `SquaredDistrLoss`.
* Consistency with the mathematical definition of the squared distribution loss.

#### Did you add any tests for the change?

No new tests were added. Existing tests covering `SquaredDistrLoss` pass locally after the fix.

#### Any other comments?

All tests pass locally (`pytest`).

#### PR checklist

##### For all contributions

* [ ] I've added myself to the list of contributors with any new badges I've earned
* [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
