### PR TITLE
[MNT] Add separate scheduled workflow for regular estimator tests

### DIFF
--- a/.github/workflows/cron-tests.yml
+++ b/.github/workflows/cron-tests.yml
@@ -1,0 +1,208 @@
+name: Test
+
+on:
+  schedule:
+    - cron: "0 0 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  # Needed for the 'trilom/file-changes-action' action
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  
+
+  detect-changed-classes:
+  
+    runs-on: ubuntu-latest
+    outputs:
+      obj_list: ${{ steps.get-change-list.outputs.obj_list }}
+      obj_list_length: ${{ steps.get-change-list.outputs.obj_list_length }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - run: git remote set-branches origin 'main'
+
+      - run: git fetch --depth 1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install skpro with dev dependencies
+        run: pip install .[dev]
+        env:
+          UV_SYSTEM_PYTHON: 1
+
+      - name: Get list of names of changed classes
+        id: get-change-list
+        run: |
+          OBJ_LIST=$(python -c 'from skpro.tests.test_switch import _get_all_changed_classes; import json; obj_list = _get_all_changed_classes(vm=True, only_changed_modules=False); print(json.dumps(obj_list))')
+          OBJ_LIST_LENGTH=$(python -c 'from skpro.tests.test_switch import _get_all_changed_classes; obj_list = _get_all_changed_classes(vm=True, only_changed_modules=False); print(len(obj_list))')
+          echo "OBJ_LIST=$OBJ_LIST" >> $GITHUB_ENV
+          echo "OBJ_LIST_LENGTH=$OBJ_LIST_LENGTH" >> $GITHUB_ENV
+          echo "obj_list=$OBJ_LIST" >> $GITHUB_OUTPUT
+          echo "obj_list_length=$OBJ_LIST_LENGTH" >> $GITHUB_OUTPUT
+
+      - name: Print changed classes
+        run: |
+          echo "Number of changed classes: $OBJ_LIST_LENGTH"
+          echo "Changed classes: $OBJ_LIST"
+
+  run-tests-no-extras:
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - run: git remote set-branches origin 'main'
+
+      - run: git fetch --depth 1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+
+      - name: Install skpro and dependencies
+        shell: bash
+        run: uv pip install .[dev] --no-cache-dir
+        env:
+          UV_SYSTEM_PYTHON: 1
+
+      - name: Show dependencies
+        run: uv pip list
+
+      - name: Show available branches
+        run: git branch -a
+
+      - name: Run tests
+        run: make test
+
+      - name: Publish code coverage
+        uses: codecov/codecov-action@v5
+
+  run-tests-all-extras:
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - run: git remote set-branches origin 'main'
+
+      - run: git fetch --depth 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+
+      - name: Install skpro and dependencies
+        shell: bash
+        run: uv pip install .[dev] --no-cache-dir
+        env:
+          UV_SYSTEM_PYTHON: 1
+
+      - name: Show dependencies
+        run: uv pip list
+
+      - name: Show available branches
+        run: git branch -a
+
+      - name: Run tests
+        run: make test
+
+      - name: Publish code coverage
+        uses: codecov/codecov-action@v5
+
+  test-est:
+    needs: detect-changed-classes
+    if: ${{ needs.detect-changed-classes.outputs.obj_list != '[]' }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        flag: ${{ fromJson(needs.detect-changed-classes.outputs.obj_list) }}
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Force non-GUI Matplotlib backend (Windows)
+        if: ${{ matrix.os == 'windows-latest' }}
+        shell: pwsh
+        run: echo "MPLBACKEND=Agg" >> $env:GITHUB_ENV
+
+      - name: Install skpro with dev dependencies
+        run: uv pip install .[dev]
+        env:
+          UV_SYSTEM_PYTHON: 1
+
+      - name: Install dependencies for ${{ matrix.flag }}
+        run: |
+          python -c "from skpro.registry import deps; print('\n'.join(deps('${{ matrix.flag }}', include_test_deps=True)))" > deps.txt
+          pip install -r deps.txt
+        continue-on-error: true
+
+      - name: Show dependencies
+        run: uv pip list
+
+      - name: Run tests with ${{ matrix.flag }}
+        env:
+          FLAG: ${{ matrix.flag }}
+        shell: bash
+        run: python -c "from skpro.tests._test_vm import run_test_vm; run_test_vm('${{ matrix.flag }}')"
+
+  

--- a/skpro/tests/test_switch.py
+++ b/skpro/tests/test_switch.py
@@ -346,7 +346,7 @@ def run_test_module_changed(module):
 
 
 @lru_cache
-def _get_all_changed_classes(vm=False):
+def _get_all_changed_classes(vm=False, only_changed_modules=True):
     """Get all skpro object classes that have changed compared to the main branch.
 
     Returns a tuple of string class names of object classes that have changed.
@@ -358,16 +358,27 @@ def _get_all_changed_classes(vm=False):
         Queries the tag ``"tests:vm"`` in the class tags.
         If ``vm`` is True, only classes with tag ``"tests:vm"=True`` are returned.
 
+    only_changed_modules : bool, optional, default=True
+        whether to restrict the returned classes to those from changed modules only.
+
     Returns
     -------
-    tuple of strings of class names : object classes that have changed
+    tuple of strings of class names : object classes to test
     """
     from skpro.registry import all_objects
 
     def _changed_class(cls):
         """Check if a class has changed compared to the main branch."""
-        run, _ = _run_test_for_class(cls, ignore_deps=True, only_vm_required=vm)
+        run, _ = _run_test_for_class(
+            cls,
+            ignore_deps=True,
+            only_vm_required=vm,
+            only_changed_modules=only_changed_modules,
+        )
         return run
 
     names = [name for name, est in all_objects() if _changed_class(est)]
     return names
+
+
+


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skpro.readthedocs.io/en/latest/contribute.html
-->

#### Reference Issues/PRs

Closes #913.


#### What does this implement/fix? Explain your changes.

Adds a separate scheduled workflow (`cron-tests.yml`) for regular running of estimator tests, as requested in #913. The workflow runs weekly and includes `run-tests-no-extras`, `run-tests-all-extras`, and `test-est` on all classes, not only those changed in a PR.

To support this, adds an `only_changed_modules` parameter to `_get_all_changed_classes` in `test_switch.py`, so the cron workflow can bypass the changed-files filter while the existing PR workflow remains unchanged.


#### Does your contribution introduce a new dependency? If yes, which one?
No

#### What should a reviewer concentrate their feedback on?

-  Whether the workflow shape (detect-changed-classes, run-tests-no-extras, run-tests-all-extras, test-est) matches the intended design

- Whether exposing the switch through the `only_changed_modules` parameter in `_get_all_changed_classes` is the preferred implementation

#### Did you add any tests for the change?

No new tests. This is a CI/workflow change.

#### Any other comments?
Opened as draft to confirm direction before finalizing.

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].

