### PR TITLE
[BUG] Reject None for required numeric distribution parameters

### DIFF
--- a/skpro/distributions/cauchy.py
+++ b/skpro/distributions/cauchy.py
@@ -57,6 +57,9 @@ class Cauchy(_ScipyAdapter):
     }
 
     def __init__(self, mu, scale, index=None, columns=None):
+        if mu is None or scale is None:
+            raise ValueError("mu and scale must not be None")
+
         self.mu = mu
         self.scale = scale
 

--- a/skpro/distributions/gumbel_l.py
+++ b/skpro/distributions/gumbel_l.py
@@ -48,6 +48,9 @@ class GumbelL(_ScipyAdapter):
     }
 
     def __init__(self, mu=0.0, sigma=1.0, index=None, columns=None):
+        if mu is None or sigma is None:
+            raise ValueError("mu and sigma must not be None")
+
         self.mu = mu
         self.sigma = sigma
         super().__init__(index=index, columns=columns)

--- a/skpro/distributions/gumbel_r.py
+++ b/skpro/distributions/gumbel_r.py
@@ -48,6 +48,9 @@ class GumbelR(_ScipyAdapter):
     }
 
     def __init__(self, mu=0.0, sigma=1.0, index=None, columns=None):
+        if mu is None or sigma is None:
+            raise ValueError("mu and sigma must not be None")
+
         self.mu = mu
         self.sigma = sigma
         super().__init__(index=index, columns=columns)

--- a/skpro/distributions/laplace.py
+++ b/skpro/distributions/laplace.py
@@ -55,6 +55,9 @@ class Laplace(BaseDistribution):
     }
 
     def __init__(self, mu, scale, index=None, columns=None):
+        if mu is None or scale is None:
+            raise ValueError("mu and scale must not be None")
+
         self.mu = mu
         self.scale = scale
 

--- a/skpro/distributions/normal.py
+++ b/skpro/distributions/normal.py
@@ -52,6 +52,9 @@ class Normal(BaseDistribution):
     }
 
     def __init__(self, mu, sigma, index=None, columns=None):
+        if mu is None or sigma is None:
+           raise ValueError("mu and sigma must not be None")
+    
         self.mu = mu
         self.sigma = sigma
 

--- a/skpro/distributions/tests/test_proba_basic.py
+++ b/skpro/distributions/tests/test_proba_basic.py
@@ -334,3 +334,28 @@ def test_pmf_support_method():
     support = delta._pmf_support(3, 4)
     assert isinstance(support, np.ndarray)
     assert len(support) == 0
+
+def test_none_required_numeric_params_rejected():
+    """Required numeric params should not accept None."""
+    import pytest
+
+    from skpro.distributions.cauchy import Cauchy
+    from skpro.distributions.gumbel_l import GumbelL
+    from skpro.distributions.gumbel_r import GumbelR
+    from skpro.distributions.laplace import Laplace
+    from skpro.distributions.normal import Normal
+
+    with pytest.raises(ValueError, match="must not be None"):
+        Normal(mu=None, sigma=None)
+
+    with pytest.raises(ValueError, match="must not be None"):
+        Laplace(mu=None, scale=None)
+
+    with pytest.raises(ValueError, match="must not be None"):
+        Cauchy(mu=None, scale=None)
+
+    with pytest.raises(ValueError, match="must not be None"):
+        GumbelL(mu=None, sigma=None)
+
+    with pytest.raises(ValueError, match="must not be None"):
+        GumbelR(mu=None, sigma=None)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skpro.readthedocs.io/en/latest/contribute.html
-->

#### Reference Issues/PRs
Fixes #884

#### What does this implement/fix? Explain your changes.
Several distributions accepted `None` for required numeric parameters during construction and then failed inconsistently when numerical methods were called. In the reported cases, `Normal` and `Laplace` returned `None` from `mean()`, while `Cauchy`, `GumbelL`, and `GumbelR` raised raw `TypeError`s.

This PR adds explicit validation in the affected distribution constructors so `None` is rejected earlier with a clear `ValueError` instead of allowing construction to succeed and fail later inconsistently.

#### Does your contribution introduce a new dependency? If yes, which one?

No

#### What should a reviewer concentrate their feedback on?

- The `None` validation added in the constructors of `cauchy.py`, `gumbel_l.py`, `gumbel_r.py`, `normal.py`, and `laplace.py`
- The regression test in `skpro/distributions/tests/test_proba_basic.py` confirming these invalid inputs now raise `ValueError`

#### Did you add any tests for the change?

Yes, added `test_none_required_numeric_params_rejected` in `skpro/distributions/tests/test_proba_basic.py`, covering all five affected distributions.

#### Any other comments?
Kept the change intentionally narrow and limited to the affected distributions reported in #884.

#### PR checklist


##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].




