### PR TITLE
Fix: Chain `RecursionError` exceptions in `BaseProbaMetric`

### DIFF
--- a/skpro/metrics/base.py
+++ b/skpro/metrics/base.py
@@ -263,10 +263,10 @@ class BaseProbaMetric(BaseObject):
                     **kwargs,
                 )
             return out_series
-        except RecursionError:
+        except RecursionError as err:
             raise RecursionError(
                 "Must implement one of _evaluate or _evaluate_by_index"
-            )
+            ) from err
 
     def _check_consistent_input(self, y_true, y_pred, multioutput):
         check_consistent_length(y_true, y_pred)


### PR DESCRIPTION
Fixes #948.\n\n### Description\nInside `_evaluate_by_index` of the `BaseProbaMetric` class, a `RecursionError` is caught and re-raised with an informative message. However, the original exception is dropped because `from err` is omitted. This PR preserves the traceback by catching `except RecursionError as err` and raising the new exception `from err`.