### PR TITLE
[BUG] Fix Levy distribution tags: move mean/var to capabilities:undefined and add missing distr:paramtype tag

### DIFF
--- a/skpro/distributions/levy.py
+++ b/skpro/distributions/levy.py
@@ -35,7 +35,9 @@ class Levy(_ScipyAdapter):
     _tags = {
         "authors": ["direkkakkar319-ops", "arnavk23", "fkiraly"],
         "distr:measuretype": "continuous",
-        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
+        "capabilities:exact": ["pdf", "log_pdf", "cdf", "ppf"],
+        "capabilities:undefined": ["mean", "var"],
+        "distr:paramtype": "parametric",
         "broadcast_init": "on",
     }
 


### PR DESCRIPTION

The Levy distribution has infinite mean and infinite variance. However, it incorrectly listed mean and var under capabilities:exact instead of capabilities:undefined. This PR corrects the tags dictionary and adds the missing distr:paramtype: parametric tag.


#### Reference Issues/PRs
fixes #941 


#### What does this implement/fix? Explain your changes.
The Lévy distribution has infinite mean and infinite variance. However, skpro/distributions/levy.py incorrectly listed mean and var under "capabilities:exact". This is misleading because the values returned are simply inf — framework components relying on this tag might assume the exact calculation yields finite, usable numbers.
This PR makes three changes:
Removes mean and var from "capabilities:exact"
Adds "capabilities:undefined": ["mean", "var"], consistent with how Cauchy handles its undefined mean
Adds the missing "distr:paramtype": "parametric" tag, required for framework functions like to_df()


#### Does your contribution introduce a new dependency? If yes, which one?
no

#### What should a reviewer concentrate their feedback on?

1.Verifying the mathematical correctness of moving mean and var to capabilities:undefined
2.Confirming the tag formatting is consistent with how other distributions like Cauchy declare undefined capabilities

#### Did you add any tests for the change?

No new tests were added. The existing automated test framework in skpro/distributions/tests/test_all_distrs.py will automatically validate against the updated capabilities for the Levy distribution.

#### Any other comments?
A screenshot of the fix applied locally is attached below.
<img width="1509" height="958" alt="Screenshot 2026-03-17 at 12 25 35 AM" src="https://github.com/user-attachments/assets/b84dd749-a082-4e3c-acde-dfa0108f2af4" />



#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [X] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [X] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
