### PR TITLE
[MNT] Add missing distr:paramtype to Skellam, GumbelL, GumbelR, FDist, Rayleigh

### DIFF
--- a/skpro/distributions/f_dist.py
+++ b/skpro/distributions/f_dist.py
@@ -32,6 +32,7 @@ class FDist(_ScipyAdapter):
     _tags = {
         "authors": ["arnavk23"],
         "distr:measuretype": "continuous",
+        "distr:paramtype": "parametric",
         "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
         "broadcast_init": "on",
     }

--- a/skpro/distributions/gumbel_l.py
+++ b/skpro/distributions/gumbel_l.py
@@ -43,6 +43,7 @@ class GumbelL(_ScipyAdapter):
     _tags = {
         "authors": ["an1k3sh"],
         "distr:measuretype": "continuous",
+        "distr:paramtype": "parametric",
         "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
         "broadcast_init": "on",
     }

--- a/skpro/distributions/gumbel_r.py
+++ b/skpro/distributions/gumbel_r.py
@@ -43,6 +43,7 @@ class GumbelR(_ScipyAdapter):
     _tags = {
         "authors": ["an1k3sh"],
         "distr:measuretype": "continuous",
+        "distr:paramtype": "parametric",
         "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
         "broadcast_init": "on",
     }

--- a/skpro/distributions/rayleigh.py
+++ b/skpro/distributions/rayleigh.py
@@ -51,6 +51,7 @@ class Rayleigh(BaseDistribution):
             "energy",
         ],
         "distr:measuretype": "continuous",
+        "distr:paramtype": "parametric",
         "broadcast_init": "on",
     }
 

--- a/skpro/distributions/skellam.py
+++ b/skpro/distributions/skellam.py
@@ -29,6 +29,7 @@ class Skellam(_ScipyAdapter):
     _tags = {
         "authors": ["arnavk23"],
         "distr:measuretype": "discrete",
+        "distr:paramtype": "parametric",
         "capabilities:exact": ["mean", "var", "pmf", "log_pmf", "cdf", "ppf"],
         "broadcast_init": "on",
     }


### PR DESCRIPTION
###Description

The `Skellam`, `GumbelL`, `GumbelR`, [FDist](cci:2://file:///Users/ananya/Desktop/GCOS/skpro/skpro/distributions/base/_base.py:1919:0-2049:25), and [Rayleigh](cci:2://file:///Users/ananya/Desktop/GCOS/skpro/skpro/distributions/rayleigh.py:11:0-169:42) distributions were missing the `distr:paramtype` tag. Consequently, they fell back to the base class default `"general"`, instead of `"parametric"`. This PR adds the missing `"distr:paramtype": "parametric"` tag to all 5 distributions to align them with other scipy-backed parametric distributions in the library.


#### Reference Issues/PRs
Fixes #942

#### What does this implement/fix? Explain your changes.
This PR simply adds the missing `"distr:paramtype": "parametric"` tag to the `_tags` dictionary for `Skellam`, `GumbelL`, `GumbelR`, [FDist](cci:2://file:///Users/ananya/Desktop/GCOS/skpro/skpro/distributions/base/_base.py:1919:0-2049:25), and [Rayleigh](cci:2://file:///Users/ananya/Desktop/GCOS/skpro/skpro/distributions/rayleigh.py:11:0-169:42). 


#### Does your contribution introduce a new dependency? If yes, which one?

no

#### What should a reviewer concentrate their feedback on?

Confirming that the correct tag has been added to the respective dictionaries.


#### Did you add any tests for the change?

No new tests needed. The existing automated test suite will correctly validate the tags.


#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->



#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [X] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [X] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
