### PR TITLE
[BUG] burr iii implementation was using the wrong `scipy` method

### DIFF
--- a/skpro/distributions/burr_iii.py
+++ b/skpro/distributions/burr_iii.py
@@ -1,6 +1,6 @@
 """Burr III probability distribution for skpro."""
 
-from scipy.stats import burr12, rv_continuous
+from scipy.stats import burr, rv_continuous
 
 from skpro.distributions.adapters.scipy import _ScipyAdapter
 
@@ -9,16 +9,18 @@ class BurrIII(_ScipyAdapter):
     r"""Burr III probability distribution.
 
     The Burr III distribution is a continuous probability distribution with two
-    parameters: shape parameter $c > 0$ and scale parameter $s > 0$.
+    shape parameters $c > 0$ and $d > 0$ and a scale parameter $s > 0$.
     Its probability density function (PDF) is:
 
     .. math::
-        f(x; c, s) = \frac{c}{s} \left(\frac{x}{s}\right)^{-c-1}
-        \left[1 + \left(\frac{x}{s}\right)^{-c}\right]^{-2}, \quad x > 0
+        f(x; c, d, s) = \frac{c d}{s} \left(\frac{x}{s}\right)^{-c-1}
+        \left[1 + \left(\frac{x}{s}\right)^{-c}\right]^{-d-1}, \quad x > 0
 
     Parameters
     ----------
     c : float
+        Shape parameter
+    d : float
         Shape parameter
     scale : float
         Scale parameter
@@ -31,19 +33,20 @@ class BurrIII(_ScipyAdapter):
         "broadcast_init": "on",
     }
 
-    def __init__(self, c, scale=1.0, index=None, columns=None):
+    def __init__(self, c, d=1.0, scale=1.0, index=None, columns=None):
         self.c = c
+        self.d = d
         self.scale = scale
         super().__init__(index=index, columns=columns)
 
     def _get_scipy_object(self) -> rv_continuous:
-        return burr12
+        return burr
 
     def _get_scipy_param(self):
         c = self._bc_params["c"]
+        d = self._bc_params["d"]
         scale = self._bc_params["scale"]
-        # Burr III is Burr XII with d=1
-        return [], {"c": c, "d": 1, "scale": scale}
+        return [], {"c": c, "d": d, "scale": scale}
 
     def _var(self):
         """Return the variance of the Burr III distribution.
@@ -61,6 +64,6 @@ class BurrIII(_ScipyAdapter):
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Return test parameters for BurrIII."""
-        params1 = {"c": 2.0, "scale": 1.0}
-        params2 = {"c": 3.0, "scale": 2.0}
+        params1 = {"c": 2.0, "d": 3.0, "scale": 1.0}
+        params2 = {"c": 3.0, "d": 2.0, "scale": 2.0}
         return [params1, params2]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skpro.readthedocs.io/en/latest/contribute.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #952. 

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #952 

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
This PR fixes a critical bug in the `BurrIII` distribution class where it incorrectly wrapped `scipy.stats.burr12` (Burr Type XII) instead of `scipy.stats.burr` (Burr Type III). 

Changes made:
- Updated `BurrIII._get_scipy_object` to return `scipy.stats.burr`.
- Updated `BurrIII` to correctly accept both the `c` and `d` shape parameters (previously, `d` was hardcoded to `1`).
- Updated the math docstring and parameter descriptions to reflect the two shape parameters.
- Expanded `get_test_params` to thoroughly test cases where `d != 1.0`.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new core dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core skpro package to a minimum.
-->
No new dependencies.

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
- [x] Correctness of the mathematical documentation in the docstring.
- [x] Confirming that `scipy.stats.burr` behaves as expected with the new `c`, `d`, and `scale` mapping logic.

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->
Yes, the existing generic test suite `test_all_distrs.py` thoroughly verifies the new parameters generated by the updated `get_test_params` class method.

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->
N/A

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).
