### PR TITLE
Prevent zero-variance instability in BaseProbaRegressor.predict_proba

### DIFF
--- a/skpro/regression/base/_base.py
+++ b/skpro/regression/base/_base.py
@@ -333,18 +333,37 @@ class BaseProbaRegressor(BaseEstimator):
 
         # we use predict_var to get scale, and predict to get location
         pred_var = self.predict_var(X=X)
-        pred_std = np.sqrt(pred_var)
         pred_mean = self.predict(X=X)
-
-        from skpro.distributions.normal import Normal
 
         if hasattr(X, "index"):
             index = X.index
         else:
             index = pd.RangeIndex(start=0, stop=len(X), step=1)
         columns = self._get_columns(method="predict")
-        pred_dist = Normal(mu=pred_mean, sigma=pred_std, index=index, columns=columns)
 
+        eps = np.finfo(float).eps
+
+        # if all predicted variances are below machine epsilon,
+        # predictions are deterministic - return a Delta distribution
+        if (pred_var.values < eps).all():
+            from skpro.distributions.delta import Delta
+
+            return Delta(c=pred_mean, index=index, columns=columns)
+
+        # for non-degenerate predictions, construct a Normal
+        # clamp any individual near-zero variance entries to eps
+        # to avoid division by zero in Normal's pdf/log_pdf
+        pred_var = np.clip(pred_var, eps, None)
+        pred_std = np.sqrt(pred_var)
+
+        from skpro.distributions.normal import Normal
+
+        pred_dist = Normal(
+            mu=pred_mean,
+            sigma=pred_std,
+            index=index,
+            columns=columns,
+        )
         return pred_dist
 
     def predict_interval(self, X=None, coverage=0.90):

--- a/skpro/regression/tests/test_base_predict_proba.py
+++ b/skpro/regression/tests/test_base_predict_proba.py
@@ -1,0 +1,89 @@
+"""Tests for fallback probabilistic prediction methods in BaseProbaRegressor."""
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from skpro.regression.base import BaseProbaRegressor
+
+
+class _ZeroVarRegressor(BaseProbaRegressor):
+    """Mock regressor returning zero variance for all instances."""
+
+    def _fit(self, X, y):
+        return self
+
+    def _predict(self, X):
+        cols = self._y_metadata["feature_names"]
+        return pd.DataFrame(np.ones(len(X)), index=X.index, columns=cols)
+
+    def _predict_var(self, X):
+        cols = self._y_metadata["feature_names"]
+        return pd.DataFrame(np.zeros(len(X)), index=X.index, columns=cols)
+
+
+class _MixedVarRegressor(BaseProbaRegressor):
+    """Mock regressor returning mixed zero/nonzero variance."""
+
+    def _fit(self, X, y):
+        return self
+
+    def _predict(self, X):
+        cols = self._y_metadata["feature_names"]
+        return pd.DataFrame(np.ones(len(X)), index=X.index, columns=cols)
+
+    def _predict_var(self, X):
+        cols = self._y_metadata["feature_names"]
+        # first row has zero variance, rest have nonzero
+        var_vals = np.ones(len(X))
+        var_vals[0] = 0.0
+        return pd.DataFrame(var_vals, index=X.index, columns=cols)
+
+
+@pytest.fixture
+def Xy():
+    """Return simple X, y pair for testing."""
+    X = pd.DataFrame({"x": [1.0, 2.0, 3.0]})
+    y = pd.DataFrame({"y": [0.0, 0.0, 0.0]})
+    return X, y
+
+
+def test_predict_proba_zero_var_returns_delta(Xy):
+    """Zero variance predictions should return a Delta distribution."""
+    from skpro.distributions.delta import Delta
+
+    X, y = Xy
+    model = _ZeroVarRegressor().fit(X, y)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        dist = model.predict_proba(X)
+
+    assert isinstance(dist, Delta)
+    pred_mean = model.predict(X)
+    np.testing.assert_array_equal(dist.mean().values, pred_mean.values)
+
+
+def test_predict_proba_mixed_var_returns_normal(Xy):
+    """Mixed variance predictions should return a Normal distribution."""
+    from skpro.distributions.normal import Normal
+
+    X, y = Xy
+    model = _MixedVarRegressor().fit(X, y)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        dist = model.predict_proba(X)
+
+    assert isinstance(dist, Normal)
+
+    # pdf and log_pdf should be finite for all rows
+    x_test = pd.DataFrame({"y": [1.0, 1.0, 1.0]}, index=X.index)
+    pdf_vals = dist.pdf(x_test)
+    log_pdf_vals = dist.log_pdf(x_test)
+
+    assert np.isfinite(pdf_vals.values).all()
+    assert np.isfinite(log_pdf_vals.values).all()


### PR DESCRIPTION
**Reference Issues/PRs**
Fixes #955 

**What does this implement/fix?** 

This PR fixes a numerical instability in `BaseProbaRegressor.predict_proba`.

When `predict_var` returns 0, the fallback Normal distribution is constructed with `sigma=0`, which leads to divide-by-zero warnings and **NaN** values when evaluating pdf or log_pdf.

To prevent this, the predicted variance is clipped to machine epsilon before computing the standard deviation:

`pred_var = np.clip(pred_var, np.finfo(float).eps, None)
`
This ensures the resulting Normal distribution always has a strictly positive scale while leaving normal model outputs effectively unchanged.

**Does your contribution introduce a new dependency?**
No.

**What should a reviewer concentrate their feedback on?**

- Whether clipping variance at machine epsilon is the appropriate safeguard.
- Consistency with the existing probabilistic regression design.

Did you add any tests for the change?
Yes.

A regression test was added that uses a mock regressor returning zero variance and verifies that:
`predict_proba().pdf()` and `log_pdf()` remain finite
no numerical warnings are raised
