### PR TITLE
[BUG] fix scipy scale mapping for HalfNormal/HalfLogistic with regression tests (towards #22)

### DIFF
--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -1,0 +1,32 @@
+# skpro Project Memory
+
+## Running Tests on Windows (IMPORTANT)
+
+`setup.cfg` has `-n auto` in `addopts` which spawns parallel xdist workers.
+On Windows this causes a **stack overflow crash** — not an infinite loop.
+
+**Always use this command pattern to run tests locally:**
+```bash
+python -m pytest <test_file> --override-ini="addopts=" --no-cov -v
+```
+
+Examples:
+```bash
+python -m pytest skpro/distributions/tests/test_halfcauchy.py --override-ini="addopts=" --no-cov -v
+python -m pytest skpro/distributions/tests/test_all_distrs.py -k "HalfCauchy" --override-ini="addopts=" --no-cov -v
+```
+
+## HalfCauchy Distribution
+
+- File: `skpro/distributions/halfcauchy.py`
+- Test file: `skpro/distributions/tests/test_halfcauchy.py`
+- Implementation wraps `scipy.stats.halfcauchy` via `_ScipyAdapter`
+- Parameter: `beta` (scale), mapped to `scale=beta` in scipy
+- All 103 tests pass (test_halfcauchy.py + test_all_distrs.py filtered to HalfCauchy)
+
+## Project Structure
+
+- Repo root: `c:/Users/Kunal Kumar/Desktop/European summer of code/skpro/`
+- Distributions: `skpro/distributions/`
+- Distribution tests: `skpro/distributions/tests/`
+- venv: `c:/Users/Kunal Kumar/Desktop/European summer of code/.venv/`

--- a/skpro/distributions/halflogistic.py
+++ b/skpro/distributions/halflogistic.py
@@ -68,7 +68,7 @@ class HalfLogistic(_ScipyAdapter):
 
     def _get_scipy_param(self):
         beta = self._bc_params["beta"]
-        return [beta], {}
+        return [], {"scale": beta}
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/skpro/distributions/halfnormal.py
+++ b/skpro/distributions/halfnormal.py
@@ -63,7 +63,7 @@ class HalfNormal(_ScipyAdapter):
 
     def _get_scipy_param(self):
         sigma = self._bc_params["sigma"]
-        return [sigma], {}
+        return [], {"scale": sigma}
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/skpro/distributions/tests/test_half_distributions.py
+++ b/skpro/distributions/tests/test_half_distributions.py
@@ -60,6 +60,10 @@ def test_half_broadcast_and_shape(dist_class, scipy_func, param_name, param_arra
     cdf = dist.cdf(x)
     ppf = dist.ppf(p)
 
+    assert isinstance(pdf, pd.DataFrame)
+    assert isinstance(cdf, pd.DataFrame)
+    assert isinstance(ppf, pd.DataFrame)
+
     assert pdf.shape == dist.shape
     assert cdf.shape == dist.shape
     assert ppf.shape == dist.shape

--- a/skpro/distributions/tests/test_half_distributions.py
+++ b/skpro/distributions/tests/test_half_distributions.py
@@ -16,44 +16,42 @@ from skpro.tests.test_switch import run_test_module_changed
     not run_test_module_changed("skpro.distributions"),
     reason="run only if skpro.distributions has been changed",
 )
-def test_halfnormal_scalar_matches_scipy_scale():
-    """HalfNormal scalar pdf/cdf/ppf should match scipy with scale=sigma."""
-    sigma = 2.5
-    dist = HalfNormal(sigma=sigma)
+@pytest.mark.parametrize(
+    "dist_class,scipy_func,param_name,param_value,x,p",
+    [
+        (HalfNormal, halfnorm, "sigma", 2.5, 1.7, 0.8),
+        (HalfLogistic, halflogistic, "beta", 1.8, 1.3, 0.7),
+    ],
+)
+def test_half_scalar_matches_scipy_scale(dist_class, scipy_func, param_name, param_value, x, p):
+    """Half-distributions should match scipy with scale parameter."""
+    dist = dist_class(**{param_name: param_value})
 
-    x = 1.7
-    p = 0.8
-
-    assert_allclose(dist.pdf(x), halfnorm.pdf(x, scale=sigma), rtol=1e-12)
-    assert_allclose(dist.cdf(x), halfnorm.cdf(x, scale=sigma), rtol=1e-12)
-    assert_allclose(dist.ppf(p), halfnorm.ppf(p, scale=sigma), rtol=1e-12)
+    assert_allclose(
+        dist.pdf(x), scipy_func.pdf(x, scale=param_value), rtol=1e-10, atol=1e-14
+    )
+    assert_allclose(
+        dist.cdf(x), scipy_func.cdf(x, scale=param_value), rtol=1e-10, atol=1e-14
+    )
+    assert_allclose(
+        dist.ppf(p), scipy_func.ppf(p, scale=param_value), rtol=1e-10, atol=1e-14
+    )
 
 
 @pytest.mark.skipif(
     not run_test_module_changed("skpro.distributions"),
     reason="run only if skpro.distributions has been changed",
 )
-def test_halflogistic_scalar_matches_scipy_scale():
-    """HalfLogistic scalar pdf/cdf/ppf should match scipy with scale=beta."""
-    beta = 1.8
-    dist = HalfLogistic(beta=beta)
-
-    x = 1.3
-    p = 0.7
-
-    assert_allclose(dist.pdf(x), halflogistic.pdf(x, scale=beta), rtol=1e-12)
-    assert_allclose(dist.cdf(x), halflogistic.cdf(x, scale=beta), rtol=1e-12)
-    assert_allclose(dist.ppf(p), halflogistic.ppf(p, scale=beta), rtol=1e-12)
-
-
-@pytest.mark.skipif(
-    not run_test_module_changed("skpro.distributions"),
-    reason="run only if skpro.distributions has been changed",
+@pytest.mark.parametrize(
+    "dist_class,scipy_func,param_name,param_array",
+    [
+        (HalfNormal, halfnorm, "sigma", [[1.0, 2.0], [3.0, 4.0]]),
+        (HalfLogistic, halflogistic, "beta", [[1.0, 2.0], [3.0, 4.0]]),
+    ],
 )
-def test_halfnormal_broadcast_and_shape():
-    """HalfNormal should preserve broadcasted shape/index/columns."""
-    sigma = [[1.0, 2.0], [3.0, 4.0]]
-    dist = HalfNormal(sigma=sigma)
+def test_half_broadcast_and_shape(dist_class, scipy_func, param_name, param_array):
+    """Half-distributions should preserve broadcasted shape/index/columns."""
+    dist = dist_class(**{param_name: param_array})
 
     x = pd.DataFrame([[0.5, 1.0], [2.0, 3.0]], index=dist.index, columns=dist.columns)
     p = pd.DataFrame([[0.1, 0.2], [0.7, 0.9]], index=dist.index, columns=dist.columns)
@@ -72,39 +70,13 @@ def test_halfnormal_broadcast_and_shape():
     assert cdf.columns.equals(dist.columns)
     assert ppf.columns.equals(dist.columns)
 
-    sigma_np = np.asarray(sigma)
-    assert_allclose(pdf.to_numpy(), halfnorm.pdf(x.to_numpy(), scale=sigma_np), rtol=1e-12)
-    assert_allclose(cdf.to_numpy(), halfnorm.cdf(x.to_numpy(), scale=sigma_np), rtol=1e-12)
-    assert_allclose(ppf.to_numpy(), halfnorm.ppf(p.to_numpy(), scale=sigma_np), rtol=1e-12)
-
-
-@pytest.mark.skipif(
-    not run_test_module_changed("skpro.distributions"),
-    reason="run only if skpro.distributions has been changed",
-)
-def test_halflogistic_broadcast_and_shape():
-    """HalfLogistic should preserve broadcasted shape/index/columns."""
-    beta = [[1.0, 2.0], [3.0, 4.0]]
-    dist = HalfLogistic(beta=beta)
-
-    x = pd.DataFrame([[0.5, 1.0], [2.0, 3.0]], index=dist.index, columns=dist.columns)
-    p = pd.DataFrame([[0.1, 0.2], [0.7, 0.9]], index=dist.index, columns=dist.columns)
-
-    pdf = dist.pdf(x)
-    cdf = dist.cdf(x)
-    ppf = dist.ppf(p)
-
-    assert pdf.shape == dist.shape
-    assert cdf.shape == dist.shape
-    assert ppf.shape == dist.shape
-    assert pdf.index.equals(dist.index)
-    assert cdf.index.equals(dist.index)
-    assert ppf.index.equals(dist.index)
-    assert pdf.columns.equals(dist.columns)
-    assert cdf.columns.equals(dist.columns)
-    assert ppf.columns.equals(dist.columns)
-
-    beta_np = np.asarray(beta)
-    assert_allclose(pdf.to_numpy(), halflogistic.pdf(x.to_numpy(), scale=beta_np), rtol=1e-12)
-    assert_allclose(cdf.to_numpy(), halflogistic.cdf(x.to_numpy(), scale=beta_np), rtol=1e-12)
-    assert_allclose(ppf.to_numpy(), halflogistic.ppf(p.to_numpy(), scale=beta_np), rtol=1e-12)
+    param_np = np.asarray(param_array)
+    assert_allclose(
+        pdf.to_numpy(), scipy_func.pdf(x.to_numpy(), scale=param_np), rtol=1e-10, atol=1e-14
+    )
+    assert_allclose(
+        cdf.to_numpy(), scipy_func.cdf(x.to_numpy(), scale=param_np), rtol=1e-10, atol=1e-14
+    )
+    assert_allclose(
+        ppf.to_numpy(), scipy_func.ppf(p.to_numpy(), scale=param_np), rtol=1e-10, atol=1e-14
+    )

--- a/skpro/distributions/tests/test_half_distributions.py
+++ b/skpro/distributions/tests/test_half_distributions.py
@@ -1,0 +1,110 @@
+"""Regression tests for half-distribution scipy parameter mappings."""
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+
+import numpy as np
+import pandas as pd
+import pytest
+from numpy.testing import assert_allclose
+from scipy.stats import halflogistic, halfnorm
+
+from skpro.distributions.halflogistic import HalfLogistic
+from skpro.distributions.halfnormal import HalfNormal
+from skpro.tests.test_switch import run_test_module_changed
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
+def test_halfnormal_scalar_matches_scipy_scale():
+    """HalfNormal scalar pdf/cdf/ppf should match scipy with scale=sigma."""
+    sigma = 2.5
+    dist = HalfNormal(sigma=sigma)
+
+    x = 1.7
+    p = 0.8
+
+    assert_allclose(dist.pdf(x), halfnorm.pdf(x, scale=sigma), rtol=1e-12)
+    assert_allclose(dist.cdf(x), halfnorm.cdf(x, scale=sigma), rtol=1e-12)
+    assert_allclose(dist.ppf(p), halfnorm.ppf(p, scale=sigma), rtol=1e-12)
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
+def test_halflogistic_scalar_matches_scipy_scale():
+    """HalfLogistic scalar pdf/cdf/ppf should match scipy with scale=beta."""
+    beta = 1.8
+    dist = HalfLogistic(beta=beta)
+
+    x = 1.3
+    p = 0.7
+
+    assert_allclose(dist.pdf(x), halflogistic.pdf(x, scale=beta), rtol=1e-12)
+    assert_allclose(dist.cdf(x), halflogistic.cdf(x, scale=beta), rtol=1e-12)
+    assert_allclose(dist.ppf(p), halflogistic.ppf(p, scale=beta), rtol=1e-12)
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
+def test_halfnormal_broadcast_and_shape():
+    """HalfNormal should preserve broadcasted shape/index/columns."""
+    sigma = [[1.0, 2.0], [3.0, 4.0]]
+    dist = HalfNormal(sigma=sigma)
+
+    x = pd.DataFrame([[0.5, 1.0], [2.0, 3.0]], index=dist.index, columns=dist.columns)
+    p = pd.DataFrame([[0.1, 0.2], [0.7, 0.9]], index=dist.index, columns=dist.columns)
+
+    pdf = dist.pdf(x)
+    cdf = dist.cdf(x)
+    ppf = dist.ppf(p)
+
+    assert pdf.shape == dist.shape
+    assert cdf.shape == dist.shape
+    assert ppf.shape == dist.shape
+    assert pdf.index.equals(dist.index)
+    assert cdf.index.equals(dist.index)
+    assert ppf.index.equals(dist.index)
+    assert pdf.columns.equals(dist.columns)
+    assert cdf.columns.equals(dist.columns)
+    assert ppf.columns.equals(dist.columns)
+
+    sigma_np = np.asarray(sigma)
+    assert_allclose(pdf.to_numpy(), halfnorm.pdf(x.to_numpy(), scale=sigma_np), rtol=1e-12)
+    assert_allclose(cdf.to_numpy(), halfnorm.cdf(x.to_numpy(), scale=sigma_np), rtol=1e-12)
+    assert_allclose(ppf.to_numpy(), halfnorm.ppf(p.to_numpy(), scale=sigma_np), rtol=1e-12)
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
+def test_halflogistic_broadcast_and_shape():
+    """HalfLogistic should preserve broadcasted shape/index/columns."""
+    beta = [[1.0, 2.0], [3.0, 4.0]]
+    dist = HalfLogistic(beta=beta)
+
+    x = pd.DataFrame([[0.5, 1.0], [2.0, 3.0]], index=dist.index, columns=dist.columns)
+    p = pd.DataFrame([[0.1, 0.2], [0.7, 0.9]], index=dist.index, columns=dist.columns)
+
+    pdf = dist.pdf(x)
+    cdf = dist.cdf(x)
+    ppf = dist.ppf(p)
+
+    assert pdf.shape == dist.shape
+    assert cdf.shape == dist.shape
+    assert ppf.shape == dist.shape
+    assert pdf.index.equals(dist.index)
+    assert cdf.index.equals(dist.index)
+    assert ppf.index.equals(dist.index)
+    assert pdf.columns.equals(dist.columns)
+    assert cdf.columns.equals(dist.columns)
+    assert ppf.columns.equals(dist.columns)
+
+    beta_np = np.asarray(beta)
+    assert_allclose(pdf.to_numpy(), halflogistic.pdf(x.to_numpy(), scale=beta_np), rtol=1e-12)
+    assert_allclose(cdf.to_numpy(), halflogistic.cdf(x.to_numpy(), scale=beta_np), rtol=1e-12)
+    assert_allclose(ppf.to_numpy(), halflogistic.ppf(p.to_numpy(), scale=beta_np), rtol=1e-12)


### PR DESCRIPTION
#### Reference Issues/PRs
See #22

#### What does this implement/fix? Explain your changes.
This PR fixes scipy parameter mapping semantics for two half-distributions and adds dedicated regression tests.

Changes:
- `HalfNormal._get_scipy_param`
  - before: `return [sigma], {}`
  - after: `return [], {"scale": sigma}`
- `HalfLogistic._get_scipy_param`
  - before: `return [beta], {}`
  - after: `return [], {"scale": beta}`

These changes align parameter passing with scipy keyword semantics and avoid incorrect positional binding behavior.

Additionally, this PR adds:
- `skpro/distributions/tests/test_half_distributions.py`

The new tests validate:
- scalar parity vs scipy (`pdf`, `cdf`, `ppf`) for `HalfNormal` and `HalfLogistic`
- broadcast/shape/index/columns behavior for both distributions

#### Does your contribution introduce a new dependency? If yes, which one?
No new dependency is introduced.

#### What should a reviewer concentrate their feedback on?
- Correctness of scipy parameter mapping updates in both distributions
- Whether test coverage is sufficient for scalar and broadcasted behavior
- Preferred conventions for grouping multiple distribution regression tests in one file

#### Did you add any tests for the change?
Yes.

Added:
- `skpro/distributions/tests/test_half_distributions.py`

Validation performed locally:
- targeted tests in `test_half_distributions.py` passed
- filtered broader checks in `test_all_distrs.py` for `HalfNormal`/`HalfLogistic` passed

#### Any other comments?
Submitted as part of my ESoC 2026 contributions towards #22.
Happy to iterate quickly on review feedback.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the list of contributors with any new badges I've earned
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].

##### For new estimators
- [ ] Not applicable (this PR fixes existing distributions and adds regression tests)
- [ ] Not applicable
- [ ] Not applicable