### PR TITLE
fix: [BUG] GeneralizedPareto: false log_pdf exact tag, missing

### DIFF
--- a/skpro/distributions/gen_pareto.py
+++ b/skpro/distributions/gen_pareto.py
@@ -21,7 +21,8 @@ class GeneralizedPareto(BaseDistribution):
     _tags = {
         "authors": ["arnavk23"],
         "distr:measuretype": "continuous",
-        "capabilities:exact": ["mean", "var", "pdf", "log_pdf", "cdf", "ppf"],
+        "capabilities:exact": ["mean", "var", "pdf", "cdf", "ppf"],
+        "distr:paramtype": "parametric",
         "broadcast_init": "on",
     }
 
@@ -90,6 +91,15 @@ class GeneralizedPareto(BaseDistribution):
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Return test parameters for GeneralizedPareto."""
-        params1 = {"c": 0.5, "scale": 1.0, "loc": 0.0}
-        params2 = {"c": 1.0, "scale": 2.0, "loc": 1.0}
-        return [params1, params2]
+        import pandas as pd
+
+        params1 = {"c": [[0.5, 0.3], [0.8, 0.4], [0.2, 0.6]], "scale": 1.0, "loc": 0.0}
+        params2 = {
+            "c": 1.0,
+            "scale": 2.0,
+            "loc": 1.0,
+            "index": pd.Index([1, 2, 5]),
+            "columns": pd.Index(["a", "b"]),
+        }
+        params3 = {"c": 0.1, "scale": 0.5, "loc": 0.0}
+        return [params1, params2, params3]


### PR DESCRIPTION
Fixes #961

`GeneralizedPareto` in `skpro/distributions/gen_pareto.py` incorrectly claimed `log_pdf` as an exact capability and was missing the `distr:paramtype` tag entirely. The `log_pdf` method was inherited without a closed-form implementation, making the tag false. Removes `log_pdf` from `capabilities:exact` and adds `"distr:paramtype": "parametric"` to `_tags`. Expands `get_test_params` from 2 to 3 parameter sets, adding array-valued `c` and explicit `index`/`columns` to improve broadcast and shape coverage.