### PR TITLE
[ENH] Remove redundant method overrides in Skellam and FDist

### DIFF
--- a/skpro/distributions/f_dist.py
+++ b/skpro/distributions/f_dist.py
@@ -49,31 +49,6 @@ class FDist(_ScipyAdapter):
         dfd = self._bc_params["dfd"]
         return [], {"dfn": dfn, "dfd": dfd}
 
-    def _pdf(self, x):
-        dfn = self._bc_params["dfn"]
-        dfd = self._bc_params["dfd"]
-        return f.pdf(x, dfn, dfd)
-
-    def _cdf(self, x):
-        dfn = self._bc_params["dfn"]
-        dfd = self._bc_params["dfd"]
-        return f.cdf(x, dfn, dfd)
-
-    def _ppf(self, p):
-        dfn = self._bc_params["dfn"]
-        dfd = self._bc_params["dfd"]
-        return f.ppf(p, dfn, dfd)
-
-    def _mean(self):
-        dfn = self._bc_params["dfn"]
-        dfd = self._bc_params["dfd"]
-        return f.mean(dfn, dfd)
-
-    def _var(self):
-        dfn = self._bc_params["dfn"]
-        dfd = self._bc_params["dfd"]
-        return f.var(dfn, dfd)
-
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Return test parameters for FDist."""

--- a/skpro/distributions/skellam.py
+++ b/skpro/distributions/skellam.py
@@ -46,31 +46,6 @@ class Skellam(_ScipyAdapter):
         mu2 = self._bc_params["mu2"]
         return [mu1, mu2], {}
 
-    def _pmf(self, x):
-        mu1 = self._bc_params["mu1"]
-        mu2 = self._bc_params["mu2"]
-        return skellam.pmf(x, mu1, mu2)
-
-    def _cdf(self, x):
-        mu1 = self._bc_params["mu1"]
-        mu2 = self._bc_params["mu2"]
-        return skellam.cdf(x, mu1, mu2)
-
-    def _ppf(self, p):
-        mu1 = self._bc_params["mu1"]
-        mu2 = self._bc_params["mu2"]
-        return skellam.ppf(p, mu1, mu2)
-
-    def _mean(self):
-        mu1 = self._bc_params["mu1"]
-        mu2 = self._bc_params["mu2"]
-        return skellam.mean(mu1, mu2)
-
-    def _var(self):
-        mu1 = self._bc_params["mu1"]
-        mu2 = self._bc_params["mu2"]
-        return skellam.var(mu1, mu2)
-
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Return test parameters for Skellam."""


### PR DESCRIPTION
### Description

Both `Skellam` and [FDist](cci:2://file:///Users/ananya/Desktop/GCOS/skpro/skpro/distributions/base/_base.py:1919:0-2049:25) distributions extend [_ScipyAdapter](cci:2://file:///Users/ananya/Desktop/GCOS/skpro/skpro/distributions/adapters/scipy/_distribution.py:15:0-89:43) and implement [_get_scipy_param()](cci:1://file:///Users/ananya/Desktop/GCOS/skpro/skpro/distributions/inversegamma.py:60:4-65:47) correctly. However, they both manually overrode [_pmf](cci:1://file:///Users/ananya/Desktop/GCOS/skpro/skpro/distributions/adapters/scipy/_distribution.py:79:4-83:40) / [_pdf](cci:1://file:///Users/ananya/Desktop/GCOS/skpro/skpro/distributions/adapters/scipy/_distribution.py:59:4-62:40), [_cdf](cci:1://file:///Users/ananya/Desktop/GCOS/skpro/skpro/distributions/adapters/scipy/_distribution.py:69:4-72:40), [_ppf](cci:1://file:///Users/ananya/Desktop/GCOS/skpro/skpro/distributions/base/_base.py:1120:4-1186:73), [_mean](cci:1://file:///Users/ananya/Desktop/GCOS/skpro/skpro/distributions/base/_base.py:1370:4-1397:37), and [_var](cci:1://file:///Users/ananya/Desktop/GCOS/skpro/skpro/distributions/chi_squared.py:71:4-79:41) with logic that is completely identical to what the adapter already provides natively.
For example, `Skellam._pmf` manually does:
For example, `Skellam._pmf` manually does:
def _pmf(self, x):
    mu1 = self._bc_params["mu1"]
    mu2 = self._bc_params["mu2"]
    return skellam.pmf(x, mu1, mu2)
But _ScipyAdapter._pmf already does exactly this via  _get_scipy_param() . Since Skellam._get_scipy_param() returns [mu1, mu2], {}, both paths are mathematically identical. These overrides add roughly 25 redundant lines per file with no functional difference whatsoever. This commit removes those redundant methods, letting the _ScipyAdapter
 base class handle them as designed, which significantly reduces code duplication. I validated this locally by removing the overrides and confirming identical outputs before and after.





#### Reference Issues/PRs

Fixes #944


#### What does this implement/fix? Explain your changes.
This PR deletes redundant core distribution method overrides from  skellam.py and f.py (or  f_dist.py), allowing them to cleanly inherit the exact same behavior from _ScipyAdapter.


#### Does your contribution introduce a new dependency? If yes, which one?

no

#### What should a reviewer concentrate their feedback on?

1. Confirming that the removed methods were indeed exactly duplicating the native  _ScipyAdapter behavior.
2. Verifying the CI tests still pass successfully using the inherited adapter methods.

#### Did you add any tests for the change?

No new tests are required because the existing distribution tests in the CI pipeline automatically verify that mean, var,pdf/
pmf, cdf and ppf work correctly, ensuring no functionality is broken by relying on the base class.

#### Any other comments?
The screenshot for the fix has been attatched
<img width="1509" height="958" alt="Screenshot 2026-03-17 at 11 10 11 PM" src="https://github.com/user-attachments/assets/c12a9721-3ae0-4ed0-b473-bbad27169aca" />


#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [X] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [X] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
