### PR TITLE
[BUG] Fix wrong chi-squared identity in ChiSquared._energy_x

### DIFF
--- a/skpro/distributions/chi_squared.py
+++ b/skpro/distributions/chi_squared.py
@@ -54,7 +54,7 @@ class ChiSquared(BaseDistribution):
     Here, :math:`k=dof`
     :math:`x <= 0, \operatorname{energy}(x) = k + \vert x \vert`
     :math:`x > 0, \operatorname{energy}(x) =
-    x*(2*\operatorname{CDF}(k,x)-1)+k-2k*\operatorname{CDF}(k+1,x)`
+    x*(2*\operatorname{CDF}(k,x)-1)+k-2k*\operatorname{CDF}(k+2,x)`
     where :math:`\operatorname{CDF}(k,x)` represents the CDF of x
     for a chi-square distribution with k degrees of freedom.
     """
@@ -173,7 +173,7 @@ class ChiSquared(BaseDistribution):
 
         Closed form implementation based on the formula:
         For x <= 0: energy(x) = k + |x|
-        For x > 0: energy(x) = x*(2*CDF(k,x)-1) + k - 2*k*CDF(k+1,x)
+        For x > 0: energy(x) = x*(2*CDF(k,x)-1) + k - 2*k*CDF(k+2,x)
         where k = degrees of freedom.
         """
         dof = self._bc_params["dof"]
@@ -183,8 +183,8 @@ class ChiSquared(BaseDistribution):
                 return k + abs(xi)
             else:
                 cdf_k = chi2.cdf(xi, k)
-                cdf_k1 = chi2.cdf(xi, k + 1)
-                return xi * (2 * cdf_k - 1) + k - 2 * k * cdf_k1
+                cdf_k2 = chi2.cdf(xi, k + 2)
+                return xi * (2 * cdf_k - 1) + k - 2 * k * cdf_k2
 
         vec_energy = np.vectorize(energy_cell)
         energy_arr = vec_energy(dof, x)


### PR DESCRIPTION
###Description
The closed-form [_energy_x](cci:1://file:///Users/ananya/Desktop/GCOS/skpro/skpro/distributions/inversegaussian.py:113:4-149:21) formula used `chi2.cdf(xi, k + 1)` for the partial expectation integral, but the correct identity is `chi2.cdf(xi, k + 2)`.
This PR fixes the identity and updates the associated docstrings.

This caused silently wrong CRPS/energy scores with errors up to 48%. The fix changes k+1 to k+2 on line 186 and updates both docstrings.



#### Reference Issues/PRs
fixes #964 


#### What does this implement/fix? Explain your changes.
The chi-squared probability density function satisfies the identity:
t · f_χ²(t; k) = k · f_χ²(t; k + 2)

This is easily proved using the relation `Γ(k/2 + 1) = (k/2) · Γ(k/2)`. Integrating both sides yields:
∫₀ˣ t · f_χ²(t; k) dt = k · F_χ²(x; k+2)

The skpro implementation on line 186 mistakenly used `k + 1` for this integral: `cdf_k1 = chi2.cdf(xi, k + 1)`. 
This mathematical error produced **silently incorrect CRPS/energy scores** with errors ranging from 25% to nearly 50%. 
**Changes in this PR:**
1. Changed `cdf_k1 = chi2.cdf(xi, k + 1)` to `cdf_k2 = chi2.cdf(xi, k + 2)`.
2. Updated the class-level docstring to reflect the correct `k+2` formula.
3. Updated the [_energy_x](cci:1://file:///Users/ananya/Desktop/GCOS/skpro/skpro/distributions/inversegaussian.py:113:4-149:21) method docstring.
**Verification:**
I created a verification script that compares the fixed [_energy_x](cci:1://file:///Users/ananya/Desktop/GCOS/skpro/skpro/distributions/inversegaussian.py:113:4-149:21) against direct numerical integration for various values of `k` and `x`. All errors are now at machine precision (< 1e-11).
The screenshot depicting the entire verification has been attatched below:
<img width="1146" height="887" alt="Screenshot 2026-03-18 at 2 22 53 AM" src="https://github.com/user-attachments/assets/37061180-e033-4a18-bbb9-b79a3faa8717" />


#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Verifying the mathematical identity (standard chi-squared partial expectation formula).
- Ensuring the docstring math formatting renders correctly.

#### Did you add any tests for the change?

No explicit new tests added, but the mathematical fix makes the closed-form solution match the numerical ground truth.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [X] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [X] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
