### PR TITLE
[BUG] Fix Pareto _pdf and _log_pdf returning nonzero values outside support

### DIFF
--- a/skpro/distributions/pareto.py
+++ b/skpro/distributions/pareto.py
@@ -108,6 +108,7 @@ class Pareto(BaseDistribution):
         scale = self._bc_params["scale"]
         pdf_arr = alpha * np.power(scale, alpha)
         pdf_arr /= np.power(x, alpha + 1)
+        pdf_arr = np.where(x >= scale, pdf_arr, 0.0)
         return pdf_arr
 
     def _log_pdf(self, x):
@@ -125,7 +126,8 @@ class Pareto(BaseDistribution):
         """
         alpha = self._bc_params["alpha"]
         scale = self._bc_params["scale"]
-        return np.log(alpha / x) + alpha * np.log(scale / x)
+        log_pdf_arr = np.log(alpha / x) + alpha * np.log(scale / x)
+        return np.where(x >= scale, log_pdf_arr, -np.inf)
 
     def _cdf(self, x):
         """Cumulative distribution function.


### PR DESCRIPTION
### Description

The Pareto distribution is defined only for `x >= scale`. However, [_pdf](cci:1://file:///Users/ananya/Desktop/GCOS/skpro/skpro/distributions/adapters/scipy/_distribution.py:59:4-62:40) and [_log_pdf](cci:1://file:///Users/ananya/Desktop/GCOS/skpro/skpro/distributions/rayleigh.py:87:4-96:23) evaluated the formula blindly for all `x`, returning large wrong positive values for `x < scale` (e.g., [pdf(1.0) = 24.0](cci:1://file:///Users/ananya/Desktop/GCOS/skpro/skpro/distributions/base/_base.py:1936:4-1969:42) when `scale=2.0`, should be `0.0`).
This PR adds `np.where` support boundary checks to both methods, matching the pattern already used by [_cdf](cci:1://file:///Users/ananya/Desktop/GCOS/skpro/skpro/distributions/t.py:153:4-174:22) in the same file.



#### Reference Issues/PRs
Fixes #967 
#### What does this implement/fix? Explain your changes.
Added `np.where(x >= scale, ...)` guards to [_pdf](cci:1://file:///Users/ananya/Desktop/GCOS/skpro/skpro/distributions/adapters/scipy/_distribution.py:59:4-62:40) and [_log_pdf](cci:1://file:///Users/ananya/Desktop/GCOS/skpro/skpro/distributions/rayleigh.py:87:4-96:23) in [pareto.py](cci:7://file:///Users/ananya/Desktop/GCOS/skpro/skpro/distributions/pareto.py:0:0-0:0):
- [_pdf](cci:1://file:///Users/ananya/Desktop/GCOS/skpro/skpro/distributions/adapters/scipy/_distribution.py:59:4-62:40): returns `0.0` for `x < scale` (was returning large positive values like 384.0)
- [_log_pdf](cci:1://file:///Users/ananya/Desktop/GCOS/skpro/skpro/distributions/rayleigh.py:87:4-96:23): returns `-np.inf` for `x < scale` (was returning finite positive values like 5.95)
The [_cdf](cci:1://file:///Users/ananya/Desktop/GCOS/skpro/skpro/distributions/t.py:153:4-174:22) method in the same file ([line 145](https://github.com/sktime/skpro/blob/main/skpro/distributions/pareto.py#L145)) already handled this correctly:
```python
cdf_arr = np.where(x < scale, 0, 1 - np.power(scale / x, alpha))
```
The fix simply applies the same pattern to [_pdf](cci:1://file:///Users/ananya/Desktop/GCOS/skpro/skpro/distributions/adapters/scipy/_distribution.py:59:4-62:40) and [_log_pdf](cci:1://file:///Users/ananya/Desktop/GCOS/skpro/skpro/distributions/rayleigh.py:87:4-96:23).
**Verification:**
```
========================================================================
VERIFY FIX: Pareto _pdf support boundary check
Parameters: alpha=3.0, scale=2.0
========================================================================
    x   in support?    skpro _pdf     scipy pdf    status
------------------------------------------------------------------------
  0.5            NO        0.0000        0.0000      PASS
  1.0            NO        0.0000        0.0000      PASS
  1.5            NO        0.0000        0.0000      PASS
  2.0           YES        1.5000        1.5000      PASS
  3.0           YES        0.2963        0.2963      PASS
  5.0           YES        0.0384        0.0384      PASS
------------------------------------------------------------------------
VERIFY FIX: Pareto _log_pdf support boundary check
------------------------------------------------------------------------
  x=0.5  in_support=NO  skpro=      -inf  scipy=      -inf  PASS
  x=1.0  in_support=NO  skpro=      -inf  scipy=      -inf  PASS
  x=1.5  in_support=NO  skpro=      -inf  scipy=      -inf  PASS
  x=2.0  in_support=YES  skpro=    0.4055  scipy=    0.4055  PASS
  x=3.0  in_support=YES  skpro=   -1.2164  scipy=   -1.2164  PASS
------------------------------------------------------------------------
ALL TESTS PASSED -- fix verified
```
Screenshot for the same is attatched below:
<img width="2628" height="1774" alt="image" src="https://github.com/user-attachments/assets/996d4a5c-5221-42f1-b557-ba45af0731d1" />



#### Does your contribution introduce a new dependency? If yes, which one?

no

#### What should a reviewer concentrate their feedback on?

- Verifying the `np.where` guard is placed correctly in both [_pdf](cci:1://file:///Users/ananya/Desktop/GCOS/skpro/skpro/distributions/adapters/scipy/_distribution.py:59:4-62:40) and [_log_pdf](cci:1://file:///Users/ananya/Desktop/GCOS/skpro/skpro/distributions/rayleigh.py:87:4-96:23).
- Confirming consistency with the existing [_cdf](cci:1://file:///Users/ananya/Desktop/GCOS/skpro/skpro/distributions/t.py:153:4-174:22) boundary check.

#### Did you add any tests for the change?

No new tests needed. The existing test suite validates PDF/CDF/PPF correctness for the Pareto distribution.



##### For all contributions
- [X] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [X] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
