### PR TITLE
Fix data leakage in _LifelinesAdapter when y has multiple columns

### DIFF
--- a/skpro/survival/adapters/lifelines.py
+++ b/skpro/survival/adapters/lifelines.py
@@ -111,17 +111,27 @@ class _LifelinesAdapter:
         if hasattr(self, "X_col_subset"):
             X = X[self.X_col_subset]
 
-        to_concat = [X, y]
+        # use only the first column of y as duration
+        y_name = y.columns[0]
+        if y.shape[1] > 1:
+            import warnings
+            warnings.warn(
+                "Multiple columns in y detected. Only the first column is used as duration."
+            )
+        # start with feature dataframe
+        df = X.copy()
 
+        # add ONLY duration column
+        df[y_name] = y[y_name]
+
+        # handle censoring column (event_col)
         if C is not None:
-            C_col = 1 - C.copy()  # lifelines uses 1 for uncensored, 0 for censored
+            C_col = 1 - C.copy()  # lifelines convention
             C_col.columns = ["__C"]
-            to_concat.append(C_col)
-
-        df = pd.concat(to_concat, axis=1)
+            df["__C"] = C_col.iloc[:, 0]        
 
         self._y_cols = y.columns  # remember column names for later
-        y_name = y.columns[0]
+        
 
         fit_args = {
             "df": df,


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #947


#### What does this implement/fix? Explain your changes.

This PR fixes a data leakage issue in `_LifelinesAdapter`.

Previously, when `y` contained multiple columns, all columns were concatenated into the training DataFrame. Since `lifelines` treats any column not specified as `duration_col` or `event_col` as covariates, this caused unintended leakage of target information into the feature set.

The fix ensures that only:
- feature columns from `X`
- the first column of `y` (used as `duration_col`)
- the event column derived from `C` (if provided)

are included in the DataFrame passed to the lifelines estimator.

Additionally, a warning is raised when `y` contains multiple columns to inform the user that only the first column is used.


#### Does your contribution introduce a new dependency? If yes, which one?

No new dependencies are introduced.


#### What should a reviewer concentrate their feedback on?

- Correctness of DataFrame construction in `_fit`
- Whether excluding extra columns from `y` is consistent with expected API behavior
- Handling of censoring column (`C`) and compatibility with lifelines


#### Did you add any tests for the change?

No new tests have been added yet, but the fix has been manually validated using a reproducible example that previously demonstrated leakage.


#### Any other comments?

This fix prevents unintended target leakage and aligns the adapter behavior with lifelines expectations.


#### PR checklist

##### For all contributions
- [ ] I've added myself to the list of contributors
- [x] The PR title starts with [BUG]

##### For new estimators
- [ ] Not applicable