### PR TITLE
[BUG] Fix incorrect variance calculation and capability tagging in Hurdle

### DIFF
--- a/skpro/distributions/hurdle.py
+++ b/skpro/distributions/hurdle.py
@@ -85,7 +85,10 @@ class Hurdle(BaseDistribution):
         # if and only if the capabilities of the inner distribution are exact
         self_exact_capas = self.get_tag("capabilities:exact", []).copy()
         self_approx_capas = self.get_tag("capabilities:approx", []).copy()
-        distr_exact_capas = distribution.get_tag("capabilities:exact", []).copy()
+        
+        # We must inherit exactness from the truncated distribution, NOT the unbound base
+        distr_exact_capas = self._truncated_distribution.get_tag("capabilities:exact", []).copy()
+        
         for capa in self_exact_capas:
             if capa not in distr_exact_capas:
                 self_exact_capas.remove(capa)
@@ -181,7 +184,7 @@ class Hurdle(BaseDistribution):
         mean_positive = self._truncated_distribution.mean()
         var_positive = self._truncated_distribution.var()
 
-        return self.p * var_positive + mean_positive * self.p * (1.0 - self.p)
+        return self.p * var_positive + (mean_positive ** 2) * self.p * (1.0 - self.p)
 
     def _ppf(self, p):
         prob_zero = 1.0 - self.p


### PR DESCRIPTION


<!--
Thanks for cont
<img width="1512" height="937" alt="Screenshot 2026-03-20 at 2 23 44 AM" src="https://github.com/user-attachments/assets/c252b944-d4e3-4350-ad90-ecd35b79f467" />
ributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skpro.readthedocs.io/en/latest/contribute.html
-->

#### Reference Issues/PRs
fixes #972 


#### What does this implement/fix? Explain your changes.

This PR fixes an issue in the `Hurdle` distribution where the variance was being computed incorrectly.  
The current implementation uses `p * var_positive + p * (1 - p) * mean_positive`, but the mean term should be squared. This was leading to significant underestimation of the variance. The formula has been corrected to use `(mean_positive ** 2)` in line with the law of total variance.

I also updated how capability tags are determined. Previously, `Hurdle` checked the base distribution to decide whether `mean`/`var` are exact, but since it internally wraps the distribution using `LeftTruncated`, those values are actually computed via numerical approximation. The tags now reflect this correctly by checking the truncated distribution instead.


#### Does your contribution introduce a new dependency? If yes, which one?

No

#### What should a reviewer concentrate their feedback on?

- Whether the updated variance formula aligns with expected behavior across different base distributions  
- Whether capability tagging should consistently be based on the internally used truncated distribution  

#### Did you add any tests for the change?

I verified the fix using Monte Carlo simulation (100k samples), where the empirical variance now matches the analytical result within tolerance. No new formal unit tests have been added yet.

#### Any other comments?

A screenshot showing the before/after behavior has also been added for clarity.

<img width="1512" height="937" alt="Screenshot 2026-03-20 at 2 23 44 AM" src="https://github.com/user-attachments/assets/c252b944-d4e3-4350-ad90-ecd35b79f467" />


#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [X] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [X] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
