### PR TITLE
[ENH]: Make PinballLoss missing alpha error message more informative

### DIFF
--- a/skpro/metrics/_classes.py
+++ b/skpro/metrics/_classes.py
@@ -127,9 +127,8 @@ class PinballLoss(BaseProbaMetric):
             # if alpha was provided, check whether  they are predicted
             #   if not all alpha are observed, raise a ValueError
             if not np.isin(alpha, y_pred_alphas).all():
-                # todo: make error msg more informative
-                #   which alphas are missing
-                msg = "not all quantile values in alpha are available in y_pred"
+                missing_alphas = list(set(alpha) - set(y_pred_alphas))
+                msg = f"not all quantile values in alpha are available in y_pred. Missing alphas: {missing_alphas}."
                 raise ValueError(msg)
             else:
                 alphas = alpha

--- a/skpro/metrics/tests/test_probabilistic_metrics.py
+++ b/skpro/metrics/tests/test_probabilistic_metrics.py
@@ -210,7 +210,7 @@ def test_evaluate_alpha_positive(Metric, y_pred, y_true):
 )
 def test_evaluate_alpha_negative(Metric, y_pred, y_true):
     """Tests whether correct error raised when required quantile not present."""
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=".*Missing alphas:.*"):
         # 0.3 not in test quantile data so raise error.
         Loss = Metric.create_test_instance().set_params(alpha=0.3)
         res = Loss(y_true=y_true, y_pred=y_pred)  # noqa


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #977

#### What does this implement/fix? Explain your changes.
This PR enhances the `ValueError` message raised by the `PinballLoss` metric when one or more requested `alpha` quantiles are missing from the given predictions (`y_pred`). 

Previously, the error message was generic and did not specify which alphas were missing, requiring manual debugging. This resolves an active `TODO` in `skpro/metrics/_classes.py` to make the error message more informative.

**Changes:**
* Modified `PinballLoss._evaluate_by_index` to compute the set difference between requested `alpha` and available `y_pred_alphas`.
* Updated the error string to explicitly list the missing values.

- **Old Error Message:** `ValueError: "not all quantile values in alpha are available in y_pred"`
- **New Error Message:** `ValueError: "not all quantile values in alpha are available in y_pred. Missing alphas: [0.1, 0.9]"`

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
- The string formatting of the new `ValueError` message in `PinballLoss`.
- The logic used to identify missing alphas (set difference).

#### Did you add any tests for the change?
Yes, I have updated `test_evaluate_alpha_negative` in `test_probabilistic_metrics.py` to use `pytest.raises(ValueError, match=".*Missing alphas:.*")`. This ensures the new informative message is correctly triggered and verified.

#### Any other comments?
All probabilistic metrics tests passed successfully on my local machine using `pytest`.

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-) (Badge: `code`)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. (Using **[ENH]**)

##### For new estimators
- [ ] I've added the estimator to the API reference. (N/A - existing estimator)
- [ ] I've added illustrative usage examples to the docstring. (N/A)
- [ ] I've set the `python_dependencies` tag for soft dependencies. (N/A)