### PR TITLE
[BUG] Fix backward independence routing in Mixture sample

### DIFF
--- a/skpro/distributions/mixture.py
+++ b/skpro/distributions/mixture.py
@@ -221,9 +221,9 @@ class Mixture(BaseMetaObject, BaseDistribution):
         rd_size[0] *= N
         full_size[0] *= N
 
-        if indep_rows:
+        if not indep_rows:
             rd_size[0] = 1
-        if indep_cols:
+        if not indep_cols:
             rd_size[1] = 1
 
         n_dist = len(self._distributions)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skpro.readthedocs.io/en/latest/contribute.html
-->

#### Reference Issues/PRs

fixes #974 


#### What does this implement/fix? Explain your changes.

This PR fixes an issue in `Mixture._sample` where the `indep_rows` and `indep_cols` flags were handled in reverse.

Previously, the implementation set `rd_size[...] = 1` when the independence flags were `True`, which caused `np.random.choice` to draw a single component and broadcast it across the dimension, making it fully dependent. When the flags were `False`, the full dimension was retained, resulting in independent sampling instead.

This PR corrects the logic by inverting the condition:

```python
if not indep_rows:
    rd_size[0] = 1
if not indep_cols:
    rd_size[1] = 1
```

This restores the intended behavior where independence retains full sampling dimensions and dependence enforces broadcasting.
#### Does your contribution introduce a new dependency? If yes, which one?
No


#### What should a reviewer concentrate their feedback on?

- Whether the updated logic correctly reflects the intended behavior of `indep_rows` and `indep_cols`
- Whether the change is consistent with other sampling implementations in the codebase

#### Did you add any tests for the change?

Tested locally using larger mixture arrays (e.g., 20x2). The output matches expectations:
- dependent settings produce identical rows
- independent settings produce varied rows

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->
A verification screenshot demonstrating the behavior has also been attached for reference.
<img width="1252" height="914" alt="Screenshot 2026-03-20 at 11 48 05 AM" src="https://github.com/user-attachments/assets/07a2eefa-8544-40e0-946f-fc686fdee635" />

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [X] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [X] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--


Thanks for contributing!
-->
