### PR TITLE
[BUG] fix test_discrete_pmf_plotting assertion, resolves #918

### DIFF
--- a/skpro/distributions/tests/test_proba_basic.py
+++ b/skpro/distributions/tests/test_proba_basic.py
@@ -141,7 +141,6 @@ def test_proba_plotting(fun):
     assert isinstance(ax, Axes)
 
 
-@pytest.mark.skip(reason="Undiagnosed failure. Skipping until resolved. See #918.")
 @pytest.mark.skipif(
     not _check_soft_dependencies("matplotlib", severity="none"),
     reason="skip if matplotlib is not available",
@@ -160,14 +159,20 @@ def test_discrete_pmf_plotting():
     # Check that stem plot was used (should have containers)
     assert len(ax.containers) > 0, "Stem plot should be used for discrete PMF"
 
-    # For small distributions, check that all support points are plotted
-    # Binomial(n=10) has support [0,1,2,...,10] = 11 points
-    # The stem plot should have evaluated at these points
-    if hasattr(ax.containers[0], "get_children"):
-        # This is a rough check - the stem plot should have multiple elements
-        assert (
-            len(ax.containers[0].get_children()) > 5
-        ), "Should plot at multiple support points"
+    # For small distributions, check that all support points are plotted.
+    # Binomial(n=10) has support [0, 1, 2, ..., 10] = 11 points.
+    # A StemContainer always has exactly 3 children (markerline, stemlines,
+    # baseline) regardless of the number of data points. The correct way to
+    # count plotted points is via stemlines.get_segments().
+    stem_container = ax.containers[0]
+    assert hasattr(
+        stem_container, "stemlines"
+    ), "Expected StemContainer from stem plot, check _plot_single uses ax.stem"
+    n_plotted = len(stem_container.stemlines.get_segments())
+    assert n_plotted > 5, (
+        f"Should plot at multiple support points, got {n_plotted}. "
+        "Binomial(n=10) has 11 support points (0..10)."
+    )
 
 
 def test_to_df_parametric():


### PR DESCRIPTION
## Summary

Fixes #918.

The [test_discrete_pmf_plotting](cci:1://file:///C:/Users/rupes/Desktop/projects/SKPRO/skpro/distributions/tests/test_proba_basic.py:143:0-174:5) test was failing because the assertion
incorrectly checked `len(ax.containers[0].get_children()) > 5`.

A matplotlib `StemContainer` **always has exactly 3 children**
(markerline, stemlines, baseline), regardless of how many data points
are plotted. So the check was always `3 > 5 = False`.

## Fix

- Removed the `@pytest.mark.skip` decorator added as a workaround in #918.
- Replaced the broken assertion with
  `len(stem_container.stemlines.get_segments()) > 5`, which correctly
  counts the number of plotted support points. For `Binomial(n=10)`,
  this is 11 (support is {0, 1, ..., 10}).

## PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  - Badge: `bug` (diagnosed and fixed a bug) + `code`
- [x] The PR title starts with `[BUG]`
