### PR TITLE
fix(regression): return variance (σ²) instead of std dev (σ) in DummyProbaRegressor._predict_var

### DIFF
--- a/skpro/regression/dummy.py
+++ b/skpro/regression/dummy.py
@@ -126,7 +126,7 @@ class DummyProbaRegressor(BaseProbaRegressor):
         X_ind = X.index
         X_n_rows = X.shape[0]
         y_pred = pd.DataFrame(
-            np.ones(X_n_rows) * self._sigma, index=X_ind, columns=self._y_columns
+            np.ones(X_n_rows) * self._sigma**2, index=X_ind, columns=self._y_columns
         )
         return y_pred
 


### PR DESCRIPTION
## Problem

`DummyProbaRegressor._predict_var` returns the standard deviation (σ) of the training labels instead of the variance (σ²). This is a unit-mismatch bug — `predict_var` should return variance, not standard deviation.

## Solution

Changed `self._sigma` to `self._sigma ** 2` in `_predict_var`, so the method correctly returns variance (σ²) as documented.

## Files Changed

- `skpro/regression/dummy.py`: Fixed `_predict_var` to return `self._sigma ** 2` instead of `self._sigma`

## Verification

```python
import numpy as np
# Before fix: _predict_var returns np.std(y) ≈ σ
# After fix: _predict_var returns np.std(y) ** 2 ≈ σ² (variance)
```

Closes #975