### PR TITLE
 [ENH] Addition of Set representation and support-aware plotting

### DIFF
--- a/skpro/distributions/base/__init__.py
+++ b/skpro/distributions/base/__init__.py
@@ -2,8 +2,30 @@
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 # adapted from sktime
 
-__all__ = ["BaseDistribution", "_DelegatedDistribution", "_BaseArrayDistribution"]
+__all__ = [
+    "BaseDistribution",
+    "_DelegatedDistribution",
+    "_BaseArrayDistribution",
+    "BaseSet",
+    "IntervalSet",
+    "FiniteSet",
+    "IntegerSet",
+    "UnionSet",
+    "IntersectionSet",
+    "EmptySet",
+    "RealSet",
+]
 
 from skpro.distributions.base._base import BaseDistribution
 from skpro.distributions.base._base_array import _BaseArrayDistribution
 from skpro.distributions.base._delegate import _DelegatedDistribution
+from skpro.distributions.base._set import (
+    BaseSet,
+    EmptySet,
+    FiniteSet,
+    IntegerSet,
+    IntersectionSet,
+    IntervalSet,
+    RealSet,
+    UnionSet,
+)

--- a/skpro/distributions/base/_base.py
+++ b/skpro/distributions/base/_base.py
@@ -1355,6 +1355,44 @@ class BaseDistribution(BaseObject):
         else:
             return spl.mean().iloc[0]
 
+    @property
+    def support(self):
+        """Return the support of the distribution as a symbolic set.
+
+        The support is the smallest closed set whose complement has
+        probability zero.
+
+        Returns
+        -------
+        BaseSet
+            Symbolic set representation of the distribution's support.
+
+        Examples
+        --------
+        >>> from skpro.distributions.normal import Normal
+        >>> n = Normal(mu=0, sigma=1)
+        >>> n.support
+        RealSet()
+        """
+        return self._support()
+
+    def _support(self):
+        r"""Return the support of the distribution.
+
+        Private method, to be overridden by subclasses.
+
+        Default returns ``RealSet``, appropriate for continuous distributions
+        with support on all of :math:`\\mathbb{R}` (e.g., Normal, Cauchy).
+
+        Returns
+        -------
+        BaseSet
+            The support of this distribution.
+        """
+        from skpro.distributions.base._set import RealSet
+
+        return RealSet(index=self.index, columns=self.columns)
+
     def mean(self):
         r"""Return expected value of the distribution.
 
@@ -1696,8 +1734,7 @@ class BaseDistribution(BaseObject):
 
         if self.ndim > 0:
             if "x_bounds" not in kwargs:
-                upper = self.ppf(0.999).values.flatten().max()
-                lower = self.ppf(0.001).values.flatten().min()
+                lower, upper = self._get_plot_bounds()
                 x_bounds = (lower, upper)
             else:
                 x_bounds = kwargs.pop("x_bounds")
@@ -1755,8 +1792,43 @@ class BaseDistribution(BaseObject):
         ax = getattr(self, plot_fun_name)(ax=ax, fun=fun, **kwargs)
         return ax
 
+    def _get_plot_bounds(self):
+        """Get x-axis bounds for plotting using support information.
+
+        Uses ``support.boundary()`` for exact bounds when available.
+        Falls back to ``ppf(0.001)``/``ppf(0.999)`` for infinite or
+        unavailable bounds.
+
+        Returns
+        -------
+        tuple of (lower, upper)
+            x-axis bounds for plotting.
+        """
+        lower, upper = None, None
+        supp = getattr(self, "support", None)
+
+        if supp is not None and hasattr(supp, "boundary"):
+            bd = supp.boundary()
+            if isinstance(bd, tuple) and len(bd) == 2:
+                lower = float(bd[0]) if not np.isinf(bd[0]) else None
+                upper = float(bd[1]) if not np.isinf(bd[1]) else None
+
+        # fall back to ppf for any missing bounds
+        if lower is None or upper is None:
+            ppf_low = self.ppf(0.001)
+            ppf_high = self.ppf(0.999)
+            if self.ndim > 0:
+                ppf_low = ppf_low.values.flatten().min()
+                ppf_high = ppf_high.values.flatten().max()
+            if lower is None:
+                lower = float(ppf_low)
+            if upper is None:
+                upper = float(ppf_high)
+
+        return lower, upper
+
     def _plot_single(self, ax=None, **kwargs):
-        """Plot the pdf of the distribution."""
+        """Plot the distribution function, handling discrete/continuous/mixed types."""
         import matplotlib.pyplot as plt
 
         fun = kwargs.pop("fun")
@@ -1767,25 +1839,60 @@ class BaseDistribution(BaseObject):
         if "x_bounds" in kwargs:
             lower, upper = kwargs.pop("x_bounds")
         elif fun != "ppf":
-            lower, upper = self.ppf(0.001), self.ppf(0.999)
-
-        if fun == "ppf":
+            lower, upper = self._get_plot_bounds()
+        else:
             lower, upper = 0.001, 0.999
-
-        is_discrete = self.get_tag("distr:measuretype", "mixed") == "discrete"
-
-        x_arr = self._get_x_for_plot(fun, lower, upper, is_discrete)
-
-        y_arr = [getattr(self, fun)(x) for x in x_arr]
-        y_arr = np.array(y_arr)
 
         if ax is None:
             ax = plt.gca()
 
-        # Use stem plot for discrete PMF, line plot otherwise
-        if is_discrete and fun == "pmf":
-            ax.stem(x_arr, y_arr, basefmt=" ", **kwargs)
+        measuretype = self.get_tag("distr:measuretype", "mixed")
+
+        if measuretype == "discrete":
+            # pure discrete: stem plot at exact support points
+            x_arr = self._get_discrete_support_points(lower, upper)
+            y_arr = np.array([getattr(self, fun)(x) for x in x_arr])
+            if fun == "pmf":
+                ax.stem(x_arr, y_arr, basefmt=" ", **kwargs)
+            elif fun == "cdf":
+                ax.step(x_arr, y_arr, where="post", **kwargs)
+            else:
+                ax.plot(x_arr, y_arr, **kwargs)
+
+        elif measuretype == "mixed":
+            # mixed distribution (e.g., ZeroInflated):
+            discrete_pts = self._get_discrete_support_points(lower, upper)
+
+            # 1. plot the continuous part as a line (if pdf or cdf)
+            x_cont = np.linspace(lower, upper, 1000)
+            if fun in ("pdf", "cdf"):
+                y_cont = np.array([getattr(self, fun)(x) for x in x_cont])
+
+                # Mask out continuous density overlapping exactly with Dirac spikes
+                if fun == "pdf" and len(discrete_pts) > 0:
+                    for pt in discrete_pts:
+                        y_cont[np.isclose(x_cont, pt, atol=1e-3)] = np.nan
+
+                ax.plot(x_cont, y_cont, **kwargs)
+
+            # 2. always overlay discrete mass points as stems
+            if len(discrete_pts) > 0:
+                # get the mass at these points from pmf
+                y_disc = np.array([self.pmf(x) for x in discrete_pts])
+                # use different style from line to distinguish
+                stem_kwargs = {k: v for k, v in kwargs.items() if k != "label"}
+                ax.stem(
+                    discrete_pts,
+                    y_disc,
+                    basefmt=" ",
+                    linefmt="C1-",
+                    markerfmt="C1o",
+                    **stem_kwargs,
+                )
         else:
+            # pure continuous: dense line plot
+            x_arr = np.linspace(lower, upper, 1000)
+            y_arr = np.array([getattr(self, fun)(x) for x in x_arr])
             ax.plot(x_arr, y_arr, **kwargs)
 
         if print_labels == "on":
@@ -1793,15 +1900,47 @@ class BaseDistribution(BaseObject):
             ax.set_ylabel(f"{fun}({x_argname})")
         return ax
 
-    def _get_x_for_plot(self, fun, lower, upper, is_discrete):
-        """Get x values for plotting, handling discrete distributions for PMF."""
-        # general case: not discrete, or not pmf
-        if not is_discrete or fun != "pmf":
-            # in this case, the function is on a continuous domain,
-            # so we can plot on a dense grid of points
-            return np.linspace(lower, upper, 1000)
+    def _get_discrete_support_points(self, lower, upper, max_points=1000):
+        """Get discrete support points within bounds for plotting.
 
-        # special case: discrete distribution and pmf - plot at the support points
+        Inspects the distribution support for FiniteSet or IntegerSet components.
+        Falls back to _pmf_support() or integer grid if no such components are found.
+        """
+        from skpro.distributions.base._set import FiniteSet, IntegerSet, UnionSet
+
+        pts = []
+        supp = getattr(self, "support", None)
+
+        if supp is not None:
+            # Flatten to check components (handles UnionSet natively)
+            sets_to_check = supp.sets if isinstance(supp, UnionSet) else [supp]
+            for s in sets_to_check:
+                if isinstance(s, FiniteSet):
+                    s_vals = s.values
+                    pts.extend(s_vals[(s_vals >= lower) & (s_vals <= upper)])
+                elif isinstance(s, IntegerSet):
+                    lo = max(int(np.floor(lower)) - 1, int(s.lower))
+                    hi_bound = s.upper
+                    hi = min(
+                        int(np.ceil(upper)) + 1,
+                        int(hi_bound) if not np.isinf(hi_bound) else lo + max_points,
+                    )
+                    pts.extend(range(lo, hi + 1))
+
+        if pts:
+            pts_arr = np.array(pts)
+            # Filter out points failing inclusion bounds (Open vs Closed)
+            if supp is not None:
+                mask = [np.all(supp.contains(p)) for p in pts_arr]
+                pts_arr = pts_arr[mask]
+
+            # Unify sub-precision duplicate stems
+            if len(pts_arr) > 0:
+                _, unique_idx = np.unique(
+                    np.round(pts_arr, decimals=8), return_index=True
+                )
+                return np.sort(pts_arr[unique_idx])
+            return np.array([])
 
         # Define fallback array construction (used when _pmf_support not available)
         def _get_fallback_arr():
@@ -1809,15 +1948,15 @@ class BaseDistribution(BaseObject):
             arr = np.round(arr).astype(int)
             return np.unique(arr)
 
-        # Use _pmf_support if the method exists and is callable
+        # fallback: use _pmf_support or integer rounding
         if hasattr(self, "_pmf_support") and callable(self._pmf_support):
-            x_arr = self._pmf_support(lower, upper, max_points=1000)
+            x_arr = self._pmf_support(lower, upper, max_points=max_points)
             if x_arr.size != 0:
                 return x_arr
 
         return _get_fallback_arr()
 
-    def _pmf_support(self, lower, upper, max_points=100):
+    def _pmf_support(self, lower, upper, max_points=1000):
         """Get support points for discrete distributions.
 
         Returns the support points of the probability mass function (PMF)

--- a/skpro/distributions/base/_set.py
+++ b/skpro/distributions/base/_set.py
@@ -1,0 +1,888 @@
+"""Symbolic set representations for distribution supports."""
+
+__author__ = ["khushmagrawal"]
+
+__all__ = [
+    "BaseSet",
+    "IntervalSet",
+    "FiniteSet",
+    "IntegerSet",
+    "UnionSet",
+    "IntersectionSet",
+    "EmptySet",
+    "RealSet",
+]
+
+import numpy as np
+import pandas as pd
+
+from skpro.base import BaseObject
+from skpro.distributions.base._base import _coerce_to_pd_index_or_none
+
+
+class BaseSet(BaseObject):
+    """Base class for symbolic set representations.
+
+    All set subclasses inherit from ``BaseSet``, gaining access to tags
+    (``is_discrete``, ``is_continuous``) and tabular shape information
+    (``index``, ``columns``).
+
+    Sets are "shape-aware": a single set object can describe the support
+    for an entire tabular distribution by storing its parameters as arrays
+    matching the distribution's ``(n_rows, n_cols)`` shape.
+
+    Parameters
+    ----------
+    index : pd.Index, optional, default = None
+        Row index of the distribution this set describes.
+    columns : pd.Index, optional, default = None
+        Column index of the distribution this set describes.
+    """
+
+    _tags = {
+        "object_type": "set",
+        "is_discrete": False,
+        "is_continuous": False,
+    }
+
+    def __init__(self, index=None, columns=None):
+        self.index = _coerce_to_pd_index_or_none(index)
+        self.columns = _coerce_to_pd_index_or_none(columns)
+
+        self._shape: tuple = ()
+        if self.index is None and self.columns is None:
+            pass
+        else:
+            row_len = len(self.index) if self.index is not None else 0
+            col_len = len(self.columns) if self.columns is not None else 0
+            if self.index is not None and self.columns is None:
+                col_len = 1
+            self._shape = (row_len, col_len)
+
+        super().__init__()
+
+    @property
+    def shape(self):
+        """Shape of self, a pair (2-tuple) or empty tuple if scalar."""
+        return self._shape
+
+    @property
+    def ndim(self):
+        """Number of dimensions of self. 2 if array, 0 if scalar."""
+        return len(self._shape)
+
+    def __contains__(self, item):
+        """Check membership using ``in`` operator.
+
+        Delegates to ``self.contains(item)``.
+        """
+        return self.contains(item)
+
+    def contains(self, x):
+        """Check whether ``x`` is contained in the set.
+
+        Parameters
+        ----------
+        x : scalar, np.ndarray, or pd.DataFrame
+            Point(s) to check for membership.
+
+        Returns
+        -------
+        bool, np.ndarray of bool, or pd.DataFrame of bool
+            Membership mask, same shape as ``x`` (or scalar if ``x`` is scalar).
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not implement 'contains'."
+        )
+
+    def boundary(self):
+        """Return the boundary of the set.
+
+        Returns
+        -------
+        depends on subclass
+            Representation of the set's boundary.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not implement 'boundary'."
+        )
+
+    def __str__(self):
+        """Return a human-readable string representation."""
+        return self.__class__.__name__
+
+    def __repr__(self):
+        """Return a developer-readable string representation."""
+        return f"{self.__class__.__name__}()"
+
+    def _align_output(self, res, x):
+        """Restore Pandas metadata for x and ensure minimal broadcast shape."""
+        if getattr(res, "ndim", 0) == 0 and self.ndim > 0:
+            res = np.full(self.shape, res, dtype=bool)
+
+        if isinstance(x, pd.DataFrame):
+            if getattr(res, "ndim", 1) == 1 and len(x.columns) > 1:
+                res = np.tile(np.asarray(res).reshape(-1, 1), (1, len(x.columns)))
+            return pd.DataFrame(res, index=x.index, columns=x.columns)
+        elif isinstance(x, pd.Series):
+            return pd.Series(res, index=x.index, name=x.name)
+        return res
+
+    def _get_bc_params(self, *args, oned_as="col"):
+        """Broadcast set parameters against index and columns.
+
+        Mirrors the broadcasting logic of ``BaseDistribution._get_bc_params``:
+        reshapes index as column vector ``(-1, 1)`` and columns as row vector,
+        then calls ``np.broadcast_arrays`` to expand all parameters to
+        the full ``(n_rows, n_cols)`` shape.
+
+        Parameters
+        ----------
+        args : floats, ints, or array-like
+            Set parameters to broadcast.
+        oned_as : str, optional, default="col"
+            If ``"col"``, 1D arrays are treated as column vectors.
+
+        Returns
+        -------
+        tuple of np.ndarray
+            Broadcasted parameter arrays, same length as ``args``.
+        """
+
+        def _to_col(arr):
+            if arr.ndim == 1 and oned_as == "col":
+                return arr.reshape(-1, 1)
+            return arr
+
+        args_np = [_to_col(np.asarray(a)) for a in args]
+
+        if self.index is not None:
+            args_np.append(self.index.to_numpy().reshape(-1, 1))
+        if self.columns is not None:
+            args_np.append(self.columns.to_numpy())
+
+        bc = np.broadcast_arrays(*args_np)
+        # return only the parameter arrays, not the index/columns anchors
+        return bc[: len(args)]
+
+
+class IntervalSet(BaseSet):
+    r"""Interval of the real line.
+
+    Represents a set of the form :math:`(a, b)`, :math:`[a, b]`,
+    :math:`[a, b)`, or :math:`(a, b]`, where
+    :math:`a, b \in \mathbb{R} \cup \{-\infty, +\infty\}`.
+
+    Boundaries ``lower`` and ``upper`` can be scalars (applying to all
+    entries of a tabular distribution) or arrays matching the
+    distribution's ``(n_rows, n_cols)`` shape.
+
+    Parameters
+    ----------
+    lower : float or array-like
+        Lower bound of the interval.
+    upper : float or array-like
+        Upper bound of the interval.
+    interval_type : str, optional, default = "[]"
+        Type of interval boundary.
+        One of ``"[]"`` (closed), ``"()"`` (open),
+        ``"[)"`` (left-closed), ``"(]"`` (right-closed).
+        Matches the notation used by ``TruncatedDistribution``.
+    index : pd.Index, optional, default = None
+    columns : pd.Index, optional, default = None
+
+    Examples
+    --------
+    >>> from skpro.distributions.base._set import IntervalSet
+
+    >>> s = IntervalSet(lower=0, upper=1, interval_type="[]")
+    >>> s.contains(0.5)
+    True
+    >>> s.contains(-1)
+    False
+    """
+
+    _tags = {
+        "is_continuous": True,
+    }
+
+    _VALID_INTERVAL_TYPES = {"[]", "()", "[)", "(]"}
+
+    def __init__(self, lower, upper, interval_type="[]", index=None, columns=None):
+        self.lower = lower
+        self.upper = upper
+        self.interval_type = interval_type
+
+        itype_arr = np.asarray(interval_type)
+        if not np.all(np.isin(itype_arr, list(self._VALID_INTERVAL_TYPES))):
+            raise ValueError(
+                f"interval_type must be one of {self._VALID_INTERVAL_TYPES}, "
+                f"but got '{interval_type}'."
+            )
+
+        super().__init__(index=index, columns=columns)
+        if self.ndim > 0:
+            self._get_bc_params(self.lower, self.upper)
+
+    def contains(self, x):
+        """Check whether ``x`` is contained in the interval.
+
+        Parameters
+        ----------
+        x : scalar, np.ndarray, or pd.DataFrame
+            Point(s) to check for membership.
+
+        Returns
+        -------
+        bool, np.ndarray of bool, or pd.DataFrame of bool
+            Membership mask.
+        """
+        x_is_df = isinstance(x, pd.DataFrame)
+        if x_is_df:
+            x_vals = x.values
+        else:
+            x_vals = np.asarray(x)
+
+        if self.ndim > 0:
+            lower, upper = self._get_bc_params(self.lower, self.upper)
+        else:
+            lower = np.asarray(self.lower, dtype=float)
+            upper = np.asarray(self.upper, dtype=float)
+
+        if self.ndim > 0 and x_vals.ndim == 1:
+            x_vals = x_vals.reshape(-1, 1)
+
+        itype = self.interval_type
+        if itype == "[]":
+            res = (x_vals >= lower) & (x_vals <= upper)
+        elif itype == "()":
+            res = (x_vals > lower) & (x_vals < upper)
+        elif itype == "[)":
+            res = (x_vals >= lower) & (x_vals < upper)
+        elif itype == "(]":
+            res = (x_vals > lower) & (x_vals <= upper)
+
+        if isinstance(res, bool) or getattr(res, "ndim", 0) == 0:
+            res = bool(res)
+        return self._align_output(res, x)
+
+    def boundary(self):
+        """Return the boundary of the interval.
+
+        Returns
+        -------
+        tuple of (lower, upper)
+            The interval endpoints.
+        """
+        return self.lower, self.upper
+
+    def __str__(self):
+        """Return a human-readable string representation."""
+        if not np.isscalar(self.lower) or not np.isscalar(self.upper):
+            shape_str = f", shape={self.shape}" if self.ndim > 0 else ""
+            return f"IntervalSet(tabular{shape_str})"
+
+        lower = float(self.lower) if np.isscalar(self.lower) else self.lower
+        upper = float(self.upper) if np.isscalar(self.upper) else self.upper
+        return f"{self.interval_type[0]}{lower}, " f"{upper}{self.interval_type[1]}"
+
+    def __repr__(self):
+        """Return a developer-readable string representation."""
+        return (
+            f"IntervalSet(lower={self.lower!r}, upper={self.upper!r}, "
+            f"interval_type={self.interval_type!r})"
+        )
+
+
+class FiniteSet(BaseSet):
+    r"""Finite set of the real line.
+
+    Represents a discrete set of the form :math:`\{a_1, \ldots, a_n\}`,
+    where :math:`a_1, \ldots, a_n \in \mathbb{R}`.
+
+    For tabular distributions, ``values`` is a flat list or 1D array of all
+    possible support points. The same set of points applies to every entry
+    of the distribution table — this is the common case for distributions
+    like ``Poisson``, ``Binomial``, or ``Delta``.
+
+    Parameters
+    ----------
+    values : list of int or float, or 1D array-like
+        The elements contained in the set.
+    index : pd.Index, optional, default = None
+    columns : pd.Index, optional, default = None
+
+    Examples
+    --------
+    >>> from skpro.distributions.base._set import FiniteSet
+
+    >>> s = FiniteSet(values=[0, 1, 2])
+    >>> s.contains(1)
+    True
+    >>> s.contains(4)
+    False
+    """
+
+    _tags = {
+        "is_discrete": True,
+    }
+
+    def __init__(self, values, index=None, columns=None):
+        vals_arr = np.asarray(values)
+
+        # Disambiguate global declarations
+        # list like [1,2,3] is treated as global set(all row share same values)
+        # [[1,2],[3,4]] is treated as tabular set (each row has different values)
+        if vals_arr.dtype == object or vals_arr.ndim >= 2:
+            self.values = vals_arr
+            if vals_arr.ndim >= 2 and vals_arr.dtype != object:
+                self.values = np.empty(len(vals_arr), dtype=object)
+                for i in range(len(vals_arr)):
+                    self.values[i] = list(vals_arr[i])
+        else:
+            self.values = np.asarray(values, dtype=float)
+
+        super().__init__(index=index, columns=columns)
+
+        if self.ndim > 0 and self.values.dtype == object:
+            self._get_bc_params(self.values)
+
+    def contains(self, x):
+        """Check whether ``x`` is contained in the set.
+
+        Parameters
+        ----------
+        x : scalar, np.ndarray, or pd.DataFrame
+            Point(s) to check for membership.
+
+        Returns
+        -------
+        bool, np.ndarray of bool, or pd.DataFrame of bool
+            Membership mask.
+        """
+        x_is_df = isinstance(x, pd.DataFrame)
+        x_vals = x.values if x_is_df else np.asarray(x)
+
+        if self.ndim > 0 and x_vals.ndim == 1:
+            x_vals = x_vals.reshape(-1, 1)
+
+        if self.values.dtype == object:
+            if self.ndim > 0:
+                (values_bc,) = self._get_bc_params(self.values)
+            else:
+                values_bc = self.values
+
+            def _in_set(val, allowed):
+                if hasattr(allowed, "item"):
+                    allowed = allowed.item()
+                try:
+                    return val in list(allowed)
+                except TypeError:
+                    return False
+
+            vfunc = np.vectorize(_in_set, otypes=[bool])
+            res = vfunc(x_vals, values_bc)
+        else:
+            res = np.isin(x_vals, self.values)
+
+        if isinstance(res, bool) or getattr(res, "ndim", 0) == 0:
+            res = bool(res)
+
+        return self._align_output(res, x)
+
+    def boundary(self):
+        """Return the boundary of the set.
+
+        Returns
+        -------
+        tuple of (lower, upper)
+            The minimum and maximum limits of the discrete elements.
+        """
+        if self.values.dtype == object:
+            if self.ndim > 0:
+                (values_bc,) = self._get_bc_params(self.values)
+            else:
+                values_bc = self.values
+
+            def _min_set(s):
+                if hasattr(s, "item"):
+                    s = s.item()
+                lst = list(s)
+                return float(np.min(lst)) if len(lst) > 0 else np.nan
+
+            def _max_set(s):
+                if hasattr(s, "item"):
+                    s = s.item()
+                lst = list(s)
+                return float(np.max(lst)) if len(lst) > 0 else np.nan
+
+            vfunc_min = np.vectorize(_min_set, otypes=[float])
+            vfunc_max = np.vectorize(_max_set, otypes=[float])
+            return vfunc_min(values_bc), vfunc_max(values_bc)
+        else:
+            if len(self.values) == 0:
+                raise ValueError("FiniteSet is empty, so it has no boundaries.")
+            return np.min(self.values), np.max(self.values)
+
+    def __str__(self):
+        """Return a human-readable string representation."""
+        sorted_vals = sorted(self.values)
+        return "{" + ", ".join(str(v) for v in sorted_vals) + "}"
+
+    def __repr__(self):
+        """Return a developer-readable string representation."""
+        return f"FiniteSet(values={self.values.tolist()!r})"
+
+
+class IntegerSet(BaseSet):
+    r"""Set of consecutive integers.
+
+    Represents a set of the form :math:`\{a, a+1, a+2, \ldots, b\}`,
+    where :math:`a, b \in \mathbb{Z} \cup \{-\infty, +\infty\}`.
+
+    This is the correct support representation for discrete distributions
+    with integer-valued support, such as ``Poisson`` (``{0, 1, 2, ...}``),
+    ``Binomial`` (``{0, 1, ..., n}``), or ``Geometric`` (``{0, 1, 2, ...}``).
+
+    Unlike ``FiniteSet``, this class can represent **countably infinite** sets
+    by setting ``upper=np.inf``. Unlike ``IntervalSet``, this class is tagged
+    ``is_discrete=True`` and its ``contains`` method checks for integer values.
+
+    Parameters
+    ----------
+    lower : int or array-like, optional, default = 0
+        Lower bound of the integer range (inclusive).
+    upper : int, float, or array-like, optional, default = np.inf
+        Upper bound of the integer range (inclusive).
+        Use ``np.inf`` for unbounded above.
+    index : pd.Index, optional, default = None
+    columns : pd.Index, optional, default = None
+
+    Examples
+    --------
+    >>> from skpro.distributions.base._set import IntegerSet
+
+    >>> s = IntegerSet(lower=0)  # {0, 1, 2, ...}
+    >>> s.contains(3)
+    True
+    >>> s.contains(3.5)
+    False
+    """
+
+    _tags = {
+        "is_discrete": True,
+    }
+
+    def __init__(self, lower=0, upper=np.inf, index=None, columns=None):
+        self.lower = lower
+        self.upper = upper
+
+        super().__init__(index=index, columns=columns)
+
+        # Fail Fast: crash if parameter arrays don't broadcast to tabular shape
+        if self.ndim > 0:
+            self._get_bc_params(self.lower, self.upper)
+
+    def contains(self, x):
+        """Check whether ``x`` is contained in the integer set.
+
+        Returns ``True`` for values that are integer-valued and
+        within ``[lower, upper]``.
+
+        Parameters
+        ----------
+        x : scalar, np.ndarray, or pd.DataFrame
+            Point(s) to check for membership.
+
+        Returns
+        -------
+        bool, np.ndarray of bool, or pd.DataFrame of bool
+            Membership mask.
+        """
+        x_is_df = isinstance(x, pd.DataFrame)
+        if x_is_df:
+            x_vals = x.values
+        else:
+            x_vals = np.asarray(x, dtype=float)
+
+        if self.ndim > 0:
+            lower, upper = self._get_bc_params(self.lower, self.upper)
+        else:
+            lower = np.asarray(self.lower, dtype=float)
+            upper = np.asarray(self.upper, dtype=float)
+
+        if self.ndim > 0 and x_vals.ndim == 1:
+            x_vals = x_vals.reshape(-1, 1)
+
+        # check integer-valued: x == floor(x)
+        is_int = np.equal(x_vals, np.floor(x_vals))
+        in_range = (x_vals >= lower) & (x_vals <= upper)
+        res = is_int & in_range
+
+        if isinstance(res, bool) or getattr(res, "ndim", 0) == 0:
+            res = bool(res)
+        return self._align_output(res, x)
+
+    def boundary(self):
+        """Return the boundary of the integer set.
+
+        Returns
+        -------
+        tuple of (lower, upper)
+            The integer range endpoints.
+        """
+        return self.lower, self.upper
+
+    def __str__(self):
+        """Return a human-readable string representation."""
+        if not np.isscalar(self.lower) or not np.isscalar(self.upper):
+            shape_str = f", shape={self.shape}" if self.ndim > 0 else ""
+            return f"IntegerSet(tabular{shape_str})"
+
+        lower = int(self.lower) if np.isfinite(self.lower) else self.lower
+        upper = int(self.upper) if np.isfinite(self.upper) else "∞"
+        nxt = lower + 1 if np.isfinite(self.lower) else "..."
+        return "{" + f"{lower}, {nxt}, ..., {upper}" + "}"
+
+    def __repr__(self):
+        """Return a developer-readable string representation."""
+        return f"IntegerSet(lower={self.lower!r}, upper={self.upper!r})"
+
+
+class UnionSet(BaseSet):
+    r"""Union of multiple sets.
+
+    Represents :math:`A_1 \\cup A_2 \\cup \\ldots \\cup A_n`.
+
+    This is the key class for mixed distributions (e.g., ``ZeroInflated``),
+    where the support is the union of a discrete mass point
+    and a continuous interval.
+
+    The ``contains`` method returns the logical **OR** of the children's
+    ``contains`` results.
+
+    Parameters
+    ----------
+    sets : positional args of BaseSet
+        The component sets to take the union of.
+    index : pd.Index, optional, default = None
+    columns : pd.Index, optional, default = None
+
+    Examples
+    --------
+    >>> from skpro.distributions.base._set import FiniteSet, IntervalSet, UnionSet
+
+    >>> s = UnionSet(FiniteSet([0]), IntervalSet(1, 5, "()"))
+    >>> s.contains(0)
+    True
+    >>> s.contains(3)
+    True
+    >>> s.contains(0.5)
+    False
+    """
+
+    def __init__(self, *sets, index=None, columns=None):
+        self.sets = sets
+        super().__init__(index=index, columns=columns)
+
+        # dynamic tag aggregation
+        is_discrete = any(s.get_tag("is_discrete", raise_error=False) for s in sets)
+        is_continuous = any(s.get_tag("is_continuous", raise_error=False) for s in sets)
+        self.set_tags(**{"is_discrete": is_discrete, "is_continuous": is_continuous})
+
+    def contains(self, x):
+        """Check whether ``x`` is in the union (logical OR).
+
+        Parameters
+        ----------
+        x : scalar, np.ndarray, or pd.DataFrame
+            Point(s) to check for membership.
+
+        Returns
+        -------
+        bool, np.ndarray of bool, or pd.DataFrame of bool
+            Membership mask.
+        """
+        x_is_df = isinstance(x, pd.DataFrame)
+        results = []
+        for s in self.sets:
+            if x_is_df and s.index is not None:
+                # Align the heterogeneous dataframe boundaries before querying
+                x_s = x.reindex(index=s.index, columns=s.columns)
+                results.append(s.contains(x_s))
+            else:
+                results.append(s.contains(x))
+
+        is_df = any(isinstance(r, pd.DataFrame) for r in results)
+        is_series = any(isinstance(r, pd.Series) for r in results)
+
+        if is_df or is_series:
+            res = results[0]
+            for i in range(1, len(results)):
+                # Pandas automatically merges DataFrames handling alignments
+                res = res | results[i]
+        else:
+            res = results[0]
+            for i in range(1, len(results)):
+                res = np.logical_or(res, results[i])
+
+        return self._align_output(res, x)
+
+    def boundary(self):
+        """Return the union of boundaries.
+
+        Returns
+        -------
+        tuple of (lower, upper)
+            The global min and max of all component set boundaries.
+        """
+        lowers = []
+        uppers = []
+        for s in self.sets:
+            try:
+                l, u = s.boundary()
+                if l is not None and u is not None:
+                    lowers.append(np.asarray(l))
+                    uppers.append(np.asarray(u))
+            except (NotImplementedError, TypeError, ValueError):
+                continue
+
+        if not lowers:
+            raise NotImplementedError("None of the component sets provide a boundary.")
+
+        l_bc = np.broadcast_arrays(*lowers)
+        u_bc = np.broadcast_arrays(*uppers)
+        return np.min(l_bc, axis=0), np.max(u_bc, axis=0)
+
+    def __str__(self):
+        """Return a human-readable string representation."""
+        return " ∪ ".join(str(s) for s in self.sets)
+
+    def __repr__(self):
+        """Return a developer-readable string representation."""
+        sets_repr = ", ".join(repr(s) for s in self.sets)
+        return f"UnionSet({sets_repr})"
+
+
+class IntersectionSet(BaseSet):
+    r"""Intersection of multiple sets.
+
+    Represents :math:`A_1 \\cap A_2 \\cap \\ldots \\cap A_n`.
+
+    This is the key class for truncated distributions, where the support
+    is the intersection of the base distribution's support and the
+    truncation interval. This avoids manual boundary recalculation.
+
+    The ``contains`` method returns the logical **AND** of the children's
+    ``contains`` results.
+
+    Parameters
+    ----------
+    sets : positional args of BaseSet
+        The component sets to take the intersection of.
+    index : pd.Index, optional, default = None
+    columns : pd.Index, optional, default = None
+
+    Examples
+    --------
+    >>> from skpro.distributions.base._set import FiniteSet, IntersectionSet
+    >>> from skpro.distributions.base._set import IntervalSet
+
+    >>> base = FiniteSet([0, 1, 2, 3, 4, 5])
+    >>> trunc = IntervalSet(2.5, 5.5, "[]")
+    >>> s = IntersectionSet(base, trunc)
+    >>> s.contains(3)
+    True
+    >>> s.contains(1)
+    False
+    """
+
+    def __init__(self, *sets, index=None, columns=None):
+        self.sets = sets
+        super().__init__(index=index, columns=columns)
+
+        # dynamic tag aggregation
+        is_discrete = all(s.get_tag("is_discrete", raise_error=False) for s in sets)
+        is_continuous = all(s.get_tag("is_continuous", raise_error=False) for s in sets)
+        self.set_tags(**{"is_discrete": is_discrete, "is_continuous": is_continuous})
+
+    def contains(self, x):
+        """Check whether ``x`` is in the intersection (logical AND).
+
+        Parameters
+        ----------
+        x : scalar, np.ndarray, or pd.DataFrame
+            Point(s) to check for membership.
+
+        Returns
+        -------
+        bool, np.ndarray of bool, or pd.DataFrame of bool
+            Membership mask.
+        """
+        x_is_df = isinstance(x, pd.DataFrame)
+        results = []
+        for s in self.sets:
+            if x_is_df and s.index is not None:
+                x_s = x.reindex(index=s.index, columns=s.columns)
+                results.append(s.contains(x_s))
+            else:
+                results.append(s.contains(x))
+
+        is_df = any(isinstance(r, pd.DataFrame) for r in results)
+        is_series = any(isinstance(r, pd.Series) for r in results)
+
+        if is_df or is_series:
+            res = results[0]
+            for i in range(1, len(results)):
+                res = res & results[i]
+        else:
+            res = results[0]
+            for i in range(1, len(results)):
+                res = np.logical_and(res, results[i])
+
+        return self._align_output(res, x)
+
+    def boundary(self):
+        """Return the intersection of boundaries.
+
+        Returns
+        -------
+        tuple of (lower, upper)
+            The intersection of all component set boundaries.
+        """
+        lowers = []
+        uppers = []
+        for s in self.sets:
+            try:
+                l, u = s.boundary()
+                if l is not None and u is not None:
+                    lowers.append(np.asarray(l))
+                    uppers.append(np.asarray(u))
+            except (NotImplementedError, TypeError, ValueError):
+                continue
+
+        if not lowers:
+            raise NotImplementedError("None of the component sets provide a boundary.")
+
+        l_bc = np.broadcast_arrays(*lowers)
+        u_bc = np.broadcast_arrays(*uppers)
+
+        out_lower = np.max(l_bc, axis=0)
+        out_upper = np.min(u_bc, axis=0)
+
+        # Discard invalid overlapping segments (Null Intersections)
+        empty_mask = out_lower > out_upper
+        out_lower = np.where(empty_mask, np.nan, out_lower)
+        out_upper = np.where(empty_mask, np.nan, out_upper)
+
+        if not empty_mask.shape and empty_mask:
+            out_lower, out_upper = np.nan, np.nan
+
+        return out_lower, out_upper
+
+    def __str__(self):
+        """Return a human-readable string representation."""
+        return " ∩ ".join(str(s) for s in self.sets)
+
+    def __repr__(self):
+        """Return a developer-readable string representation."""
+        sets_repr = ", ".join(repr(s) for s in self.sets)
+        return f"IntersectionSet({sets_repr})"
+
+
+class EmptySet(BaseSet):
+    """The empty set.
+
+    ``contains`` always returns ``False``.
+
+    Parameters
+    ----------
+    index : pd.Index, optional, default = None
+    columns : pd.Index, optional, default = None
+    """
+
+    def __init__(self, index=None, columns=None):
+        super().__init__(index=index, columns=columns)
+
+    def contains(self, x):
+        """Check whether ``x`` is in the empty set (always False).
+
+        Parameters
+        ----------
+        x : scalar, np.ndarray, or pd.DataFrame
+            Point(s) to check for membership.
+
+        Returns
+        -------
+        bool, np.ndarray of bool, or pd.DataFrame of bool
+            Always False.
+        """
+        if hasattr(x, "shape") and getattr(x, "ndim", 0) > 0:
+            res = np.zeros(x.shape, dtype=bool)
+        else:
+            res = False
+        return self._align_output(res, x)
+
+    def boundary(self):
+        """Return the boundary (empty)."""
+        return np.array([])
+
+    def __str__(self):
+        """Return a human-readable string representation."""
+        return "∅"
+
+    def __repr__(self):
+        """Return a developer-readable string representation."""
+        return "EmptySet()"
+
+
+class RealSet(BaseSet):
+    r"""The set of all real numbers :math:`\mathbb{R}`.
+
+    ``contains`` always returns ``True``.
+    This is the default support for unbounded continuous distributions
+    like ``Normal`` or ``Cauchy``.
+
+    Parameters
+    ----------
+    index : pd.Index, optional, default = None
+    columns : pd.Index, optional, default = None
+    """
+
+    _tags = {
+        "is_continuous": True,
+    }
+
+    def __init__(self, index=None, columns=None):
+        super().__init__(index=index, columns=columns)
+
+    def contains(self, x):
+        r"""Check whether ``x`` is in :math:`\mathbb{R}` (always True).
+
+        Parameters
+        ----------
+        x : scalar, np.ndarray, or pd.DataFrame
+            Point(s) to check for membership.
+
+        Returns
+        -------
+        bool, np.ndarray of bool, or pd.DataFrame of bool
+            Always True.
+        """
+        if hasattr(x, "shape") and getattr(x, "ndim", 0) > 0:
+            res = np.ones(x.shape, dtype=bool)
+        else:
+            res = True
+        return self._align_output(res, x)
+
+    def boundary(self):
+        """Return the boundary (-inf, +inf)."""
+        return -np.inf, np.inf
+
+    def __str__(self):
+        """Return a human-readable string representation."""
+        return "ℝ"
+
+    def __repr__(self):
+        """Return a developer-readable string representation."""
+        return "RealSet()"

--- a/skpro/distributions/base/tests/test_set.py
+++ b/skpro/distributions/base/tests/test_set.py
@@ -1,0 +1,408 @@
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+"""Tests for symbolic set representations."""
+
+__author__ = ["khushmagrawal"]
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from skpro.distributions.base._set import (
+    BaseSet,
+    EmptySet,
+    FiniteSet,
+    IntegerSet,
+    IntersectionSet,
+    IntervalSet,
+    RealSet,
+    UnionSet,
+)
+
+
+@pytest.fixture
+def sample_indices():
+    """Sample index and columns for tabular tests."""
+    return pd.Index([0, 1, 2], name="rows"), pd.Index(["a", "b"], name="cols")
+
+
+@pytest.fixture
+def multiindex_data():
+    """MultiIndex and DataFrame for indexing tests."""
+    ix = pd.MultiIndex.from_product([["A", "B"], [1, 2]], names=["L1", "L2"])
+    cols = pd.Index(["v1", "v2"])
+    df = pd.DataFrame(np.random.randn(4, 2), index=ix, columns=cols)
+    return ix, cols, df
+
+
+# Instances for generic interface testing
+def get_all_set_types():
+    return [
+        IntervalSet(0, 1),
+        FiniteSet([0, 1]),
+        IntegerSet(0, 10),
+        EmptySet(),
+        RealSet(),
+        UnionSet(FiniteSet([0]), IntervalSet(1, 2)),
+        IntersectionSet(IntervalSet(0, 10), IntervalSet(5, 15)),
+    ]
+
+
+class TestSetInterface:
+    """Generic tests for the BaseSet interface across all subclasses."""
+
+    @pytest.mark.parametrize("s", get_all_set_types())
+    def test_metadata_scalar(self, s):
+        """Test shape and ndim for scalar sets."""
+        assert s.shape == ()
+        assert s.ndim == 0
+        assert s.index is None
+        assert s.columns is None
+
+    @pytest.mark.parametrize(
+        "s_cls", [IntervalSet, FiniteSet, IntegerSet, EmptySet, RealSet]
+    )
+    def test_index_coercion(self, s_cls):
+        """Test that list inputs for index/columns are coerced to pd.Index."""
+        if s_cls in (IntervalSet, IntegerSet):
+            s = s_cls(0, 1, index=[0, 1], columns=["a"])
+        elif s_cls == FiniteSet:
+            s = s_cls([0], index=[0, 1], columns=["a"])
+        else:
+            s = s_cls(index=[0, 1], columns=["a"])
+
+        assert isinstance(s.index, pd.Index)
+        assert isinstance(s.columns, pd.Index)
+        assert s.shape == (2, 1)
+
+    @pytest.mark.parametrize("s", get_all_set_types())
+    def test_serialization(self, s):
+        """Test str and repr output something sensible."""
+        assert isinstance(str(s), str)
+        assert len(str(s)) > 0
+        assert s.__class__.__name__ in repr(s)
+
+    @pytest.mark.parametrize("s", get_all_set_types())
+    def test_output_format_consistency(self, s):
+        """Verify: scalar in -> bool out; array in -> array out; DF in -> DF out."""
+        # 1. Scalar
+        assert isinstance(s.contains(0.5), (bool, np.bool_))
+
+        # 2. Numpy array
+        x_np = np.array([0, 0.5, 1])
+        res_np = s.contains(x_np)
+        assert isinstance(res_np, np.ndarray)
+        assert res_np.dtype == bool
+        assert res_np.shape == (3,)
+
+        # 3. DataFrame (scalar set)
+        x_df = pd.DataFrame({"a": [0, 1], "b": [0.5, 2]})
+        res_df = s.contains(x_df)
+        assert isinstance(res_df, pd.DataFrame)
+        assert res_df.shape == (2, 2)
+        assert res_df.index.equals(x_df.index)
+
+    def test_base_set_defaults(self):
+        """Check BaseSet defaults and abstract behavior."""
+        s = BaseSet()
+        assert s.get_tag("is_discrete") is False
+        assert s.get_tag("is_continuous") is False
+        with pytest.raises(NotImplementedError):
+            s.contains(0)
+
+
+class TestTabularAndBroadcasting:
+    """Focus on 2D sets, alignment, and MultiIndex support."""
+
+    def test_tabular_contains_alignment(self, sample_indices):
+        """Verify that contains aligns input DataFrame to set index/columns."""
+        idx, cols = sample_indices
+        s = IntervalSet(0, 5, index=idx, columns=cols)
+
+        # Input has same shape but different order
+        x = pd.DataFrame({"b": [1, 2, 3], "a": [6, 0, 1]}, index=[2, 0, 1])
+        res = s.contains(x)
+
+        # Result should match input's index/columns
+        assert res.index.equals(x.index)
+        assert res.columns.equals(x.columns)
+
+        # Value check: x.loc[2, 'a'] is 6 (Out), s.loc[2, 'a'] is [0, 5]
+        assert bool(res.loc[2, "a"]) is False
+        assert bool(res.loc[0, "a"]) is True
+
+    def test_scalar_set_broadcasting_to_df(self):
+        """Scalar set should broadcast its logic to any input shape."""
+        s = IntegerSet(lower=0, upper=10)
+        x = pd.DataFrame({"a": [1, 11], "b": [5, -1]})
+        res = s.contains(x)
+        expected = pd.DataFrame({"a": [True, False], "b": [True, False]})
+        pd.testing.assert_frame_equal(res, expected)
+
+    def test_multiindex_support(self, multiindex_data):
+        """Sets should handle MultiIndex in both definition and input."""
+        ix, cols, df = multiindex_data
+        s = IntervalSet(0, 1, index=ix, columns=cols)
+
+        assert s.shape == (4, 2)
+        res = s.contains(df)
+        assert isinstance(res, pd.DataFrame)
+        assert isinstance(res.index, pd.MultiIndex)
+        assert res.index.equals(ix)
+
+    def test_vectorized_boundaries(self, sample_indices):
+        """IntervalSet with array-like boundaries (vectorized set)."""
+        idx, cols = sample_indices
+        # Row 0: [0, 5], Row 1: [10, 15], Row 2: [20, 25] (broadcast across columns)
+        s = IntervalSet(lower=[0, 10, 20], upper=[5, 15, 25], index=idx, columns=cols)
+        x = pd.DataFrame([[3, 3], [12, 12], [22, 100]], index=idx, columns=cols)
+        res = s.contains(x)
+        expected = pd.DataFrame(
+            [[True, True], [True, True], [True, False]], index=idx, columns=cols
+        )
+        pd.testing.assert_frame_equal(res, expected)
+
+
+# -----------------------------------------------------------------------------
+# Subclass Specific Testing
+# -----------------------------------------------------------------------------
+
+
+class TestIntervalSet:
+    """Interval specific logic (open/closed, boundaries)."""
+
+    @pytest.mark.parametrize(
+        "type_str, inner, left, right",
+        [
+            ("[]", True, True, True),
+            ("()", True, False, False),
+            ("[)", True, True, False),
+            ("(]", True, False, True),
+        ],
+    )
+    def test_boundary_inclusivity(self, type_str, inner, left, right):
+        """Test Open/Closed math boundaries."""
+        s = IntervalSet(0, 5, interval_type=type_str)
+        assert s.contains(2.5) == inner
+        assert s.contains(0) == left
+        assert s.contains(5) == right
+
+    def test_edge_cases(self):
+        """Test Infinity and NaN boundaries."""
+        # Inf
+        s_inf = IntervalSet(-np.inf, np.inf)
+        assert s_inf.contains(1e10) is True
+        assert s_inf.boundary() == (-np.inf, np.inf)
+
+        # NaN
+        s_nan = IntervalSet(np.nan, np.nan)
+        assert s_nan.contains(0) is False
+
+        # Half-bounded
+        s_half = IntervalSet(0, np.inf, "[)")
+        assert s_half.contains(0) is True
+        assert s_half.contains(-1) is False
+
+    def test_interval_type_broadcast(self):
+        """Test interval_type broadcasting logic."""
+        # Using a scalar interval type cleanly handles bounding logics uniformly
+        s = IntervalSet([0, 0], [10, 10], interval_type="()", index=[1, 2])
+        res = s.contains(pd.DataFrame({"a": [0, 0]}, index=[1, 2]))
+        assert bool(res.iloc[0, 0]) is False
+        assert bool(res.iloc[1, 0]) is False
+
+    def test_lazy_evaluation_shape_mismatch(self):
+        """Test lazy evaluation shape mismatch initialization."""
+        with pytest.raises(ValueError, match="broadcast"):
+            IntervalSet([0, 1], [10, 20], index=[1, 2, 3])
+
+
+class TestFiniteSet:
+    """Specifics for set of discrete points."""
+
+    def test_membership(self):
+        """Test explicit floating inclusions."""
+        s = FiniteSet([1, 2, 4.5])
+        assert s.contains(1) is True
+        assert s.contains(3) is False
+        assert s.contains(4.5) is True
+        assert s.get_tag("is_discrete") is True
+
+    def test_boundary(self):
+        """Test accurate reduction of set components."""
+        s = FiniteSet([10, 2, 5])
+        # FiniteSet boundaries are simply (min, max)
+        l, u = s.boundary()
+        np.testing.assert_array_equal(l, 2)
+        np.testing.assert_array_equal(u, 10)
+
+    def test_multiindex_flattening(self, multiindex_data):
+        """Test MultiIndex flattening over tabular arrays."""
+        ix, cols, df = multiindex_data
+        s = FiniteSet(
+            np.array([[1], [2], [3], [4]], dtype=object), index=ix, columns=cols
+        )
+        res = s.contains(df)
+        assert res.index.equals(ix)
+
+    def test_finiteset_tabular_evaluation(self):
+        """Test FiniteSet values tabular broadcasting."""
+        vals = np.empty((2, 1), dtype=object)
+        vals[0, 0] = [1, 2]
+        vals[1, 0] = [3, 4]
+        s = FiniteSet(vals, index=[1, 2], columns=["a"])
+        res = s.contains(pd.DataFrame({"a": [2, 2]}, index=[1, 2]))
+        assert bool(res.iloc[0, 0]) is True
+        assert bool(res.iloc[1, 0]) is False
+
+        # Test boundary mathematical extraction
+        l, u = s.boundary()
+        np.testing.assert_array_equal(l, [[1], [3]])
+        np.testing.assert_array_equal(u, [[2], [4]])
+
+
+class TestIntegerSet:
+    """Specifics for countably infinite/finite integer sets."""
+
+    def test_integer_logic(self):
+        """Ensure math accurately rejects precision floats."""
+        s = IntegerSet(lower=0, upper=5)
+        assert s.contains(3) is True
+        assert s.contains(3.1) is False
+        assert s.contains(-1) is False
+        assert s.contains(6) is False
+        assert s.get_tag("is_discrete") is True
+
+    def test_metadata_preserved_in_contains(self):
+        """Test metadata preservation across Pandas structures."""
+        s = IntegerSet(0, 10)
+        df = pd.DataFrame({"A": [1, 2], "B": [3, 4]}, index=["p1", "p2"])
+        res = s.contains(df)
+        assert isinstance(res, pd.DataFrame)
+        assert list(res.columns) == ["A", "B"]
+        assert list(res.index) == ["p1", "p2"]
+
+
+class TestEmptySet:
+    """Specifics for completely unpopulated boundaries."""
+
+    def test_emptyset_tabular_scalar_query(self):
+        """Test EmptySet ignores shape via pd.Index properties."""
+        s_empty = EmptySet(index=[1, 2, 3])
+        res_empty = s_empty.contains(5)
+        assert res_empty.shape == (3, 1)
+
+
+class TestRealSet:
+    """Specifics for totally unrestricted boundaries."""
+
+    def test_realset_tabular_scalar_query(self):
+        """Test RealSet ignores shape via pd.Index properties."""
+        s_real = RealSet(index=[1, 2, 3])
+        res_real = s_real.contains(5)
+        assert res_real.shape == (3, 1)
+
+
+class TestUnionSet:
+    """Tests for Union logic arrays."""
+
+    def test_union_basic(self):
+        """Basic interval overlapping queries."""
+        u = UnionSet(IntervalSet(0, 1), IntervalSet(5, 6))
+        assert bool(u.contains(0.5)) is True
+        assert bool(u.contains(3)) is False
+        assert bool(u.contains(5.5)) is True
+        assert u.boundary() == (0, 6)
+
+    def test_heterogeneous_index_union(self):
+        """Test heterogeneous index alignments in UnionSet."""
+        s1 = IntervalSet(0, 10, index=pd.Index([1, 2, 3]))
+        s2 = IntervalSet(20, 30, index=pd.Index([3, 4, 5]))
+        u = UnionSet(s1, s2)
+
+        # DataFrame explicitly captures partial mismatches
+        df = pd.DataFrame({"col": [5, 5, 25, 25, 25]}, index=[1, 2, 3, 4, 5])
+        res = u.contains(df)
+        assert isinstance(res, pd.DataFrame)
+        assert len(res) == 5
+
+    def test_scalar_set_broadcast_union(self):
+        """Test broadcasted scalar set mapped against UnionSet logic."""
+        tab_set = IntervalSet([0, 0], [10, 10], index=[1, 2])
+        scalar_set = FiniteSet([100])
+        u = UnionSet(tab_set, scalar_set)
+        res = u.contains(100)
+        assert res.shape == (2, 1)
+
+    def test_union_boundary_flattening(self):
+        """Test recursive inner flattening math logic in boundaries."""
+        s1 = IntervalSet([0, 10], [5, 15], index=[1, 2])
+        s2 = IntervalSet([-5, 5], [0, 10], index=[1, 2])
+        u = UnionSet(s1, s2)
+        l, h = u.boundary()
+        np.testing.assert_array_equal(l, [-5, 5])
+        np.testing.assert_array_equal(h, [5, 15])
+
+    def test_raw_bitwise_or_numpy_arrays(self):
+        """Test NumPy ndarray logical collapse against DataFrames."""
+        s1 = IntervalSet(0, 5)
+        s2 = IntegerSet(10, 15)
+        u = UnionSet(s1, s2)
+        x = np.array([2, 12, 20])
+        res = u.contains(x)
+        assert res.shape == (3,)
+        np.testing.assert_array_equal(res, [True, True, False])
+
+
+class TestIntersectionSet:
+    """Tests for Intersectional mapping geometry."""
+
+    def test_intersection_basic(self):
+        """Basic bound inclusion masks."""
+        i = IntersectionSet(IntervalSet(0, 10), IntervalSet(5, 15))
+        assert bool(i.contains(7)) is True
+        assert bool(i.contains(2)) is False
+        assert bool(i.contains(12)) is False
+        assert i.boundary() == (5, 10)
+
+    def test_identity_algebra(self):
+        """Ensure abstract object geometry behaves cleanly when nested."""
+        a = IntervalSet(0, 1)
+        # A n Real = A
+        assert bool(IntersectionSet(a, RealSet()).contains(0.5)) == bool(
+            a.contains(0.5)
+        )
+        # A n Empty = Empty
+        assert bool(IntersectionSet(a, EmptySet()).contains(0.5)) is False
+
+    def test_nested_algebra(self):
+        """Test mathematical overlaps combining Union arrays and Intersection limits."""
+        s1 = IntersectionSet(IntervalSet(0, 10), IntervalSet(5, 15))  # [5, 10]
+        s2 = FiniteSet([20])
+        u = UnionSet(s1, s2)
+        assert bool(u.contains(7)) is True
+        assert bool(u.contains(20)) is True
+        assert bool(u.contains(15)) is False
+
+    def test_intersection_ghost_boundary(self):
+        """Test array mathematical geometry across distinct limits."""
+        s1 = IntervalSet([0, 10], [10, 20], index=[1, 2])
+        s2 = IntervalSet([5, 5], [15, 15], index=[1, 2])
+        i = IntersectionSet(s1, s2)
+        l, h = i.boundary()
+        np.testing.assert_array_equal(l, [5, 10])
+        np.testing.assert_array_equal(h, [10, 15])
+
+    def test_intersection_null(self):
+        """Test completely disjoint geometries collapsing strictly to NaN spaces."""
+        s1 = IntervalSet([0, 30], [5, 35], index=[1, 2])
+        s2 = IntervalSet([10, 10], [15, 15], index=[1, 2])
+        i = IntersectionSet(s1, s2)
+        l, h = i.boundary()
+
+        # Row 1 overrides null overlap because 10 > 5 -> NaN
+        assert np.isnan(l[0])
+        assert np.isnan(h[0])
+
+        # Row 2 overrides null overlap because 30 > 15 -> NaN
+        assert np.isnan(l[1])
+        assert np.isnan(h[1])

--- a/skpro/distributions/binomial.py
+++ b/skpro/distributions/binomial.py
@@ -5,6 +5,7 @@ import pandas as pd
 from scipy.stats import binom, rv_discrete
 
 from skpro.distributions.adapters.scipy import _ScipyAdapter
+from skpro.distributions.base._set import IntegerSet
 
 
 class Binomial(_ScipyAdapter):
@@ -58,6 +59,23 @@ class Binomial(_ScipyAdapter):
         p = self._bc_params["p"]
 
         return [], {"n": n, "p": p}
+
+    def _support(self):
+        r"""Return the support of the Binomial distribution.
+
+        The support is the set of integers :math:`\{0, 1, \ldots, n\}`.
+
+        Returns
+        -------
+        IntegerSet
+            ``IntegerSet(lower=0, upper=n)``.
+        """
+        return IntegerSet(
+            lower=0,
+            upper=self._bc_params["n"],
+            index=self.index,
+            columns=self.columns,
+        )
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/skpro/distributions/empirical.py
+++ b/skpro/distributions/empirical.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 
 from skpro.distributions.base import BaseDistribution
+from skpro.distributions.base._set import FiniteSet
 
 
 class Empirical(BaseDistribution):
@@ -480,6 +481,39 @@ class Empirical(BaseDistribution):
         """Quantile function = percent point function = inverse cdf."""
         ppf_val = self._apply_per_ix(_ppf_np, {"assume_sorted": True}, x=p)
         return ppf_val
+
+    def _support(self):
+        r"""Return the support of the empirical distribution.
+
+        The support is the set of unique sample values in ``spl``.
+        For a weighted empirical distribution, the support is the unique
+        weighted sample values.
+
+        Returns
+        -------
+        FiniteSet
+            ``FiniteSet`` with values being the unique empirical support points.
+        """
+        spl = self.spl
+
+        if self.ndim == 0:
+            # Scalar case: extract unique values from samples
+            spl_values = spl.values.flatten()
+            unique_values = np.unique(spl_values)
+            return FiniteSet(unique_values, index=self.index, columns=self.columns)
+
+        # Array case: build tabular mapping per cell to avoid global flattening
+        shape = (len(self.index), len(self.columns))
+        vals_arr = np.empty(shape, dtype=object)
+
+        for i, idx in enumerate(self.index):
+            for j, col in enumerate(self.columns):
+                sl = (slice(None),) + self._coerce_tuple(idx)
+                spl_col = spl.loc[sl, col].values
+                unique_col = np.unique(spl_col)
+                vals_arr[i, j] = list(unique_col)
+
+        return FiniteSet(vals_arr, index=self.index, columns=self.columns)
 
     def _pmf_support(self, lower, upper, max_points=100):
         """Get support points for empirical distribution.

--- a/skpro/distributions/poisson.py
+++ b/skpro/distributions/poisson.py
@@ -5,6 +5,7 @@ import pandas as pd
 from scipy.stats import poisson, rv_discrete
 
 from skpro.distributions.adapters.scipy import _ScipyAdapter
+from skpro.distributions.base._set import IntegerSet
 
 
 class Poisson(_ScipyAdapter):
@@ -105,6 +106,19 @@ class Poisson(_ScipyAdapter):
         if getattr(self, "index", None) is None and result.size == 1:
             return result.item()
         return result
+
+    def _support(self):
+        r"""Return the support of the Poisson distribution.
+
+        The support is the set of non-negative integers
+        :math:`\{0, 1, 2, \ldots\}`.
+
+        Returns
+        -------
+        IntegerSet
+            ``IntegerSet(lower=0)``, representing non-negative integers.
+        """
+        return IntegerSet(lower=0, index=self.index, columns=self.columns)
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/skpro/distributions/truncated.py
+++ b/skpro/distributions/truncated.py
@@ -4,6 +4,7 @@ from typing import Tuple, Union
 import numpy as np
 
 from skpro.distributions.base import BaseDistribution
+from skpro.distributions.base._set import IntersectionSet, IntervalSet
 
 
 class TruncatedDistribution(BaseDistribution):
@@ -121,6 +122,35 @@ class TruncatedDistribution(BaseDistribution):
         inner_paramtype = distribution.get_tag("distr:paramtype", "parametric")
         if inner_paramtype != "parametric":
             self.set_tags(**{"distr:paramtype": inner_paramtype})
+
+    def _support(self):
+        r"""Return the support of the truncated distribution.
+
+        The support is :math:`\text{supp}(f) \cap I`, where
+        :math:`f` is the base distribution and :math:`I` is the
+        truncation interval defined by ``lower``, ``upper``, and
+        ``interval_type``.
+
+        Returns
+        -------
+        IntersectionSet
+            Intersection of the base support and the truncation interval.
+        """
+        lower = self.lower if self.lower is not None else -np.inf
+        upper = self.upper if self.upper is not None else np.inf
+        trunc_interval = IntervalSet(
+            lower=lower,
+            upper=upper,
+            interval_type=self.interval_type,
+            index=self.index,
+            columns=self.columns,
+        )
+        return IntersectionSet(
+            self.distribution.support,
+            trunc_interval,
+            index=self.index,
+            columns=self.columns,
+        )
 
     def _get_low_high_prob(self) -> Tuple[float, float]:
         prob_at_lower = (

--- a/skpro/distributions/zeroinflated.py
+++ b/skpro/distributions/zeroinflated.py
@@ -4,6 +4,7 @@ import numpy as np
 from numpy.typing import ArrayLike
 
 from skpro.distributions.base import BaseDistribution
+from skpro.distributions.base._set import FiniteSet, UnionSet
 
 
 class ZeroInflated(BaseDistribution):
@@ -91,6 +92,26 @@ class ZeroInflated(BaseDistribution):
         inner_paramtype = distribution.get_tag("distr:paramtype", "parametric")
         if inner_paramtype != "parametric":
             self.set_tags(**{"distr:paramtype": inner_paramtype})
+
+    def _support(self):
+        r"""Return the support of the zero-inflated distribution.
+
+        The support is :math:`\{0\} \cup \text{supp}(f)`, where
+        :math:`f` is the base distribution.
+
+        Returns
+        -------
+        UnionSet
+            Union of ``FiniteSet([0])`` and the base distribution's support.
+        """
+        zero_set = FiniteSet([0], index=self.index, columns=self.columns)
+        base_support = self.distribution.support
+        return UnionSet(
+            zero_set,
+            base_support,
+            index=self.index,
+            columns=self.columns,
+        )
 
     def _log_pmf(self, x):
         p = self._bc_params["p"]
@@ -237,6 +258,15 @@ class ZeroInflated(BaseDistribution):
 
     # TODO: Replace with default behavior after PR #644 is merged.
     def _iloc(self, rowidx=None, colidx=None):
+        # delegate scalar-scalar case to _iat, matching BaseDistribution._iloc
+        if (
+            rowidx is not None
+            and np.isscalar(rowidx)
+            and colidx is not None
+            and np.isscalar(colidx)
+        ):
+            return self._iat(rowidx, colidx)
+
         distr = self.distribution.iloc[rowidx, colidx]
         p = self.p
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skpro.readthedocs.io/en/latest/contribute.html
-->

#### Reference Issues/PRs
Fixes #244

#### What does this implement/fix? Explain your changes.

I have implemented hierarchy of set classes to represent the mathematical support of distributions: `RealSet`, `IntegerSet`, `IntervalSet`, `FiniteSet`, and `EmptySet`, `UnionSet` and `IntersectionSet`. These sets are designed to be tabular, meaning a single set object can store parameters (bounds/values) as arrays 

The `BaseDistribution` now includes a `support` property). This would allow distributions to programmatically communicate where their probability mass/density resides. This method was overrided currently only in few distributions to test different types of set  - `Binomial` (IntegerSet), `Poisson` (IntegerSet), `Empirical` (FiniteSet), `TruncatedDistribution` (IntersectionSet), and `ZeroInflated` (UnionSet) have been updated.

The `plot` functionality has been changed to use `support.boundary()` to determine exact x-axis limits.  For discrete and mixed distributions, the plotter now queries the support for FiniteSet or IntegerSet components to identify exact coordinates for stem plots.

#### Does your contribution introduce a new dependency? If yes, which one?
No new dependencies are introduced.

#### What should a reviewer concentrate their feedback on?

-  `_plot_single`, mixed distributions (like ZeroInflated) for pdf currently plot the continuous part as a line and the discrete mass as stems. Mathematically, a PDF of a mixed distribution includes Dirac delta spikes (infinite density). To distinguish Mass from Density, we mask the PDF line at spike points using np.isclose, would that be right?
- Broadcasting logic in  `_get_bc_params`  (We currently utilize `oned_as="col"` to force 1D parameter arrays  ) into column vectors `(N, 1)`)
- In UnionSet and IntersectionSet, we allow a mix of scalar and tabular children. We currently force the output to match the parent set's ndim
- Are the current Set types sufficient?


#### Did you add any tests for the change?
Yes, `test_set.py` has been added to verify the symbolic set logic

#### Any other comments?
Includes a minor fix for `ZeroInflated._iloc` to ensure scalar-scalar indexing correctly delegates to `_iat`, which was necessary for cell-level plotting in array distributions
#### PR checklist


##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.


