### PR TITLE
[BUG] Fix probability mass loss and temporal alignment in _SksurvAdapter predict_proba function

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -257,5 +257,13 @@
         "bug"
       ]
     },
+    {
+      "login": "MurtuzaShaikh26",
+      "profile": "https://github.com/MurtuzaShaikh26",
+      "contributions": [
+        "bug",
+        "code"
+      ]
+    }
   ]
 }

--- a/skpro/survival/adapters/sksurv.py
+++ b/skpro/survival/adapters/sksurv.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 
 from skpro.distributions.empirical import Empirical
-from skpro.survival.adapters._common import _get_fitted_params_default_safe
+from skpro.survival.adapters._common import _clip_surv, _get_fitted_params_default_safe
 from skpro.utils.sklearn import prep_skl_df
 
 
@@ -139,7 +139,7 @@ class _SksurvAdapter:
         # predict on X
         sksurv_survf = sksurv_est.predict_survival_function(X, return_array=True)
 
-        times = sksurv_est.unique_times_[:-1]
+        times = sksurv_est.unique_times_
 
         nt = len(times)
         mi = pd.MultiIndex.from_product([X.index, range(nt)]).swaplevel()
@@ -147,7 +147,23 @@ class _SksurvAdapter:
         times_val = np.repeat(times, repeats=len(X))
         times_df = pd.DataFrame(times_val, index=mi, columns=self._y_cols)
 
-        weights = -np.diff(sksurv_survf, axis=1).flatten()
+        _, surv_arr_diff, clipped = _clip_surv(sksurv_survf)
+
+        if clipped:
+            from warnings import warn
+
+            warn(
+                f"Warning from {self.__class__.__name__}: "
+                f"Interfaced sksurv class {sksurv_est.__class__.__name__} "
+                "produced improper survival function predictions, i.e., "
+                "not monotonically decreasing or not in [0, 1]. "
+                "skpro has clipped the predictions to enforce proper range and "
+                "valid predictive distributions. "
+                "However, predictions may still be unreliable.",
+                stacklevel=2,
+            )
+
+        weights = -surv_arr_diff.flatten()
         weights_df = pd.Series(weights, index=mi)
 
         dist = Empirical(

--- a/skpro/tests/test_sksurv_adapter.py
+++ b/skpro/tests/test_sksurv_adapter.py
@@ -1,0 +1,56 @@
+"""Tests for _SksurvAdapter."""
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+
+from skpro.survival.adapters.sksurv import _SksurvAdapter
+
+
+class MockSksurvAdapter(_SksurvAdapter):
+    """Mock adapter for reproducing sksurv adapter behavior."""
+
+    def _get_sksurv_class(self):
+        return MagicMock()
+
+    def get_params(self, deep=True):
+        return {}
+
+
+def test_sksurv_adapter_probability_mass_and_alignment():
+    """Test _SksurvAdapter predict_proba mass and temporal alignment."""
+    # Define mock survival results
+    mock_surv = np.array([[0.8, 0.5, 0.5]])
+    mock_times = np.array([10.0, 20.0, 30.0])
+
+    X = pd.DataFrame({"feature1": [1.0]})
+
+    # Initialize and mock the estimator internals
+    adapter = MockSksurvAdapter()
+    adapter._estimator = MagicMock()
+    adapter._estimator.predict_survival_function = MagicMock(return_value=mock_surv)
+    adapter._estimator.unique_times_ = mock_times
+    adapter._y_cols = ["time"]
+
+    # Run the predict_proba logic
+    dist = adapter._predict_proba(X)
+
+    # Retrieve expected features
+    times = dist.spl.values.flatten()
+    weights = dist.weights.values
+
+    # Check alignment - Times should not be truncated
+    np.testing.assert_allclose(times, mock_times)
+
+    # Expected masses:
+    # 1.0 -> 0.8  at t=10.0 (mass 0.2)
+    # 0.8 -> 0.5  at t=20.0 (mass 0.3)
+    # 0.5 -> 0.5  at t=30.0 (mass 0.0 + 0.5 tail mass = 0.5)
+    expected_weights = np.array([0.2, 0.3, 0.5])
+    
+    np.testing.assert_allclose(weights, expected_weights, atol=1e-7)
+
+    # Verify that total mass is precisely 1.0
+    total_mass = weights.sum()
+    assert np.isclose(total_mass, 1.0, atol=1e-7), f"Expected total mass 1.0, got {total_mass}"


### PR DESCRIPTION
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
-->
Fixes #958 

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
The [predict_proba](skpro/skpro/survival/adapters/sksurv.py) method in [_SksurvAdapter](skpro/skpro/survival/adapters/sksurv.py) (used by estimators like `CoxPHSkSurv`) calculated distribution weights via raw `np.diff` ignoring boundaries, resulting in massive probability drops and time regressions:

1. Initial Mass Loss: The drop from 1.0 to the first timepoint was discarded.
2. Tail Mass Loss: The remaining survival probability after the last valid timepoint was discarded instead of mapped to the last step, resulting in Empirical distribution weights summing to far less than 1.0.
3. Temporal Alignment: It incorrectly stripped the last recorded survival times using `[:-1]`, stripping context and effectively dragging all probability masses backwards in time to previous disconnected timesteps.

**Proposed Solution:
This PR replaces `np.diff` with [_clip_surv](skpro/skpro/survival/adapters/_common.py) from [_common.py](skpro/skpro/survival/adapters/_common.py) which leverages [_surv_diff](skpro/skpro/survival/adapters/_common.py) (applying `prepend=1.0, append=0.0`) handling both margin boundaries. This efficiently validates that every mass is conserved, monotonically scaled, and sums exactly to `1.0`. We also preserve the full unmodified `unique_times_` for perfectly matched event distribution timestamps.

<details>
<summary><b>Verification Script</b></summary>
When tracking an estimator with survival probabilities <code>[0.8, 0.5, 0.5]</code> descending over timestamps <code>[10.0, 20.0, 30.0]</code>:

    import numpy as np
    import pandas as pd
    from unittest.mock import MagicMock
    from skpro.survival.adapters.sksurv import _SksurvAdapter
    
    class MockSksurvAdapter(_SksurvAdapter):
        def _get_sksurv_class(self): return MagicMock()
        def get_params(self, deep=True): return {}
    
    X = pd.DataFrame({"feature1": [1.0]})
    adapter = MockSksurvAdapter()
    adapter._estimator = MagicMock()
    adapter._estimator.predict_survival_function = MagicMock(return_value=np.array([[0.8, 0.5, 0.5]]))
    adapter._estimator.unique_times_ = np.array([10.0, 20.0, 30.0])
    adapter._y_cols = ["time"]
    
    dist = adapter._predict_proba(X)
    
    print("\n--- RESULTS ---")
    print("Times in resulting Empirical distribution:", dist.spl.values.flatten())
    print("Weights in resulting Empirical distribution:", dist.weights.values)
    print(f"Total mass: {dist.weights.sum()}")

</details>

 
<img width="533" height="330" alt="image" src="https://github.com/user-attachments/assets/3bb9e42a-e68f-447d-a365-dbc2fba920ca" />


#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
- Reviewing the `np.diff`/`[:-1]` replacement logic using [_clip_surv](cci:1://file:///c:/Users/murtu/OneDrive/Documents/Murtuza/Open-Source/Skpro/skpro/skpro/survival/adapters/_common.py:5:0-53:40) to preserve the probability boundaries.
- The new adapter test [test_sksurv_adapter.py](cci:7://file:///c:/Users/murtu/OneDrive/Documents/Murtuza/Open-Source/Skpro/skpro/skpro/tests/test_sksurv_adapter.py:0:0-0:0) validating the resulting `dist.weights`, timeline boundary assignments, and asserting total mass strictly evaluates to `1.0`.

#### Did you add any tests for the change?
- [x] Yes, added [test_sksurv_adapter_probability_mass_and_alignment](skpro/skpro/tests/test_sksurv_adapter.py) in [skpro/tests/test_sksurv_adapter.py](skpro/skpro/tests/test_sksurv_adapter.py).

#### Any other comments?
N/A

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].

##### For new estimators
- [ ] I've added the estimator to the API reference
- [ ] I've added one or more illustrative usage examples to the docstring
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag
