### PR TITLE
[DOC] Add missing `LogNormal` distribution to API reference

### DIFF
--- a/docs/source/api_reference/distributions.rst
+++ b/docs/source/api_reference/distributions.rst
@@ -70,6 +70,7 @@ Continuous support - non-negative reals
     GumbelR
     Levy
     LogGamma
+    LogNormal
     HalfCauchy
     HalfLogistic
     HalfNormal


### PR DESCRIPTION
## 🚀 **Summary**
The `LogNormal` distribution, although implemented and exported, was missing from the public API reference. This PR adds it to the documentation to ensure consistency and improve discoverability.

---

## 🛠️ **Changes**
- **Modified**: `docs/source/api_reference/distributions.rst`  
  - Added `LogNormal` under the **"Continuous support – non-negative reals"** section  
  - Maintained alphabetical order for consistency  

---

## 🔧 **Type of Change**
- [x] Documentation fix (missing API reference entry)

---

## 🔗 **Related Issues**
Closes #991