### PR TITLE
[ENH] Add `UnconditionalDistfitRegressor` and `DeterministicReductionRegressor`

### DIFF
--- a/docs/source/api_reference/regression.rst
+++ b/docs/source/api_reference/regression.rst
@@ -196,6 +196,21 @@ This section lists simple regressors which can be used as baselines.
     DeltaPointRegressor
     DummyProbaRegressor
 
+.. currentmodule:: skpro.regression.unconditional_distfit
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    UnconditionalDistfitRegressor
+
+.. currentmodule:: skpro.regression.deterministic_reduction
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    DeterministicReductionRegressor
 
 Linear regression
 -----------------

--- a/examples/baseline_regressors_demo.py
+++ b/examples/baseline_regressors_demo.py
@@ -1,8 +1,11 @@
-# Example usage for baseline probabilistic regressors
+"""Example usage for baseline probabilistic regressors."""
+import logging
+
 import numpy as np
 from sklearn.linear_model import LinearRegression
-from skpro.regression.unconditional_distfit import UnconditionalDistfitRegressor
+
 from skpro.regression.deterministic_reduction import DeterministicReductionRegressor
+from skpro.regression.unconditional_distfit import UnconditionalDistfitRegressor
 
 # Generate synthetic data
 X = np.random.randn(100, 3)
@@ -12,13 +15,13 @@ y = 2 * X[:, 0] + np.random.randn(100)
 reg1 = UnconditionalDistfitRegressor()
 reg1.fit(X, y)
 dist1 = reg1.predict_proba(X)
-print('UnconditionalDistfitRegressor mean:', dist1.mean())
-print('Sample from unconditional:', dist1.sample(5))
+logging.info("UnconditionalDistfitRegressor mean: %s", dist1.mean())
+logging.info("Sample from unconditional: %s", dist1.sample(5))
 
 # 2. Deterministic-style baseline (mean from regressor, constant variance)
-reg2 = DeterministicReductionRegressor(LinearRegression(), distr_type='gaussian')
+reg2 = DeterministicReductionRegressor(LinearRegression(), distr_type="gaussian")
 reg2.fit(X, y)
 dist2 = reg2.predict_proba(X)
-print('DeterministicReductionRegressor mean:', dist2.mean)
-print('DeterministicReductionRegressor sigma:', dist2.sigma)
-print('Sample from deterministic baseline:', dist2.sample(5))
+logging.info("DeterministicReductionRegressor mean: %s", dist2.mean)
+logging.info("DeterministicReductionRegressor sigma: %s", dist2.sigma)
+logging.info("Sample from deterministic baseline: %s", dist2.sample(5))

--- a/examples/baseline_regressors_demo.py
+++ b/examples/baseline_regressors_demo.py
@@ -1,0 +1,24 @@
+# Example usage for baseline probabilistic regressors
+import numpy as np
+from sklearn.linear_model import LinearRegression
+from skpro.regression.unconditional_distfit import UnconditionalDistfitRegressor
+from skpro.regression.deterministic_reduction import DeterministicReductionRegressor
+
+# Generate synthetic data
+X = np.random.randn(100, 3)
+y = 2 * X[:, 0] + np.random.randn(100)
+
+# 1. Unconditional density baseline (featureless)
+reg1 = UnconditionalDistfitRegressor()
+reg1.fit(X, y)
+dist1 = reg1.predict_proba(X)
+print('UnconditionalDistfitRegressor mean:', dist1.mean())
+print('Sample from unconditional:', dist1.sample(5))
+
+# 2. Deterministic-style baseline (mean from regressor, constant variance)
+reg2 = DeterministicReductionRegressor(LinearRegression(), distr_type='gaussian')
+reg2.fit(X, y)
+dist2 = reg2.predict_proba(X)
+print('DeterministicReductionRegressor mean:', dist2.mean)
+print('DeterministicReductionRegressor sigma:', dist2.sigma)
+print('Sample from deterministic baseline:', dist2.sample(5))

--- a/examples/baseline_regressors_kde_hist.py
+++ b/examples/baseline_regressors_kde_hist.py
@@ -1,4 +1,4 @@
-"""Example: using KDE and histogram with UnconditionalDistfitRegressor."""
+"""Example: unconditional norm and laplace baselines with distfit."""
 import logging
 
 import numpy as np
@@ -8,14 +8,14 @@ from skpro.regression.unconditional_distfit import UnconditionalDistfitRegressor
 X = np.random.randn(80, 2)
 y = np.random.randn(80)
 
-# KDE baseline
-reg_kde = UnconditionalDistfitRegressor(fit_kde=True)
-reg_kde.fit(X, y)
-dist_kde = reg_kde.predict_proba(X)
-logging.info("KDE baseline mean: %s", dist_kde.mean())
+# Distfit norm baseline
+reg_norm = UnconditionalDistfitRegressor(distr_type="norm")
+reg_norm.fit(X, y)
+dist_norm = reg_norm.predict_proba(X)
+logging.info("Norm baseline mean: %s", dist_norm.mean())
 
-# Histogram baseline
-reg_hist = UnconditionalDistfitRegressor(fit_histogram=True)
-reg_hist.fit(X, y)
-dist_hist = reg_hist.predict_proba(X)
-logging.info("Histogram baseline mean: %s", dist_hist.mean())
+# Distfit laplace baseline
+reg_laplace = UnconditionalDistfitRegressor(distr_type="laplace")
+reg_laplace.fit(X, y)
+dist_laplace = reg_laplace.predict_proba(X)
+logging.info("Laplace baseline mean: %s", dist_laplace.mean())

--- a/examples/baseline_regressors_kde_hist.py
+++ b/examples/baseline_regressors_kde_hist.py
@@ -1,5 +1,8 @@
-# Example: using KDE and histogram with UnconditionalDistfitRegressor
+"""Example: using KDE and histogram with UnconditionalDistfitRegressor."""
+import logging
+
 import numpy as np
+
 from skpro.regression.unconditional_distfit import UnconditionalDistfitRegressor
 
 X = np.random.randn(80, 2)
@@ -9,10 +12,10 @@ y = np.random.randn(80)
 reg_kde = UnconditionalDistfitRegressor(fit_kde=True)
 reg_kde.fit(X, y)
 dist_kde = reg_kde.predict_proba(X)
-print('KDE baseline mean:', dist_kde.mean())
+logging.info("KDE baseline mean: %s", dist_kde.mean())
 
 # Histogram baseline
 reg_hist = UnconditionalDistfitRegressor(fit_histogram=True)
 reg_hist.fit(X, y)
 dist_hist = reg_hist.predict_proba(X)
-print('Histogram baseline mean:', dist_hist.mean())
+logging.info("Histogram baseline mean: %s", dist_hist.mean())

--- a/examples/baseline_regressors_kde_hist.py
+++ b/examples/baseline_regressors_kde_hist.py
@@ -1,0 +1,18 @@
+# Example: using KDE and histogram with UnconditionalDistfitRegressor
+import numpy as np
+from skpro.regression.unconditional_distfit import UnconditionalDistfitRegressor
+
+X = np.random.randn(80, 2)
+y = np.random.randn(80)
+
+# KDE baseline
+reg_kde = UnconditionalDistfitRegressor(fit_kde=True)
+reg_kde.fit(X, y)
+dist_kde = reg_kde.predict_proba(X)
+print('KDE baseline mean:', dist_kde.mean())
+
+# Histogram baseline
+reg_hist = UnconditionalDistfitRegressor(fit_histogram=True)
+reg_hist.fit(X, y)
+dist_hist = reg_hist.predict_proba(X)
+print('Histogram baseline mean:', dist_hist.mean())

--- a/examples/benchmark_baseline_regressors.py
+++ b/examples/benchmark_baseline_regressors.py
@@ -1,9 +1,12 @@
-# Benchmark script for baseline probabilistic regressors
+"""Benchmark script for baseline probabilistic regressors."""
+import logging
+
 import numpy as np
 from sklearn.linear_model import LinearRegression
-from skpro.regression.unconditional_distfit import UnconditionalDistfitRegressor
-from skpro.regression.deterministic_reduction import DeterministicReductionRegressor
+
 from skpro.metrics import PinballLoss
+from skpro.regression.deterministic_reduction import DeterministicReductionRegressor
+from skpro.regression.unconditional_distfit import UnconditionalDistfitRegressor
 
 # Generate synthetic data
 X = np.random.randn(200, 5)
@@ -19,7 +22,7 @@ reg1.fit(X_train, y_train)
 dist1 = reg1.predict_proba(X_test)
 
 # Baseline 2: Deterministic reduction
-reg2 = DeterministicReductionRegressor(LinearRegression(), distr_type='gaussian')
+reg2 = DeterministicReductionRegressor(LinearRegression(), distr_type="gaussian")
 reg2.fit(X_train, y_train)
 dist2 = reg2.predict_proba(X_test)
 
@@ -28,4 +31,10 @@ alphas = [0.1, 0.5, 0.9]
 for alpha in alphas:
     loss1 = PinballLoss(alpha=alpha)(y_test, dist1)
     loss2 = PinballLoss(alpha=alpha)(y_test, dist2)
-    print(f"Alpha={alpha}: UnconditionalDistfitRegressor pinball loss={loss1:.4f}, DeterministicReductionRegressor pinball loss={loss2:.4f}")
+    logging.info(
+        "Alpha=%s: UnconditionalDistfitRegressor pinball loss=%.4f, "
+        "DeterministicReductionRegressor pinball loss=%.4f",
+        alpha,
+        loss1,
+        loss2,
+    )

--- a/examples/benchmark_baseline_regressors.py
+++ b/examples/benchmark_baseline_regressors.py
@@ -1,0 +1,31 @@
+# Benchmark script for baseline probabilistic regressors
+import numpy as np
+from sklearn.linear_model import LinearRegression
+from skpro.regression.unconditional_distfit import UnconditionalDistfitRegressor
+from skpro.regression.deterministic_reduction import DeterministicReductionRegressor
+from skpro.metrics import PinballLoss
+
+# Generate synthetic data
+X = np.random.randn(200, 5)
+y = 3 * X[:, 0] - 2 * X[:, 1] + np.random.randn(200)
+
+# Split
+X_train, X_test = X[:150], X[150:]
+y_train, y_test = y[:150], y[150:]
+
+# Baseline 1: Unconditional
+reg1 = UnconditionalDistfitRegressor()
+reg1.fit(X_train, y_train)
+dist1 = reg1.predict_proba(X_test)
+
+# Baseline 2: Deterministic reduction
+reg2 = DeterministicReductionRegressor(LinearRegression(), distr_type='gaussian')
+reg2.fit(X_train, y_train)
+dist2 = reg2.predict_proba(X_test)
+
+# Evaluate pinball loss at alpha=0.1, 0.5, 0.9
+alphas = [0.1, 0.5, 0.9]
+for alpha in alphas:
+    loss1 = PinballLoss(alpha=alpha)(y_test, dist1)
+    loss2 = PinballLoss(alpha=alpha)(y_test, dist2)
+    print(f"Alpha={alpha}: UnconditionalDistfitRegressor pinball loss={loss1:.4f}, DeterministicReductionRegressor pinball loss={loss2:.4f}")

--- a/skpro/distributions/tests/test_proba_basic.py
+++ b/skpro/distributions/tests/test_proba_basic.py
@@ -112,6 +112,9 @@ def test_proba_index_coercion():
 @pytest.mark.parametrize("fun", ["pdf", "ppf", "cdf"])
 def test_proba_plotting(fun):
     """Test that plotting functions do not crash and return ax as expected."""
+    import matplotlib
+
+    matplotlib.use("Agg", force=True)
     from matplotlib.axes import Axes
     from matplotlib.figure import Figure
 

--- a/skpro/regression/__init__.py
+++ b/skpro/regression/__init__.py
@@ -5,13 +5,17 @@ from skpro.regression.conformal import (
     MapieCrossConformalRegressor,
     MapieSplitConformalRegressor,
 )
+from skpro.regression.deterministic_reduction import DeterministicReductionRegressor
 from skpro.regression.jackknife import MapieJackknifeAfterBootstrapRegressor
 from skpro.regression.nonparametric import NadarayaWatsonCDE
+from skpro.regression.unconditional_distfit import UnconditionalDistfitRegressor
 
 __all__ = [
+    "DeterministicReductionRegressor",
     "MapieSplitConformalRegressor",
     "MapieCrossConformalRegressor",
     "MapieConformalizedQuantileRegressor",
     "MapieJackknifeAfterBootstrapRegressor",
     "NadarayaWatsonCDE",
+    "UnconditionalDistfitRegressor",
 ]

--- a/skpro/regression/deterministic_reduction.py
+++ b/skpro/regression/deterministic_reduction.py
@@ -1,45 +1,64 @@
-"""
-Deterministic regression reduction baseline: outputs Gaussian (or Laplace) with mean=prediction, var=training sample var.
+"""Deterministic regression reduction baseline.
+
+Outputs Gaussian (or Laplace) with mean=prediction, var=training sample var.
 """
 
 import numpy as np
-from skpro.regression.base import BaseProbaRegressor
-from skpro.distributions.normal import Normal
+
 from skpro.distributions.laplace import Laplace
+from skpro.distributions.normal import Normal
+from skpro.regression.base import BaseProbaRegressor
 
 
 class DeterministicReductionRegressor(BaseProbaRegressor):
     """
-    Wraps a deterministic regressor to output a Gaussian or Laplace with mean=prediction, var=training sample var.
+    Wraps a deterministic regressor to output a Gaussian or Laplace.
+
+    The output has mean=prediction, var=training sample var.
 
     References
     ----------
-    - Gaussian Processes for State Space Models and Change Point Detection (Turner, 2011 thesis).
-      https://mlg.eng.cam.ac.uk/pub/pdf/Tur11.pdf
-    - A Probabilistic View of Linear Regression (Bishop, PRML; Keng, 2016; various tutorials).
+    - Gaussian Processes for State Space Models and Change Point Detection
+      (Turner, 2011 thesis). https://mlg.eng.cam.ac.uk/pub/pdf/Tur11.pdf
+    - A Probabilistic View of Linear Regression
+      (Bishop, PRML; Keng, 2016; various tutorials).
     - mlr3proba and related probabilistic ML frameworks.
-    - Efficient and Distance-Aware Deep Regressor for Uncertainty Quantification (Bui et al., 2024).
+    - Efficient and Distance-Aware Deep Regressor for Uncertainty Quantification
+      (Bui et al., 2024).
       https://proceedings.mlr.press/v238/manh-bui24a/manh-bui24a.pdf
+
+    Examples
+    --------
+    >>> from skpro.regression.deterministic_reduction import \
+    ...     DeterministicReductionRegressor
+    >>> from sklearn.linear_model import LinearRegression
+    >>> import numpy as np
+    >>> X = np.random.randn(100, 2)
+    >>> y = np.random.randn(100)
+    >>> reg = DeterministicReductionRegressor(LinearRegression(), distr_type='gaussian')
+    >>> reg.fit(X, y)
+    >>> dist = reg.predict_proba(X)
+    >>> print(dist.mean.shape)
+    (100,)
     """
 
-    def __init__(self, regressor, distr_type='gaussian'):
+    def __init__(self, regressor, distr_type="gaussian"):
         self.regressor = regressor
         self.distr_type = distr_type
         super().__init__()
 
     def _fit(self, X, y, C=None):
         self.regressor_ = self.regressor.fit(X, y)
-        y_arr = y.values.flatten() if hasattr(y, 'values') else np.asarray(y).flatten()
+        y_arr = y.values.flatten() if hasattr(y, "values") else np.asarray(y).flatten()
         self.train_mean_ = np.mean(y_arr)
         self.train_var_ = np.var(y_arr)
         return self
 
     def _predict_proba(self, X):
         mean_pred = self.regressor_.predict(X)
-        if self.distr_type == 'gaussian':
+        if self.distr_type == "gaussian":
             return Normal(mu=mean_pred, sigma=np.sqrt(self.train_var_))
-        elif self.distr_type == 'laplace':
+        if self.distr_type == "laplace":
             # Laplace scale = sqrt(var/2)
-            return Laplace(mu=mean_pred, scale=np.sqrt(self.train_var_/2))
-        else:
-            raise ValueError(f"Unknown distr_type: {self.distr_type}")
+            return Laplace(mu=mean_pred, scale=np.sqrt(self.train_var_ / 2))
+        raise ValueError(f"Unknown distr_type: {self.distr_type}")

--- a/skpro/regression/deterministic_reduction.py
+++ b/skpro/regression/deterministic_reduction.py
@@ -11,21 +11,6 @@ from skpro.regression.base import BaseProbaRegressor
 
 
 class DeterministicReductionRegressor(BaseProbaRegressor):
-        _tags = {
-            # packaging info
-            # --------------
-            "authors": ["arnavk23"],
-            "estimator_type": "regressor_proba",
-            # estimator tags
-            # --------------
-            "capability:multioutput": False,
-            "capability:missing": True,
-            "X_inner_mtype": "pd_DataFrame_Table",
-            "y_inner_mtype": "pd_DataFrame_Table",
-            # CI and test flags
-            # -----------------
-            "tests:vm": True,  # set True if special VM is needed
-        }
     """
     Wraps a deterministic regressor to output a Gaussian or Laplace.
 
@@ -62,6 +47,16 @@ class DeterministicReductionRegressor(BaseProbaRegressor):
       (Bui et al., 2024).
       https://proceedings.mlr.press/v238/manh-bui24a/manh-bui24a.pdf
     """
+            _tags = {
+            "authors": ["arnavk23"],
+            "estimator_type": "regressor_proba",
+            # estimator tags
+            # --------------
+            "capability:multioutput": False,
+            "capability:missing": True,
+            "X_inner_mtype": "pd_DataFrame_Table",
+            "y_inner_mtype": "pd_DataFrame_Table",
+        }
 
     def __init__(self, regressor, distr_type="gaussian"):
         allowed_types = ["gaussian", "laplace"]

--- a/skpro/regression/deterministic_reduction.py
+++ b/skpro/regression/deterministic_reduction.py
@@ -47,16 +47,17 @@ class DeterministicReductionRegressor(BaseProbaRegressor):
       (Bui et al., 2024).
       https://proceedings.mlr.press/v238/manh-bui24a/manh-bui24a.pdf
     """
-            _tags = {
-            "authors": ["arnavk23"],
-            "estimator_type": "regressor_proba",
-            # estimator tags
-            # --------------
-            "capability:multioutput": False,
-            "capability:missing": True,
-            "X_inner_mtype": "pd_DataFrame_Table",
-            "y_inner_mtype": "pd_DataFrame_Table",
-        }
+
+    _tags = {
+        "authors": ["arnavk23"],
+        "estimator_type": "regressor_proba",
+        # estimator tags
+        # --------------
+        "capability:multioutput": False,
+        "capability:missing": True,
+        "X_inner_mtype": "pd_DataFrame_Table",
+        "y_inner_mtype": "pd_DataFrame_Table",
+    }
 
     def __init__(self, regressor, distr_type="gaussian"):
         allowed_types = ["gaussian", "laplace"]

--- a/skpro/regression/deterministic_reduction.py
+++ b/skpro/regression/deterministic_reduction.py
@@ -38,7 +38,7 @@ class DeterministicReductionRegressor(BaseProbaRegressor):
     >>> reg = DeterministicReductionRegressor(LinearRegression(), distr_type='gaussian')
     >>> reg.fit(X, y)
     >>> dist = reg.predict_proba(X)
-    >>> print(dist.mean.shape)
+    >>> print(dist.mean().shape)
     (100,)
     """
 
@@ -48,17 +48,70 @@ class DeterministicReductionRegressor(BaseProbaRegressor):
         super().__init__()
 
     def _fit(self, X, y, C=None):
-        self.regressor_ = self.regressor.fit(X, y)
-        y_arr = y.values.flatten() if hasattr(y, "values") else np.asarray(y).flatten()
+        # Ensure X and y are DataFrames with string column names
+        import pandas as pd
+        from sklearn.base import clone
+        if not isinstance(X, pd.DataFrame):
+            X = pd.DataFrame(X)
+        X = X.copy()
+        X.columns = [str(col) for col in X.columns]
+        if not isinstance(y, pd.DataFrame):
+            y = pd.DataFrame(y)
+        y = y.copy()
+        y.columns = [str(col) for col in y.columns]
+        self._X_cols = X.columns
+        self._y_cols = y.columns
+        self._X_index = X.index
+        self._y_index = y.index
+        # Clone the regressor to avoid mutating the parameter
+        self.regressor_ = clone(self.regressor)
+        self.regressor_ = self.regressor_.fit(
+            X, y.values.ravel() if y.shape[1] == 1 else y
+        )
+        y_arr = y.values.flatten()
         self.train_mean_ = np.mean(y_arr)
         self.train_var_ = np.var(y_arr)
         return self
 
     def _predict_proba(self, X):
+        import pandas as pd
+        # Ensure X is a DataFrame with string column names
+        if not isinstance(X, pd.DataFrame):
+            X = pd.DataFrame(X, columns=self._X_cols)
+        X = X.copy()
+        X.columns = [str(col) for col in X.columns]
         mean_pred = self.regressor_.predict(X)
+        # Ensure output shape matches y
+        if mean_pred.ndim == 1:
+            mean_pred = mean_pred.reshape(-1, 1)
+        # Return distribution with correct index/columns
         if self.distr_type == "gaussian":
-            return Normal(mu=mean_pred, sigma=np.sqrt(self.train_var_))
+            return Normal(
+                mu=mean_pred,
+                sigma=np.sqrt(self.train_var_),
+                index=X.index,
+                columns=self._y_cols,
+            )
         if self.distr_type == "laplace":
             # Laplace scale = sqrt(var/2)
-            return Laplace(mu=mean_pred, scale=np.sqrt(self.train_var_ / 2))
+            return Laplace(
+                mu=mean_pred,
+                scale=np.sqrt(self.train_var_ / 2),
+                index=X.index,
+                columns=self._y_cols,
+            )
         raise ValueError(f"Unknown distr_type: {self.distr_type}")
+
+    def get_params(self, deep=True):
+        # Only return true hyperparameters, not fitted attributes
+        return {"regressor": self.regressor, "distr_type": self.distr_type}
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter sets for automated tests."""
+        from sklearn.linear_model import LinearRegression
+
+        return [
+            {"regressor": LinearRegression(), "distr_type": "gaussian"},
+            {"regressor": LinearRegression(), "distr_type": "laplace"},
+        ]

--- a/skpro/regression/deterministic_reduction.py
+++ b/skpro/regression/deterministic_reduction.py
@@ -1,0 +1,45 @@
+"""
+Deterministic regression reduction baseline: outputs Gaussian (or Laplace) with mean=prediction, var=training sample var.
+"""
+
+import numpy as np
+from skpro.regression.base import BaseProbaRegressor
+from skpro.distributions.normal import Normal
+from skpro.distributions.laplace import Laplace
+
+
+class DeterministicReductionRegressor(BaseProbaRegressor):
+    """
+    Wraps a deterministic regressor to output a Gaussian or Laplace with mean=prediction, var=training sample var.
+
+    References
+    ----------
+    - Gaussian Processes for State Space Models and Change Point Detection (Turner, 2011 thesis).
+      https://mlg.eng.cam.ac.uk/pub/pdf/Tur11.pdf
+    - A Probabilistic View of Linear Regression (Bishop, PRML; Keng, 2016; various tutorials).
+    - mlr3proba and related probabilistic ML frameworks.
+    - Efficient and Distance-Aware Deep Regressor for Uncertainty Quantification (Bui et al., 2024).
+      https://proceedings.mlr.press/v238/manh-bui24a/manh-bui24a.pdf
+    """
+
+    def __init__(self, regressor, distr_type='gaussian'):
+        self.regressor = regressor
+        self.distr_type = distr_type
+        super().__init__()
+
+    def _fit(self, X, y, C=None):
+        self.regressor_ = self.regressor.fit(X, y)
+        y_arr = y.values.flatten() if hasattr(y, 'values') else np.asarray(y).flatten()
+        self.train_mean_ = np.mean(y_arr)
+        self.train_var_ = np.var(y_arr)
+        return self
+
+    def _predict_proba(self, X):
+        mean_pred = self.regressor_.predict(X)
+        if self.distr_type == 'gaussian':
+            return Normal(mu=mean_pred, sigma=np.sqrt(self.train_var_))
+        elif self.distr_type == 'laplace':
+            # Laplace scale = sqrt(var/2)
+            return Laplace(mu=mean_pred, scale=np.sqrt(self.train_var_/2))
+        else:
+            raise ValueError(f"Unknown distr_type: {self.distr_type}")

--- a/skpro/regression/deterministic_reduction.py
+++ b/skpro/regression/deterministic_reduction.py
@@ -26,19 +26,6 @@ class DeterministicReductionRegressor(BaseProbaRegressor):
     - Efficient and Distance-Aware Deep Regressor for Uncertainty Quantification
       (Bui et al., 2024).
       https://proceedings.mlr.press/v238/manh-bui24a/manh-bui24a.pdf
-
-    Examples
-    --------
-    >>> from skpro.regression.deterministic_reduction import \
-        ...     DeterministicReductionRegressor
-    >>> from sklearn.linear_model import LinearRegression
-    >>> import numpy as np
-    >>> X = np.random.randn(100, 2)
-    >>> y = np.random.randn(100)
-    >>> reg = DeterministicReductionRegressor(LinearRegression(), distr_type='gaussian')
-    >>> reg.fit(X, y)
-    >>> dist = reg.predict_proba(X)
-    >>> print(dist.mean())
     """
 
     def __init__(self, regressor, distr_type="gaussian"):

--- a/skpro/regression/deterministic_reduction.py
+++ b/skpro/regression/deterministic_reduction.py
@@ -30,7 +30,7 @@ class DeterministicReductionRegressor(BaseProbaRegressor):
     Examples
     --------
     >>> from skpro.regression.deterministic_reduction import \
-    ...     DeterministicReductionRegressor
+        ...     DeterministicReductionRegressor
     >>> from sklearn.linear_model import LinearRegression
     >>> import numpy as np
     >>> X = np.random.randn(100, 2)

--- a/skpro/regression/deterministic_reduction.py
+++ b/skpro/regression/deterministic_reduction.py
@@ -11,10 +11,45 @@ from skpro.regression.base import BaseProbaRegressor
 
 
 class DeterministicReductionRegressor(BaseProbaRegressor):
+        _tags = {
+            # packaging info
+            # --------------
+            "authors": ["arnavk23"],
+            "estimator_type": "regressor_proba",
+            # estimator tags
+            # --------------
+            "capability:multioutput": False,
+            "capability:missing": True,
+            "X_inner_mtype": "pd_DataFrame_Table",
+            "y_inner_mtype": "pd_DataFrame_Table",
+            # CI and test flags
+            # -----------------
+            "tests:vm": True,  # set True if special VM is needed
+        }
     """
     Wraps a deterministic regressor to output a Gaussian or Laplace.
 
     The output has mean=prediction, var=training sample var.
+    Multi-output y is not supported (raises NotImplementedError).
+
+    Examples
+    --------
+    >>> from sklearn.linear_model import LinearRegression
+    >>> from skpro.regression.deterministic_reduction import (
+    ...     DeterministicReductionRegressor
+    ... )
+    >>> import pandas as pd
+    >>> X = pd.DataFrame({"a": [1, 2, 3]})
+    >>> y = pd.DataFrame([1, 2, 3])
+    >>> reg = DeterministicReductionRegressor(LinearRegression(), distr_type="gaussian")
+     >>> reg.fit(X, y)  # doctest: +ELLIPSIS
+     DeterministicReductionRegressor(...)
+     >>> dist = reg.predict_proba(X)
+     >>> dist.mean()  # doctest: +NORMALIZE_WHITESPACE
+         0
+     0  1.0
+     1  2.0
+     2  3.0
 
     References
     ----------
@@ -29,6 +64,11 @@ class DeterministicReductionRegressor(BaseProbaRegressor):
     """
 
     def __init__(self, regressor, distr_type="gaussian"):
+        allowed_types = ["gaussian", "laplace"]
+        if distr_type not in allowed_types:
+            raise ValueError(
+                f"distr_type must be one of {allowed_types}, got {distr_type}"
+            )
         self.regressor = regressor
         self.distr_type = distr_type
         super().__init__()
@@ -46,6 +86,11 @@ class DeterministicReductionRegressor(BaseProbaRegressor):
             y = pd.DataFrame(y)
         y = y.copy()
         y.columns = [str(col) for col in y.columns]
+        if y.shape[1] > 1:
+            raise NotImplementedError(
+                "DeterministicReductionRegressor only supports univariate y. "
+                f"Got shape: {y.shape}"
+            )
         self._X_cols = X.columns
         self._y_cols = y.columns
         self._X_index = X.index

--- a/skpro/regression/deterministic_reduction.py
+++ b/skpro/regression/deterministic_reduction.py
@@ -104,6 +104,7 @@ class DeterministicReductionRegressor(BaseProbaRegressor):
         raise ValueError(f"Unknown distr_type: {self.distr_type}")
 
     def get_params(self, deep=True):
+        """Get parameters for this estimator."""
         # Only return true hyperparameters, not fitted attributes
         return {"regressor": self.regressor, "distr_type": self.distr_type}
 

--- a/skpro/regression/deterministic_reduction.py
+++ b/skpro/regression/deterministic_reduction.py
@@ -38,8 +38,7 @@ class DeterministicReductionRegressor(BaseProbaRegressor):
     >>> reg = DeterministicReductionRegressor(LinearRegression(), distr_type='gaussian')
     >>> reg.fit(X, y)
     >>> dist = reg.predict_proba(X)
-    >>> print(dist.mean().shape)
-    (100,)
+    >>> print(dist.mean())
     """
 
     def __init__(self, regressor, distr_type="gaussian"):
@@ -51,6 +50,7 @@ class DeterministicReductionRegressor(BaseProbaRegressor):
         # Ensure X and y are DataFrames with string column names
         import pandas as pd
         from sklearn.base import clone
+
         if not isinstance(X, pd.DataFrame):
             X = pd.DataFrame(X)
         X = X.copy()
@@ -75,6 +75,7 @@ class DeterministicReductionRegressor(BaseProbaRegressor):
 
     def _predict_proba(self, X):
         import pandas as pd
+
         # Ensure X is a DataFrame with string column names
         if not isinstance(X, pd.DataFrame):
             X = pd.DataFrame(X, columns=self._X_cols)

--- a/skpro/regression/deterministic_reduction.py
+++ b/skpro/regression/deterministic_reduction.py
@@ -26,15 +26,18 @@ class DeterministicReductionRegressor(BaseProbaRegressor):
     >>> import pandas as pd
     >>> X = pd.DataFrame({"a": [1, 2, 3]})
     >>> y = pd.DataFrame([1, 2, 3])
-    >>> reg = DeterministicReductionRegressor(LinearRegression(), distr_type="gaussian")
-     >>> reg.fit(X, y)  # doctest: +ELLIPSIS
-     DeterministicReductionRegressor(...)
-     >>> dist = reg.predict_proba(X)
-     >>> dist.mean()  # doctest: +NORMALIZE_WHITESPACE
-         0
-     0  1.0
-     1  2.0
-     2  3.0
+    >>> reg = DeterministicReductionRegressor(
+    ...     LinearRegression(),
+    ...     distr_type="gaussian"
+    ... )
+    >>> reg.fit(X, y)  # doctest: +ELLIPSIS
+    DeterministicReductionRegressor(...)
+    >>> dist = reg.predict_proba(X)
+    >>> dist.mean()  # doctest: +NORMALIZE_WHITESPACE
+        0
+    0  1.0
+    1  2.0
+    2  3.0
 
     References
     ----------
@@ -47,16 +50,17 @@ class DeterministicReductionRegressor(BaseProbaRegressor):
       (Bui et al., 2024).
       https://proceedings.mlr.press/v238/manh-bui24a/manh-bui24a.pdf
     """
-            _tags = {
-            "authors": ["arnavk23"],
-            "estimator_type": "regressor_proba",
-            # estimator tags
-            # --------------
-            "capability:multioutput": False,
-            "capability:missing": True,
-            "X_inner_mtype": "pd_DataFrame_Table",
-            "y_inner_mtype": "pd_DataFrame_Table",
-        }
+
+    _tags = {
+        "authors": ["arnavk23"],
+        "estimator_type": "regressor_proba",
+        # estimator tags
+        # --------------
+        "capability:multioutput": False,
+        "capability:missing": True,
+        "X_inner_mtype": "pd_DataFrame_Table",
+        "y_inner_mtype": "pd_DataFrame_Table",
+    }
 
     def __init__(self, regressor, distr_type="gaussian"):
         allowed_types = ["gaussian", "laplace"]

--- a/skpro/regression/tests/test_baseline_regressors.py
+++ b/skpro/regression/tests/test_baseline_regressors.py
@@ -43,22 +43,3 @@ def test_deterministic_reduction_regressor_laplace():
     assert hasattr(dist, "mu")
     assert hasattr(dist, "scale")
     assert np.allclose(dist.scale, np.sqrt(np.var(y) / 2))
-
-
-@pytest.mark.xfail(
-    reason="distfit KDE support is broken with recent scipy (scipy.stats.kde removed).",
-    strict=False,
-)
-def test_unconditional_distfit_regressor_kde():
-    # Test KDE as a nonparametric option if distfit supports it
-    # Broken in distfit due to scipy.stats.kde removal in recent scipy versions.
-    X = np.random.randn(50, 2)
-    y = np.random.randn(50)
-    reg = UnconditionalDistfitRegressor(distr_type="kde")
-    reg.fit(X, y)
-    dist = reg.predict_proba(X)
-    samples = dist.sample(5)
-    assert samples.shape[0] == 5
-
-
-# Note: duplicate test removed to fix F811

--- a/skpro/regression/tests/test_baseline_regressors.py
+++ b/skpro/regression/tests/test_baseline_regressors.py
@@ -11,6 +11,17 @@ from skpro.regression.unconditional_distfit import UnconditionalDistfitRegressor
     reason="distfit not installed",
 )
 def test_unconditional_distfit_regressor():
+    def test_unconditional_distfit_regressor_invalid_distr_type():
+        with pytest.raises(ValueError):
+            UnconditionalDistfitRegressor(distr_type="not_a_dist")
+
+    def test_unconditional_distfit_regressor_multioutput():
+        X = np.random.randn(100, 3)
+        y = np.random.randn(100, 2)
+        reg = UnconditionalDistfitRegressor(distr_type="norm")
+        with pytest.raises(NotImplementedError):
+            reg.fit(X, y)
+
     X = np.random.randn(100, 3)
     y = np.random.randn(100)
     reg = UnconditionalDistfitRegressor(distr_type="norm")
@@ -24,6 +35,17 @@ def test_unconditional_distfit_regressor():
 
 
 def test_deterministic_reduction_regressor_gaussian():
+    def test_deterministic_reduction_regressor_invalid_distr_type():
+        with pytest.raises(ValueError):
+            DeterministicReductionRegressor(LinearRegression(), distr_type="not_a_dist")
+
+    def test_deterministic_reduction_regressor_multioutput():
+        X = np.random.randn(100, 2)
+        y = np.random.randn(100, 2)
+        reg = DeterministicReductionRegressor(LinearRegression(), distr_type="gaussian")
+        with pytest.raises(NotImplementedError):
+            reg.fit(X, y)
+
     X = np.random.randn(100, 2)
     y = np.random.randn(100)
     reg = DeterministicReductionRegressor(LinearRegression(), distr_type="gaussian")
@@ -35,6 +57,24 @@ def test_deterministic_reduction_regressor_gaussian():
 
 
 def test_deterministic_reduction_regressor_laplace():
+    def test_unconditional_distfit_regressor_non_dataframe():
+        # Should work with numpy arrays as y
+        X = np.random.randn(50, 2)
+        y = np.random.randn(50)
+        reg = UnconditionalDistfitRegressor(distr_type="norm")
+        reg.fit(X, y)
+        dist = reg.predict_proba(X)
+        assert hasattr(dist, "mean")
+
+    def test_deterministic_reduction_regressor_non_dataframe():
+        # Should work with numpy arrays as X and y
+        X = np.random.randn(50, 2)
+        y = np.random.randn(50)
+        reg = DeterministicReductionRegressor(LinearRegression(), distr_type="gaussian")
+        reg.fit(X, y)
+        dist = reg.predict_proba(X)
+        assert hasattr(dist, "mean")
+
     X = np.random.randn(100, 2)
     y = np.random.randn(100)
     reg = DeterministicReductionRegressor(LinearRegression(), distr_type="laplace")

--- a/skpro/regression/tests/test_baseline_regressors.py
+++ b/skpro/regression/tests/test_baseline_regressors.py
@@ -1,0 +1,59 @@
+import numpy as np
+import pytest
+from sklearn.linear_model import LinearRegression
+from skpro.regression.unconditional_distfit import UnconditionalDistfitRegressor
+from skpro.regression.deterministic_reduction import DeterministicReductionRegressor
+
+@pytest.mark.skipif(not pytest.importorskip('distfit', reason='distfit required'), reason='distfit not installed')
+def test_unconditional_distfit_regressor():
+    X = np.random.randn(100, 3)
+    y = np.random.randn(100)
+    reg = UnconditionalDistfitRegressor(distr_type='norm')
+    reg.fit(X, y)
+    dist = reg.predict_proba(X)
+    samples = dist.sample(10)
+    assert samples.shape[0] == 10
+    assert hasattr(dist, 'pdf')
+    assert hasattr(dist, 'mean')
+    assert hasattr(dist, 'var')
+
+def test_deterministic_reduction_regressor_gaussian():
+    X = np.random.randn(100, 2)
+    y = np.random.randn(100)
+    reg = DeterministicReductionRegressor(LinearRegression(), distr_type='gaussian')
+    reg.fit(X, y)
+    dist = reg.predict_proba(X)
+    assert hasattr(dist, 'mean')
+    assert hasattr(dist, 'sigma')
+    assert np.allclose(dist.sigma, np.sqrt(np.var(y)))
+
+def test_deterministic_reduction_regressor_laplace():
+    X = np.random.randn(100, 2)
+    y = np.random.randn(100)
+    reg = DeterministicReductionRegressor(LinearRegression(), distr_type='laplace')
+    reg.fit(X, y)
+    dist = reg.predict_proba(X)
+    assert hasattr(dist, 'mu')
+    assert hasattr(dist, 'scale')
+    assert np.allclose(dist.scale, np.sqrt(np.var(y)/2))
+
+@pytest.mark.xfail(reason='distfit KDE broken with recent scipy (scipy.stats.kde removed)')
+def test_unconditional_distfit_regressor_kde():
+    # Test KDE as a nonparametric option if distfit supports it
+    X = np.random.randn(50, 2)
+    y = np.random.randn(50)
+    reg = UnconditionalDistfitRegressor(distr_type='kde')
+    reg.fit(X, y)
+    dist = reg.predict_proba(X)
+    samples = dist.sample(5)
+    assert samples.shape[0] == 5
+
+def test_deterministic_reduction_regressor_laplace():
+    X = np.random.randn(60, 2)
+    y = np.random.randn(60)
+    reg = DeterministicReductionRegressor(LinearRegression(), distr_type='laplace')
+    reg.fit(X, y)
+    dist = reg.predict_proba(X)
+    assert hasattr(dist, 'mu')
+    assert hasattr(dist, 'scale')
+    assert np.allclose(dist.scale, np.sqrt(np.var(y)/2))

--- a/skpro/regression/tests/test_baseline_regressors.py
+++ b/skpro/regression/tests/test_baseline_regressors.py
@@ -1,85 +1,154 @@
 import numpy as np
 import pytest
 from sklearn.linear_model import LinearRegression
+import importlib.util
 
 from skpro.regression.deterministic_reduction import DeterministicReductionRegressor
 from skpro.regression.unconditional_distfit import UnconditionalDistfitRegressor
 
 
-@pytest.mark.skipif(
-    not pytest.importorskip("distfit", reason="distfit required"),
-    reason="distfit not installed",
-)
-def test_unconditional_distfit_regressor():
-    def test_unconditional_distfit_regressor_invalid_distr_type():
-        with pytest.raises(ValueError):
-            UnconditionalDistfitRegressor(distr_type="not_a_dist")
+HAS_DISTFIT = importlib.util.find_spec("distfit") is not None
 
-    def test_unconditional_distfit_regressor_multioutput():
-        X = np.random.randn(100, 3)
-        y = np.random.randn(100, 2)
-        reg = UnconditionalDistfitRegressor(distr_type="norm")
-        with pytest.raises(NotImplementedError):
-            reg.fit(X, y)
+requires_distfit = pytest.mark.skipif(not HAS_DISTFIT, reason="distfit required")
 
-    X = np.random.randn(100, 3)
-    y = np.random.randn(100)
-    reg = UnconditionalDistfitRegressor(distr_type="norm")
+
+@requires_distfit
+def test_unconditional_distfit_regressor_invalid_distr_type():
+    with pytest.raises(ValueError, match="distr_type"):
+        UnconditionalDistfitRegressor(distr_type="not_a_dist")
+
+
+@requires_distfit
+def test_unconditional_distfit_regressor_fit_and_predict():
+    rng = np.random.default_rng(42)
+    X = rng.normal(size=(100, 3))
+    y = rng.normal(size=100)
+
+    reg = UnconditionalDistfitRegressor(distr_type="norm", random_state=42)
     reg.fit(X, y)
     dist = reg.predict_proba(X)
+
     samples = dist.sample(10)
-    assert samples.shape[0] == 10
+    assert samples.shape[0] == 10 * len(X)
     assert hasattr(dist, "pdf")
     assert hasattr(dist, "mean")
     assert hasattr(dist, "var")
 
 
+@requires_distfit
+def test_unconditional_distfit_distribution_parameters_and_mean():
+    rng = np.random.default_rng(123)
+    X = rng.normal(size=(120, 2))
+    y = rng.normal(loc=2.5, scale=1.3, size=120)
+
+    reg = UnconditionalDistfitRegressor(distr_type="laplace", random_state=123)
+    reg.fit(X, y)
+    dist = reg.predict_proba(X)
+
+    model = dist.distfit_obj.model
+    assert isinstance(model, dict)
+    assert "loc" in model
+    assert "scale" in model
+    # distfit is fit on y only; mean of returned distribution should match fitted location.
+    assert np.allclose(dist.mean().values, model["loc"])
+
+
+@requires_distfit
+def test_unconditional_distfit_regressor_multioutput_raises():
+    rng = np.random.default_rng(7)
+    X = rng.normal(size=(100, 3))
+    y = rng.normal(size=(100, 2))
+
+    reg = UnconditionalDistfitRegressor(distr_type="norm")
+    with pytest.raises(NotImplementedError, match="univariate"):
+        reg.fit(X, y)
+
+
+@requires_distfit
+def test_unconditional_distfit_regressor_supports_numpy_arrays():
+    rng = np.random.default_rng(99)
+    X = rng.normal(size=(50, 2))
+    y = rng.normal(size=50)
+
+    reg = UnconditionalDistfitRegressor(distr_type="norm")
+    reg.fit(X, y)
+    dist = reg.predict_proba(X)
+
+    assert hasattr(dist, "mean")
+
+
 def test_deterministic_reduction_regressor_gaussian():
-    def test_deterministic_reduction_regressor_invalid_distr_type():
-        with pytest.raises(ValueError):
-            DeterministicReductionRegressor(LinearRegression(), distr_type="not_a_dist")
+    rng = np.random.default_rng(24)
+    X = rng.normal(size=(100, 2))
+    y = rng.normal(size=100)
 
-    def test_deterministic_reduction_regressor_multioutput():
-        X = np.random.randn(100, 2)
-        y = np.random.randn(100, 2)
-        reg = DeterministicReductionRegressor(LinearRegression(), distr_type="gaussian")
-        with pytest.raises(NotImplementedError):
-            reg.fit(X, y)
-
-    X = np.random.randn(100, 2)
-    y = np.random.randn(100)
     reg = DeterministicReductionRegressor(LinearRegression(), distr_type="gaussian")
     reg.fit(X, y)
     dist = reg.predict_proba(X)
+
     assert hasattr(dist, "mean")
     assert hasattr(dist, "sigma")
     assert np.allclose(dist.sigma, np.sqrt(np.var(y)))
 
 
+def test_deterministic_reduction_regressor_invalid_distr_type():
+    with pytest.raises(ValueError, match="distr_type"):
+        DeterministicReductionRegressor(LinearRegression(), distr_type="not_a_dist")
+
+
+def test_deterministic_reduction_regressor_multioutput_raises():
+    rng = np.random.default_rng(8)
+    X = rng.normal(size=(100, 2))
+    y = rng.normal(size=(100, 2))
+
+    reg = DeterministicReductionRegressor(LinearRegression(), distr_type="gaussian")
+    with pytest.raises(NotImplementedError, match="univariate"):
+        reg.fit(X, y)
+
+
+def test_deterministic_reduction_regressor_supports_numpy_arrays():
+    rng = np.random.default_rng(101)
+    X = rng.normal(size=(50, 2))
+    y = rng.normal(size=50)
+
+    reg = DeterministicReductionRegressor(LinearRegression(), distr_type="gaussian")
+    reg.fit(X, y)
+    dist = reg.predict_proba(X)
+
+    assert hasattr(dist, "mean")
+
+
+@pytest.mark.parametrize("distr_type", ["gaussian", "laplace"])
+def test_deterministic_reduction_distribution_correctness(distr_type):
+    rng = np.random.default_rng(202)
+    X = rng.normal(size=(120, 3))
+    y = 1.5 * X[:, 0] - 0.3 * X[:, 1] + rng.normal(scale=0.2, size=120)
+
+    reg = DeterministicReductionRegressor(LinearRegression(), distr_type=distr_type)
+    reg.fit(X, y)
+    dist = reg.predict_proba(X)
+
+    pred = reg.regressor_.predict(X).reshape(-1, 1)
+    mean_df = dist.mean()
+
+    assert np.allclose(mean_df.values, pred)
+    if distr_type == "gaussian":
+        assert hasattr(dist, "sigma")
+        assert np.allclose(dist.sigma, np.sqrt(np.var(y)))
+    else:
+        assert hasattr(dist, "scale")
+        assert np.allclose(dist.scale, np.sqrt(np.var(y) / 2))
+
+
 def test_deterministic_reduction_regressor_laplace():
-    def test_unconditional_distfit_regressor_non_dataframe():
-        # Should work with numpy arrays as y
-        X = np.random.randn(50, 2)
-        y = np.random.randn(50)
-        reg = UnconditionalDistfitRegressor(distr_type="norm")
-        reg.fit(X, y)
-        dist = reg.predict_proba(X)
-        assert hasattr(dist, "mean")
+    rng = np.random.default_rng(77)
+    X = rng.normal(size=(100, 2))
+    y = rng.normal(size=100)
 
-    def test_deterministic_reduction_regressor_non_dataframe():
-        # Should work with numpy arrays as X and y
-        X = np.random.randn(50, 2)
-        y = np.random.randn(50)
-        reg = DeterministicReductionRegressor(LinearRegression(), distr_type="gaussian")
-        reg.fit(X, y)
-        dist = reg.predict_proba(X)
-        assert hasattr(dist, "mean")
-
-    X = np.random.randn(100, 2)
-    y = np.random.randn(100)
     reg = DeterministicReductionRegressor(LinearRegression(), distr_type="laplace")
     reg.fit(X, y)
     dist = reg.predict_proba(X)
+
     assert hasattr(dist, "mu")
     assert hasattr(dist, "scale")
     assert np.allclose(dist.scale, np.sqrt(np.var(y) / 2))

--- a/skpro/regression/tests/test_baseline_regressors.py
+++ b/skpro/regression/tests/test_baseline_regressors.py
@@ -1,59 +1,64 @@
 import numpy as np
 import pytest
 from sklearn.linear_model import LinearRegression
-from skpro.regression.unconditional_distfit import UnconditionalDistfitRegressor
-from skpro.regression.deterministic_reduction import DeterministicReductionRegressor
 
-@pytest.mark.skipif(not pytest.importorskip('distfit', reason='distfit required'), reason='distfit not installed')
+from skpro.regression.deterministic_reduction import DeterministicReductionRegressor
+from skpro.regression.unconditional_distfit import UnconditionalDistfitRegressor
+
+
+@pytest.mark.skipif(
+    not pytest.importorskip("distfit", reason="distfit required"),
+    reason="distfit not installed",
+)
 def test_unconditional_distfit_regressor():
     X = np.random.randn(100, 3)
     y = np.random.randn(100)
-    reg = UnconditionalDistfitRegressor(distr_type='norm')
+    reg = UnconditionalDistfitRegressor(distr_type="norm")
     reg.fit(X, y)
     dist = reg.predict_proba(X)
     samples = dist.sample(10)
     assert samples.shape[0] == 10
-    assert hasattr(dist, 'pdf')
-    assert hasattr(dist, 'mean')
-    assert hasattr(dist, 'var')
+    assert hasattr(dist, "pdf")
+    assert hasattr(dist, "mean")
+    assert hasattr(dist, "var")
+
 
 def test_deterministic_reduction_regressor_gaussian():
     X = np.random.randn(100, 2)
     y = np.random.randn(100)
-    reg = DeterministicReductionRegressor(LinearRegression(), distr_type='gaussian')
+    reg = DeterministicReductionRegressor(LinearRegression(), distr_type="gaussian")
     reg.fit(X, y)
     dist = reg.predict_proba(X)
-    assert hasattr(dist, 'mean')
-    assert hasattr(dist, 'sigma')
+    assert hasattr(dist, "mean")
+    assert hasattr(dist, "sigma")
     assert np.allclose(dist.sigma, np.sqrt(np.var(y)))
+
 
 def test_deterministic_reduction_regressor_laplace():
     X = np.random.randn(100, 2)
     y = np.random.randn(100)
-    reg = DeterministicReductionRegressor(LinearRegression(), distr_type='laplace')
+    reg = DeterministicReductionRegressor(LinearRegression(), distr_type="laplace")
     reg.fit(X, y)
     dist = reg.predict_proba(X)
-    assert hasattr(dist, 'mu')
-    assert hasattr(dist, 'scale')
-    assert np.allclose(dist.scale, np.sqrt(np.var(y)/2))
+    assert hasattr(dist, "mu")
+    assert hasattr(dist, "scale")
+    assert np.allclose(dist.scale, np.sqrt(np.var(y) / 2))
 
-@pytest.mark.xfail(reason='distfit KDE broken with recent scipy (scipy.stats.kde removed)')
+
+@pytest.mark.xfail(
+    reason="distfit KDE support is broken with recent scipy (scipy.stats.kde removed).",
+    strict=False,
+)
 def test_unconditional_distfit_regressor_kde():
     # Test KDE as a nonparametric option if distfit supports it
+    # Broken in distfit due to scipy.stats.kde removal in recent scipy versions.
     X = np.random.randn(50, 2)
     y = np.random.randn(50)
-    reg = UnconditionalDistfitRegressor(distr_type='kde')
+    reg = UnconditionalDistfitRegressor(distr_type="kde")
     reg.fit(X, y)
     dist = reg.predict_proba(X)
     samples = dist.sample(5)
     assert samples.shape[0] == 5
 
-def test_deterministic_reduction_regressor_laplace():
-    X = np.random.randn(60, 2)
-    y = np.random.randn(60)
-    reg = DeterministicReductionRegressor(LinearRegression(), distr_type='laplace')
-    reg.fit(X, y)
-    dist = reg.predict_proba(X)
-    assert hasattr(dist, 'mu')
-    assert hasattr(dist, 'scale')
-    assert np.allclose(dist.scale, np.sqrt(np.var(y)/2))
+
+# Note: duplicate test removed to fix F811

--- a/skpro/regression/tests/test_baseline_regressors.py
+++ b/skpro/regression/tests/test_baseline_regressors.py
@@ -1,11 +1,11 @@
+import importlib.util
+
 import numpy as np
 import pytest
 from sklearn.linear_model import LinearRegression
-import importlib.util
 
 from skpro.regression.deterministic_reduction import DeterministicReductionRegressor
 from skpro.regression.unconditional_distfit import UnconditionalDistfitRegressor
-
 
 HAS_DISTFIT = importlib.util.find_spec("distfit") is not None
 
@@ -49,7 +49,8 @@ def test_unconditional_distfit_distribution_parameters_and_mean():
     assert isinstance(model, dict)
     assert "loc" in model
     assert "scale" in model
-    # distfit is fit on y only; mean of returned distribution should match fitted location.
+    # distfit is fit on y only.
+    # mean of returned distribution should match fitted location.
     assert np.allclose(dist.mean().values, model["loc"])
 
 

--- a/skpro/regression/unconditional_distfit.py
+++ b/skpro/regression/unconditional_distfit.py
@@ -80,7 +80,7 @@ class UnconditionalDistfitRegressor(BaseProbaRegressor):
         # Block KDE usage due to scipy.stats.kde deprecation in distfit
         if self.fit_kde or self.distr_type == "kde":
             raise RuntimeError(
-                "distfit KDE support is broken due to scipy.stats.kde removal in recent scipy. "
+                "distfit KDE support broken due to scipy.stats.kde removal. "
                 "Please use a different distribution type or set fit_kde=False."
             )
         if self.fit_histogram:

--- a/skpro/regression/unconditional_distfit.py
+++ b/skpro/regression/unconditional_distfit.py
@@ -1,15 +1,13 @@
-"""
-Unconditional probabilistic regression baseline using distfit.
+"""Unconditional probabilistic regression baseline using distfit.
 
-This regressor ignores all features and fits a univariate density to the target using distfit.
+Regressor ignores all features and fits a univariate density to target using distfit.
 """
-
 
 import numpy as np
-from skpro.regression.base import BaseProbaRegressor
-from skpro.distributions.base import BaseDistribution
-
 from distfit import distfit
+
+from skpro.distributions.base import BaseDistribution
+from skpro.regression.base import BaseProbaRegressor
 
 
 class UnconditionalDistfitRegressor(BaseProbaRegressor):
@@ -17,27 +15,47 @@ class UnconditionalDistfitRegressor(BaseProbaRegressor):
     Featureless unconditional probabilistic regressor using distfit.
 
     Fits a univariate density to the target using distfit, ignoring all features.
-    Supports parametric (e.g., normal, laplace), nonparametric (kde), and histogram fitting via distfit's API.
+    Supports parametric (e.g., normal, laplace), nonparametric (kde),
+    and histogram fitting via distfit's API.
 
     References
     ----------
-    - mlr3proba: Probabilistic Supervised Learning in R (mlr3 book chapter on density estimation, 2020–ongoing).
+    - mlr3proba: Probabilistic Supervised Learning in R (density estimation).
       https://mlr3book.mlr-org.com/chapters/chapter13/beyond_regression_and_classification.html
-    - LinCDE: Conditional Density Estimation via Lindsey’s Method (Gao & Hastie, JMLR 2022).
-      https://jmlr.org/papers/volume23/21-0840/21-0840.pdf
+    - LinCDE: Conditional Density Estimation via Lindsey’s Method
+      (Gao & Hastie, JMLR 2022). https://jmlr.org/papers/volume23/21-0840/21-0840.pdf
     - Conditional Density Estimation with Histogram Trees (Yang et al., NeurIPS 2024).
       https://arxiv.org/html/2410.11449v1
     - Nonparametric Conditional Density Estimation (Hansen, 2004).
       https://users.ssc.wisc.edu/~behansen/papers/ncde.pdf
     - distfit documentation: https://erdogant.github.io/distfit/
+
+    Examples
+    --------
+    >>> from skpro.regression.unconditional_distfit import \
+    ...     UnconditionalDistfitRegressor
+    >>> import numpy as np
+    >>> X = np.random.randn(100, 2)
+    >>> y = np.random.randn(100)
+    >>> reg = UnconditionalDistfitRegressor(distr_type='norm')
+    >>> reg.fit(X, y)
+    >>> dist = reg.predict_proba(X)
+    >>> samples = dist.sample(5)
+    >>> print(samples.shape)
+    (5,)
     """
 
-    def __init__(self, distr_type='norm', random_state=None, fit_kde=False, fit_histogram=False):
+    def __init__(
+        self, distr_type="norm", random_state=None, fit_kde=False, fit_histogram=False
+    ):
         """
+        Initialize UnconditionalDistfitRegressor.
+
         Parameters
         ----------
         distr_type : str, default='norm'
-            Distribution type for distfit (e.g., 'norm', 'laplace', etc.; see distfit docs for full list).
+            Distribution type for distfit (e.g., 'norm', 'laplace', etc.; see
+            distfit docs for full list).
         random_state : int or None
             Random seed for reproducibility.
         fit_kde : bool, default=False
@@ -52,13 +70,15 @@ class UnconditionalDistfitRegressor(BaseProbaRegressor):
         super().__init__()
 
     def _fit(self, X, y, C=None):
-        y_arr = y.values.flatten() if hasattr(y, 'values') else np.asarray(y).flatten()
+        y_arr = y.values.flatten() if hasattr(y, "values") else np.asarray(y).flatten()
         if self.fit_kde:
-            self.distfit_ = distfit(distr='kde', random_state=self.random_state)
+            self.distfit_ = distfit(distr="kde", random_state=self.random_state)
         elif self.fit_histogram:
-            self.distfit_ = distfit(distr='histogram', random_state=self.random_state)
+            self.distfit_ = distfit(distr="histogram", random_state=self.random_state)
         else:
-            self.distfit_ = distfit(distr=self.distr_type, random_state=self.random_state)
+            self.distfit_ = distfit(
+                distr=self.distr_type, random_state=self.random_state
+            )
         self.distfit_.fit_transform(y_arr)
         return self
 
@@ -66,8 +86,10 @@ class UnconditionalDistfitRegressor(BaseProbaRegressor):
         # Return a distribution object that wraps the fitted distfit
         return _DistfitDistribution(self.distfit_)
 
+
 class _DistfitDistribution(BaseDistribution):
     """Wraps a distfit fitted object as a skpro distribution."""
+
     def __init__(self, distfit_obj):
         self.distfit_obj = distfit_obj
         super().__init__()

--- a/skpro/regression/unconditional_distfit.py
+++ b/skpro/regression/unconditional_distfit.py
@@ -122,7 +122,7 @@ class _DistfitDistribution(BaseDistribution):
             if "mean" in model:
                 return model["mean"]
             raise AttributeError(
-                "distfit model dict has neither 'loc' nor 'mean' key; cannot determine mean."
+                "distfit dict has neither 'loc' nor 'mean' key; cannot determine mean."
             )
         return model.mean()
 

--- a/skpro/regression/unconditional_distfit.py
+++ b/skpro/regression/unconditional_distfit.py
@@ -15,8 +15,27 @@ class UnconditionalDistfitRegressor(BaseProbaRegressor):
     Featureless unconditional probabilistic regressor using distfit.
 
     Fits a univariate density to the target using distfit, ignoring all features.
-    Supports parametric (e.g., normal, laplace), nonparametric (kde),
-    and histogram fitting via distfit's API.
+    Supports parametric (e.g., normal, laplace) and histogram fitting via distfit's API.
+    Multi-output y is not supported (raises NotImplementedError).
+
+    This is a constant-uncertainty baseline: uncertainty does not shrink with more
+    data. Requires the optional dependency `distfit` (install with
+    `pip install distfit`).
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from skpro.regression.unconditional_distfit import (
+    ...     UnconditionalDistfitRegressor
+    ... )
+    >>> y = pd.DataFrame([1, 2, 3, 4, 5])
+    >>> X = pd.DataFrame(index=y.index)  # featureless DataFrame
+    >>> reg = UnconditionalDistfitRegressor(distr_type="norm")
+    >>> reg.fit(X, y)
+    UnconditionalDistfitRegressor()
+    >>> dist = reg.predict_proba(X)
+    >>> dist.mean()
+    3.0
 
     References
     ----------
@@ -49,19 +68,22 @@ class UnconditionalDistfitRegressor(BaseProbaRegressor):
     }
 
     def __init__(self, distr_type="norm", random_state=None, fit_histogram=False):
-        """
-        Initialize UnconditionalDistfitRegressor.
+        """Initialize UnconditionalDistfitRegressor.
 
         Parameters
         ----------
         distr_type : str, default='norm'
-            Distribution type for distfit (e.g., 'norm', 'laplace', etc.; see
-            distfit docs for full list).
+            Distribution type for distfit (e.g., 'norm', 'laplace'; see distfit docs).
         random_state : int or None
             Random seed for reproducibility.
         fit_histogram : bool, default=False
             If True, fit a histogram using distfit's histogram option.
         """
+        allowed_types = ["norm", "laplace", "histogram"]
+        if distr_type not in allowed_types:
+            raise ValueError(
+                f"distr_type must be one of {allowed_types}, got {distr_type}"
+            )
         self.distr_type = distr_type
         self.random_state = random_state
         self.fit_histogram = fit_histogram
@@ -72,7 +94,11 @@ class UnconditionalDistfitRegressor(BaseProbaRegressor):
         from distfit import distfit
 
         y_arr = y.values.flatten() if hasattr(y, "values") else np.asarray(y).flatten()
-        # KDE support removed due to scipy.stats.kde deprecation in distfit
+        if y_arr.ndim != 1:
+            raise NotImplementedError(
+                "UnconditionalDistfitRegressor only supports univariate y. Got shape: "
+                + str(y.shape)
+            )
         if self.distr_type == "kde":
             raise RuntimeError(
                 "KDE support is removed due to scipy.stats.kde deprecation in distfit. "

--- a/skpro/regression/unconditional_distfit.py
+++ b/skpro/regression/unconditional_distfit.py
@@ -48,6 +48,7 @@ class UnconditionalDistfitRegressor(BaseProbaRegressor):
         "tests:vm": True,  # set True if special VM is needed
     }
 
+
     def __init__(self, distr_type="norm", random_state=None, fit_histogram=False):
         """
         Initialize UnconditionalDistfitRegressor.
@@ -117,7 +118,11 @@ class _DistfitDistribution(BaseDistribution):
         return self.distfit_obj.model.mean()
 
     def var(self):
-        return self.distfit_obj.model.var()
+        # For normal/laplace, variance is scale**2
+        model = self.distfit_obj.model
+        if isinstance(model, dict) and "scale" in model:
+            return model["scale"] ** 2
+        raise AttributeError("distfit model does not have a 'scale' (variance) attribute")
 
     def get_params(self, deep=True):
         """Return parameters of the distribution."""

--- a/skpro/regression/unconditional_distfit.py
+++ b/skpro/regression/unconditional_distfit.py
@@ -77,9 +77,13 @@ class UnconditionalDistfitRegressor(BaseProbaRegressor):
         from distfit import distfit
 
         y_arr = y.values.flatten() if hasattr(y, "values") else np.asarray(y).flatten()
-        if self.fit_kde:
-            self.distfit_ = distfit(distr="kde", random_state=self.random_state)
-        elif self.fit_histogram:
+        # Block KDE usage due to scipy.stats.kde deprecation in distfit
+        if self.fit_kde or self.distr_type == "kde":
+            raise RuntimeError(
+                "distfit KDE support is broken due to scipy.stats.kde removal in recent scipy. "
+                "Please use a different distribution type or set fit_kde=False."
+            )
+        if self.fit_histogram:
             self.distfit_ = distfit(distr="histogram", random_state=self.random_state)
         else:
             self.distfit_ = distfit(

--- a/skpro/regression/unconditional_distfit.py
+++ b/skpro/regression/unconditional_distfit.py
@@ -48,7 +48,6 @@ class UnconditionalDistfitRegressor(BaseProbaRegressor):
         "tests:vm": True,  # set True if special VM is needed
     }
 
-
     def __init__(self, distr_type="norm", random_state=None, fit_histogram=False):
         """
         Initialize UnconditionalDistfitRegressor.
@@ -122,7 +121,9 @@ class _DistfitDistribution(BaseDistribution):
         model = self.distfit_obj.model
         if isinstance(model, dict) and "scale" in model:
             return model["scale"] ** 2
-        raise AttributeError("distfit model does not have a 'scale' (variance) attribute")
+        raise AttributeError(
+            "distfit model does not have a 'scale' (variance) attribute"
+        )
 
     def get_params(self, deep=True):
         """Return parameters of the distribution."""

--- a/skpro/regression/unconditional_distfit.py
+++ b/skpro/regression/unconditional_distfit.py
@@ -49,7 +49,7 @@ class UnconditionalDistfitRegressor(BaseProbaRegressor):
     }
 
     def __init__(
-        self, distr_type="norm", random_state=None, fit_kde=True, fit_histogram=False
+        self, distr_type="norm", random_state=None, fit_histogram=False
     ):
         """
         Initialize UnconditionalDistfitRegressor.
@@ -61,14 +61,11 @@ class UnconditionalDistfitRegressor(BaseProbaRegressor):
             distfit docs for full list).
         random_state : int or None
             Random seed for reproducibility.
-            fit_kde : bool, default=True
-                If True, fit a KDE (kernel density estimate) using distfit's kde option.
         fit_histogram : bool, default=False
             If True, fit a histogram using distfit's histogram option.
         """
         self.distr_type = distr_type
         self.random_state = random_state
-        self.fit_kde = fit_kde
         self.fit_histogram = fit_histogram
         super().__init__()
 
@@ -77,11 +74,11 @@ class UnconditionalDistfitRegressor(BaseProbaRegressor):
         from distfit import distfit
 
         y_arr = y.values.flatten() if hasattr(y, "values") else np.asarray(y).flatten()
-        # Block KDE usage due to scipy.stats.kde deprecation in distfit
-        if self.fit_kde or self.distr_type == "kde":
+        # KDE support removed due to scipy.stats.kde deprecation in distfit
+        if self.distr_type == "kde":
             raise RuntimeError(
-                "distfit KDE support broken due to scipy.stats.kde removal. "
-                "Please use a different distribution type or set fit_kde=False."
+                "KDE support is removed due to scipy.stats.kde deprecation in distfit. "
+                "Please use a different distribution type."
             )
         if self.fit_histogram:
             self.distfit_ = distfit(distr="histogram", random_state=self.random_state)
@@ -100,8 +97,8 @@ class UnconditionalDistfitRegressor(BaseProbaRegressor):
     def get_test_params(cls, parameter_set="default"):
         """Return testing parameter sets for automated tests."""
         return [
-            {"distr_type": "norm", "fit_kde": False, "fit_histogram": False},
-            {"distr_type": "laplace", "fit_kde": True, "fit_histogram": False},
+            {"distr_type": "norm", "fit_histogram": False},
+            {"distr_type": "laplace", "fit_histogram": False},
         ]
 
 

--- a/skpro/regression/unconditional_distfit.py
+++ b/skpro/regression/unconditional_distfit.py
@@ -114,7 +114,10 @@ class _DistfitDistribution(BaseDistribution):
         return self.distfit_obj.model.pdf(x)
 
     def mean(self):
-        return self.distfit_obj.model.mean()
+        model = self.distfit_obj.model
+        if isinstance(model, dict) and "loc" in model:
+            return model["loc"]
+        return model.mean()
 
     def var(self):
         # For normal/laplace, variance is scale**2

--- a/skpro/regression/unconditional_distfit.py
+++ b/skpro/regression/unconditional_distfit.py
@@ -29,20 +29,6 @@ class UnconditionalDistfitRegressor(BaseProbaRegressor):
     - Nonparametric Conditional Density Estimation (Hansen, 2004).
       https://users.ssc.wisc.edu/~behansen/papers/ncde.pdf
     - distfit documentation: https://erdogant.github.io/distfit/
-
-    Examples
-    --------
-    >>> from skpro.regression.unconditional_distfit import \
-        ...     UnconditionalDistfitRegressor
-    >>> import numpy as np
-    >>> X = np.random.randn(100, 2)
-    >>> y = np.random.randn(100)
-    >>> reg = UnconditionalDistfitRegressor(distr_type='norm')
-    >>> reg.fit(X, y)
-    >>> dist = reg.predict_proba(X)
-    >>> samples = dist.sample(5)
-    >>> print(samples.shape)
-    (5,)
     """
 
     _tags = {

--- a/skpro/regression/unconditional_distfit.py
+++ b/skpro/regression/unconditional_distfit.py
@@ -48,9 +48,7 @@ class UnconditionalDistfitRegressor(BaseProbaRegressor):
         "tests:vm": True,  # set True if special VM is needed
     }
 
-    def __init__(
-        self, distr_type="norm", random_state=None, fit_histogram=False
-    ):
+    def __init__(self, distr_type="norm", random_state=None, fit_histogram=False):
         """
         Initialize UnconditionalDistfitRegressor.
 

--- a/skpro/regression/unconditional_distfit.py
+++ b/skpro/regression/unconditional_distfit.py
@@ -1,0 +1,85 @@
+"""
+Unconditional probabilistic regression baseline using distfit.
+
+This regressor ignores all features and fits a univariate density to the target using distfit.
+"""
+
+
+import numpy as np
+from skpro.regression.base import BaseProbaRegressor
+from skpro.distributions.base import BaseDistribution
+
+from distfit import distfit
+
+
+class UnconditionalDistfitRegressor(BaseProbaRegressor):
+    """
+    Featureless unconditional probabilistic regressor using distfit.
+
+    Fits a univariate density to the target using distfit, ignoring all features.
+    Supports parametric (e.g., normal, laplace), nonparametric (kde), and histogram fitting via distfit's API.
+
+    References
+    ----------
+    - mlr3proba: Probabilistic Supervised Learning in R (mlr3 book chapter on density estimation, 2020–ongoing).
+      https://mlr3book.mlr-org.com/chapters/chapter13/beyond_regression_and_classification.html
+    - LinCDE: Conditional Density Estimation via Lindsey’s Method (Gao & Hastie, JMLR 2022).
+      https://jmlr.org/papers/volume23/21-0840/21-0840.pdf
+    - Conditional Density Estimation with Histogram Trees (Yang et al., NeurIPS 2024).
+      https://arxiv.org/html/2410.11449v1
+    - Nonparametric Conditional Density Estimation (Hansen, 2004).
+      https://users.ssc.wisc.edu/~behansen/papers/ncde.pdf
+    - distfit documentation: https://erdogant.github.io/distfit/
+    """
+
+    def __init__(self, distr_type='norm', random_state=None, fit_kde=False, fit_histogram=False):
+        """
+        Parameters
+        ----------
+        distr_type : str, default='norm'
+            Distribution type for distfit (e.g., 'norm', 'laplace', etc.; see distfit docs for full list).
+        random_state : int or None
+            Random seed for reproducibility.
+        fit_kde : bool, default=False
+            If True, fit a KDE (kernel density estimate) using distfit's kde option.
+        fit_histogram : bool, default=False
+            If True, fit a histogram using distfit's histogram option.
+        """
+        self.distr_type = distr_type
+        self.random_state = random_state
+        self.fit_kde = fit_kde
+        self.fit_histogram = fit_histogram
+        super().__init__()
+
+    def _fit(self, X, y, C=None):
+        y_arr = y.values.flatten() if hasattr(y, 'values') else np.asarray(y).flatten()
+        if self.fit_kde:
+            self.distfit_ = distfit(distr='kde', random_state=self.random_state)
+        elif self.fit_histogram:
+            self.distfit_ = distfit(distr='histogram', random_state=self.random_state)
+        else:
+            self.distfit_ = distfit(distr=self.distr_type, random_state=self.random_state)
+        self.distfit_.fit_transform(y_arr)
+        return self
+
+    def _predict_proba(self, X):
+        # Return a distribution object that wraps the fitted distfit
+        return _DistfitDistribution(self.distfit_)
+
+class _DistfitDistribution(BaseDistribution):
+    """Wraps a distfit fitted object as a skpro distribution."""
+    def __init__(self, distfit_obj):
+        self.distfit_obj = distfit_obj
+        super().__init__()
+
+    def sample(self, n_samples=1):
+        return self.distfit_obj.generate(n_samples)
+
+    def pdf(self, x):
+        return self.distfit_obj.model.pdf(x)
+
+    def mean(self):
+        return self.distfit_obj.model.mean()
+
+    def var(self):
+        return self.distfit_obj.model.var()

--- a/skpro/regression/unconditional_distfit.py
+++ b/skpro/regression/unconditional_distfit.py
@@ -49,7 +49,7 @@ class UnconditionalDistfitRegressor(BaseProbaRegressor):
     }
 
     def __init__(
-        self, distr_type="norm", random_state=None, fit_kde=False, fit_histogram=False
+        self, distr_type="norm", random_state=None, fit_kde=True, fit_histogram=False
     ):
         """
         Initialize UnconditionalDistfitRegressor.
@@ -68,7 +68,7 @@ class UnconditionalDistfitRegressor(BaseProbaRegressor):
         """
         self.distr_type = distr_type
         self.random_state = random_state
-        self.fit_kde = False
+        self.fit_kde = fit_kde
         self.fit_histogram = fit_histogram
         super().__init__()
 

--- a/skpro/regression/unconditional_distfit.py
+++ b/skpro/regression/unconditional_distfit.py
@@ -45,7 +45,7 @@ class UnconditionalDistfitRegressor(BaseProbaRegressor):
         "y_inner_mtype": "pd_DataFrame_Table",
         # CI and test flags
         # -----------------
-        "tests:vm": True,  # set True if special VM is needed
+        "tests:vm": False,  # set True if special VM is needed
     }
 
     def __init__(self, distr_type="norm", random_state=None, fit_histogram=False):

--- a/skpro/regression/unconditional_distfit.py
+++ b/skpro/regression/unconditional_distfit.py
@@ -88,7 +88,7 @@ class UnconditionalDistfitRegressor(BaseProbaRegressor):
         return self
 
     def _predict_proba(self, X):
-        # Return a distribution object that wraps the fitted distfit
+        # Return a single distribution object for all samples
         return _DistfitDistribution(self.distfit_)
 
     @classmethod

--- a/skpro/regression/unconditional_distfit.py
+++ b/skpro/regression/unconditional_distfit.py
@@ -115,8 +115,15 @@ class _DistfitDistribution(BaseDistribution):
 
     def mean(self):
         model = self.distfit_obj.model
-        if isinstance(model, dict) and "loc" in model:
-            return model["loc"]
+        if isinstance(model, dict):
+            # distfit returns 'loc' for normal/laplace, sometimes 'mean' for others
+            if "loc" in model:
+                return model["loc"]
+            if "mean" in model:
+                return model["mean"]
+            raise AttributeError(
+                "distfit model dict has neither 'loc' nor 'mean' key; cannot determine mean."
+            )
         return model.mean()
 
     def var(self):

--- a/skpro/regression/unconditional_distfit.py
+++ b/skpro/regression/unconditional_distfit.py
@@ -3,8 +3,8 @@
 Regressor ignores all features and fits a univariate density to target using distfit.
 """
 
+
 import numpy as np
-from distfit import distfit
 
 from skpro.distributions.base import BaseDistribution
 from skpro.regression.base import BaseProbaRegressor
@@ -45,6 +45,23 @@ class UnconditionalDistfitRegressor(BaseProbaRegressor):
     (5,)
     """
 
+    _tags = {
+        # packaging info
+        # --------------
+        "authors": ["arnavk23"],
+        "estimator_type": "regressor_proba",
+        "python_dependencies": "distfit>=1.6.8",
+        # estimator tags
+        # --------------
+        "capability:multioutput": False,
+        "capability:missing": True,
+        "X_inner_mtype": "pd_DataFrame_Table",
+        "y_inner_mtype": "pd_DataFrame_Table",
+        # CI and test flags
+        # -----------------
+        "tests:vm": True,  # set True if special VM is needed
+    }
+
     def __init__(
         self, distr_type="norm", random_state=None, fit_kde=False, fit_histogram=False
     ):
@@ -70,6 +87,9 @@ class UnconditionalDistfitRegressor(BaseProbaRegressor):
         super().__init__()
 
     def _fit(self, X, y, C=None):
+        # Import distfit only when needed for dependency isolation
+        from distfit import distfit
+
         y_arr = y.values.flatten() if hasattr(y, "values") else np.asarray(y).flatten()
         if self.fit_kde:
             self.distfit_ = distfit(distr="kde", random_state=self.random_state)
@@ -85,6 +105,14 @@ class UnconditionalDistfitRegressor(BaseProbaRegressor):
     def _predict_proba(self, X):
         # Return a distribution object that wraps the fitted distfit
         return _DistfitDistribution(self.distfit_)
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter sets for automated tests."""
+        return [
+            {"distr_type": "norm", "fit_kde": False, "fit_histogram": False},
+            {"distr_type": "laplace", "fit_kde": True, "fit_histogram": False},
+        ]
 
 
 class _DistfitDistribution(BaseDistribution):
@@ -105,3 +133,9 @@ class _DistfitDistribution(BaseDistribution):
 
     def var(self):
         return self.distfit_obj.model.var()
+
+    def get_params(self, deep=True):
+        """Return parameters of the distribution."""
+        # Example: expose distfit_obj and its distribution type if available
+        distr_type = getattr(self.distfit_obj, "distr", None)
+        return {"distfit_obj": self.distfit_obj, "distr_type": distr_type}

--- a/skpro/regression/unconditional_distfit.py
+++ b/skpro/regression/unconditional_distfit.py
@@ -34,7 +34,7 @@ class UnconditionalDistfitRegressor(BaseProbaRegressor):
     >>> reg.fit(X, y)
     UnconditionalDistfitRegressor()
     >>> dist = reg.predict_proba(X)
-    >>> dist.mean()
+    >>> float(dist.mean().iloc[0, 0])
     3.0
 
     References
@@ -93,19 +93,30 @@ class UnconditionalDistfitRegressor(BaseProbaRegressor):
         # Import distfit only when needed for dependency isolation
         from distfit import distfit
 
-        y_arr = y.values.flatten() if hasattr(y, "values") else np.asarray(y).flatten()
-        if y_arr.ndim != 1:
+        y_arr_raw = y.values if hasattr(y, "values") else np.asarray(y)
+        if y_arr_raw.ndim > 2 or (y_arr_raw.ndim == 2 and y_arr_raw.shape[1] > 1):
             raise NotImplementedError(
                 "UnconditionalDistfitRegressor only supports univariate y. Got shape: "
-                + str(y.shape)
+                + str(y_arr_raw.shape)
             )
+
+        if hasattr(y, "columns"):
+            self._y_cols = y.columns
+        else:
+            self._y_cols = ["0"]
+
+        y_arr = np.asarray(y_arr_raw).reshape(-1)
         if self.distr_type == "kde":
             raise RuntimeError(
                 "KDE support is removed due to scipy.stats.kde deprecation in distfit. "
                 "Please use a different distribution type."
             )
         if self.fit_histogram:
-            self.distfit_ = distfit(distr="histogram", random_state=self.random_state)
+            raise RuntimeError(
+                "Histogram support is not available in distfit>=2.0.1. "
+                "Please set fit_histogram=False and use a parametric distr_type "
+                "such as 'norm' or 'laplace'."
+            )
         else:
             self.distfit_ = distfit(
                 distr=self.distr_type, random_state=self.random_state
@@ -114,8 +125,8 @@ class UnconditionalDistfitRegressor(BaseProbaRegressor):
         return self
 
     def _predict_proba(self, X):
-        # Return a single distribution object for all samples
-        return _DistfitDistribution(self.distfit_)
+        # Return one-row-per-instance distribution with y-aligned columns.
+        return _DistfitDistribution(self.distfit_, index=X.index, columns=self._y_cols)
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):
@@ -129,37 +140,59 @@ class UnconditionalDistfitRegressor(BaseProbaRegressor):
 class _DistfitDistribution(BaseDistribution):
     """Wraps a distfit fitted object as a skpro distribution."""
 
-    def __init__(self, distfit_obj):
+    def __init__(self, distfit_obj, index=None, columns=None, distr_type=None):
+        if isinstance(distfit_obj, np.ndarray):
+            distfit_obj = distfit_obj.item()
+
         self.distfit_obj = distfit_obj
-        super().__init__()
+        if distr_type is None:
+            distr_type = getattr(self.distfit_obj, "distr", None)
+        self.distr_type = distr_type
+        super().__init__(index=index, columns=columns)
 
-    def sample(self, n_samples=1):
-        return self.distfit_obj.generate(n_samples)
-
-    def pdf(self, x):
-        return self.distfit_obj.model.pdf(x)
-
-    def mean(self):
+    def _get_fitted_model(self):
+        """Return fitted scipy frozen distribution when available."""
         model = self.distfit_obj.model
         if isinstance(model, dict):
-            # distfit returns 'loc' for normal/laplace, sometimes 'mean' for others
-            if "loc" in model:
-                return model["loc"]
-            if "mean" in model:
-                return model["mean"]
-            raise AttributeError(
-                "distfit dict has neither 'loc' nor 'mean' key; cannot determine mean."
-            )
-        return model.mean()
+            model = model.get("model", model)
+        return model
 
-    def var(self):
-        # For normal/laplace, variance is scale**2
+    def _get_scalar_mean(self):
+        """Return scalar mean for the fitted distribution."""
+        model = self.distfit_obj.model
+        if isinstance(model, dict):
+            if "loc" in model:
+                return float(model["loc"])
+            if "mean" in model:
+                return float(model["mean"])
+        fitted = self._get_fitted_model()
+        return float(fitted.mean())
+
+    def _get_scalar_var(self):
+        """Return scalar variance for the fitted distribution."""
         model = self.distfit_obj.model
         if isinstance(model, dict) and "scale" in model:
-            return model["scale"] ** 2
-        raise AttributeError(
-            "distfit model does not have a 'scale' (variance) attribute"
-        )
+            return float(model["scale"]) ** 2
+        fitted = self._get_fitted_model()
+        return float(fitted.var())
+
+    def _mean(self):
+        return np.full(self.shape, self._get_scalar_mean(), dtype=float)
+
+    def _var(self):
+        return np.full(self.shape, self._get_scalar_var(), dtype=float)
+
+    def _pdf(self, x):
+        fitted = self._get_fitted_model()
+        return fitted.pdf(x)
+
+    def _cdf(self, x):
+        fitted = self._get_fitted_model()
+        return fitted.cdf(x)
+
+    def _ppf(self, p):
+        fitted = self._get_fitted_model()
+        return fitted.ppf(p)
 
     def get_params(self, deep=True):
         """Return parameters of the distribution."""

--- a/skpro/regression/unconditional_distfit.py
+++ b/skpro/regression/unconditional_distfit.py
@@ -33,7 +33,7 @@ class UnconditionalDistfitRegressor(BaseProbaRegressor):
     Examples
     --------
     >>> from skpro.regression.unconditional_distfit import \
-    ...     UnconditionalDistfitRegressor
+        ...     UnconditionalDistfitRegressor
     >>> import numpy as np
     >>> X = np.random.randn(100, 2)
     >>> y = np.random.randn(100)

--- a/skpro/regression/unconditional_distfit.py
+++ b/skpro/regression/unconditional_distfit.py
@@ -61,14 +61,14 @@ class UnconditionalDistfitRegressor(BaseProbaRegressor):
             distfit docs for full list).
         random_state : int or None
             Random seed for reproducibility.
-        fit_kde : bool, default=False
-            If True, fit a KDE (kernel density estimate) using distfit's kde option.
+            fit_kde : bool, default=True
+                If True, fit a KDE (kernel density estimate) using distfit's kde option.
         fit_histogram : bool, default=False
             If True, fit a histogram using distfit's histogram option.
         """
         self.distr_type = distr_type
         self.random_state = random_state
-        self.fit_kde = fit_kde
+        self.fit_kde = False
         self.fit_histogram = fit_histogram
         super().__init__()
 


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #7

### What does this implement/fix? Explain your changes.
This PR adds two unconditional baselines for probabilistic regression to improve benchmarking:

UnconditionalDistfitRegressor

- Fits a univariate distribution to `y` using `distfit`.
- Ignores `X` entirely by design (feature-agnostic baseline).
- Supports stable distribution choices (`norm`, `laplace`) and histogram mode.

DeterministicReductionRegressor

- Wraps a deterministic regressor.
- Uses deterministic predictions as location (`mu`) and constant uncertainty from training target variance:
- Gaussian: `sigma = sqrt(var(y_train))`
- Laplace: `scale = sqrt(var(y_train) / 2)`

Additional updates:

- Aligns behavior with current `distfit` compatibility constraints.
- Fixes probabilistic output contract behavior for quantiles/intervals and estimator checks.
- Cleans up deprecated KDE path handling (not treated as actively supported in this PR).

### Limitations

UnconditionalDistfitRegressor
- Ignores features completely.
- Cannot model feature-conditional uncertainty or heteroscedasticity.
- Produces global uncertainty not adapted per sample.

DeterministicReductionRegressor

- Uses constant scale across all samples.
- Does not model input-dependent uncertainty.
- Both current `y` target univariate y.

### Does your contribution introduce a new dependency? If yes, which one?
`distfit` is used as a soft dependency.

### What should a reviewer concentrate their feedback on?
- Correctness of Gaussian/Laplace parameterization (`mu`, `sigma`, `scale`)
- Quantile/interval behavior and distribution output contracts
- Mean consistency between wrapped deterministic predictions and returned distributions
- Baseline semantics and documented limitations

### Did you add any tests for the change?
Yes. Tests cover:

- Invalid distribution type handling

- Univariate vs multioutput behavior

- Distribution parameter correctness (`loc`/`scale`, `sigma`/`scale`)
- Mean consistency with deterministic predictions
- Estimator-wide contract checks for probabilistic outputs

### Any other comments?
KDE-related behavior was cleaned up to reflect upstream instability/deprecation in the `distfit`/SciPy stack. This PR does not present KDE as an actively supported option.
- Ensures compatibility with distfit 2.0.1: default `distr_type` is now 'norm' (was 'best').


#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [x] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [x] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
