### PR TITLE
[ENH] add truncated_mean interface to BaseDistribution

### DIFF
--- a/skpro/distributions/base/_base.py
+++ b/skpro/distributions/base/_base.py
@@ -37,7 +37,7 @@ class BaseDistribution(BaseObject):
         "approx_spl": 1000,  # sample size used in other MC estimates
         "bisect_iter": 1000,  # max iters for bisection method in ppf
         # which methods are approximate (not numerically exact) should be listed here
-        "capabilities:approx": ["energy", "mean", "var", "pdfnorm"],
+        "capabilities:approx": ["energy", "mean", "var", "pdfnorm", "truncated_mean"],
         # broadcasting and parameter settings
         # -----------------------------------
         # used to control broadcasting of parameters
@@ -1244,7 +1244,48 @@ class BaseDistribution(BaseObject):
         -------
         2D np.ndarray, same shape as ``self``
             energy values w.r.t. the given points
+
+        Notes
+        -----
+        Uses an analytical shortcut when both ``"truncated_mean"`` and
+        ``"cdf"`` appear in the subclass's ``capabilities:exact`` tag.
+        In that case, the energy is computed via:
+
+        .. math::
+
+            \mathbb{E}[|X - c|]
+            = (\mathbb{E}[X \mid X > c] - c)(1 - F(c))
+            + (c - \mathbb{E}[X \mid X < c]) F(c)
+
+        When either capability is missing, falls back to Monte Carlo
+        via ``_energy_default``.
         """
+        exact_capas = self.get_tag("capabilities:exact", [])
+        has_exact_trunc = "truncated_mean" in exact_capas
+        has_exact_cdf = "cdf" in exact_capas
+
+        if has_exact_trunc and has_exact_cdf:
+            cdf_x = self._cdf(x)
+            x_float = np.asarray(x, dtype=float)
+            inf_arr = np.full_like(x_float, np.inf)
+            neg_inf_arr = np.full_like(x_float, -np.inf)
+
+            right_mean = self._truncated_mean(x_float, inf_arr)
+            left_mean = self._truncated_mean(neg_inf_arr, x_float)
+
+            right_mass = 1 - cdf_x
+            left_mass = cdf_x
+            zero_right = right_mass < 1e-15
+            zero_left = left_mass < 1e-15
+
+            right_term = np.where(zero_right, 0.0, (right_mean - x_float) * right_mass)
+            left_term = np.where(zero_left, 0.0, (x_float - left_mean) * left_mass)
+            energy_arr = right_term + left_term
+
+            if energy_arr.ndim > 0:
+                energy_arr = np.sum(energy_arr, axis=1)
+            return energy_arr
+
         return self._energy_default(x)
 
     def _energy_default(self, x=None):
@@ -1355,18 +1396,35 @@ class BaseDistribution(BaseObject):
         else:
             return spl.mean().iloc[0]
 
-    def mean(self):
+    def mean(self, lower=None, upper=None):
         r"""Return expected value of the distribution.
 
-        Let :math:`X` be a random variable with the distribution of ``self``.
-        Returns the expectation :math:`\mathbb{E}[X]`
+        If ``lower`` or ``upper`` are provided, returns the truncated mean
+        :math:`\mathbb{E}[X \mid \text{lower} < X < \text{upper}]`.
+
+        If both are None (default), returns the ordinary expectation
+        :math:`\mathbb{E}[X]`.
+
+        Parameters
+        ----------
+        lower : float or array-like or None, optional, default=None
+            Lower truncation bound. If None, no lower truncation is applied.
+        upper : float or array-like or None, optional, default=None
+            Upper truncation bound. If None, no upper truncation is applied.
 
         Returns
         -------
         ``pd.DataFrame`` with same rows, columns as ``self``
             expected value of distribution (entry-wise)
         """
-        return self._boilerplate("_mean")
+        if lower is None and upper is None:
+            return self._boilerplate("_mean")
+
+        if lower is None:
+            lower = -np.inf
+        if upper is None:
+            upper = np.inf
+        return self._boilerplate("_truncated_mean", lower=lower, upper=upper)
 
     def _mean(self):
         """Return expected value of the distribution.
@@ -1387,7 +1445,6 @@ class BaseDistribution(BaseObject):
             means = np.mean(np3D, axis=0)
             return means
 
-        # else we have to rely on samples
         approx_method = (
             "by approximating the expected value by the arithmetic mean of "
             f"{approx_spl_size} samples"
@@ -1396,6 +1453,63 @@ class BaseDistribution(BaseObject):
 
         spl = self.sample(approx_spl_size)
         return self._sample_mean(spl)
+
+    def _truncated_mean(self, lower, upper):
+        r"""Return expected value of the distribution truncated to [lower, upper].
+
+        Private method, to be implemented by subclasses.
+
+        Parameters
+        ----------
+        lower : 2D np.ndarray, same shape as ``self``
+            lower truncation bound (entry-wise)
+        upper : 2D np.ndarray, same shape as ``self``
+            upper truncation bound (entry-wise)
+
+        Returns
+        -------
+        2D np.ndarray, same shape as ``self``
+            truncated expected value of distribution (entry-wise)
+        """
+        approx_spl_size = self.get_tag("approx_spl")
+
+        if self._has_implementation_of("_cdf") and self._has_implementation_of("_ppf"):
+            approx_method = (
+                "by approximating the truncated mean via ppf integration "
+                f"over the truncated CDF region, with {approx_spl_size} nodes"
+            )
+            warn(self._method_error_msg("truncated_mean", fill_in=approx_method))
+
+            cdf_l = self._cdf(lower)
+            cdf_u = self._cdf(upper)
+
+            ps = np.linspace(0, 1, approx_spl_size + 2)[1:-1]
+            qs = [self._ppf(cdf_l + p * (cdf_u - cdf_l)) for p in ps]
+            np3D = np.array(qs)
+            result = np.mean(np3D, axis=0)
+
+            zero_mass = np.abs(cdf_u - cdf_l) < 1e-15
+            if np.any(zero_mass):
+                result = np.where(zero_mass, np.nan, result)
+
+            return result
+
+        approx_method = (
+            "by approximating the truncated mean by the arithmetic mean of "
+            f"{approx_spl_size} samples filtered to the truncation bounds"
+        )
+        warn(self._method_error_msg("truncated_mean", fill_in=approx_method))
+
+        spl = self.sample(approx_spl_size)
+        spl_arr = spl.values if hasattr(spl, "values") else np.asarray(spl)
+        spl_arr = spl_arr.reshape(approx_spl_size, *lower.shape)
+
+        mask = (spl_arr >= lower) & (spl_arr <= upper)
+        masked = np.where(mask, spl_arr, np.nan)
+        with np.errstate(all="ignore"):
+            result = np.nanmean(masked, axis=0)
+
+        return result
 
     def var(self):
         r"""Return element/entry-wise variance of the distribution.

--- a/skpro/distributions/base/_base.py
+++ b/skpro/distributions/base/_base.py
@@ -88,7 +88,7 @@ class BaseDistribution(BaseObject):
         "approx_spl": 1000,  # sample size used in other MC estimates
         "bisect_iter": 1000,  # max iters for bisection method in ppf
         # which methods are approximate (not numerically exact) should be listed here
-        "capabilities:approx": ["energy", "mean", "var", "pdfnorm"],
+        "capabilities:approx": ["energy", "mean", "var", "pdfnorm", "truncated_mean"],
         # broadcasting and parameter settings
         # -----------------------------------
         # used to control broadcasting of parameters
@@ -1350,7 +1350,48 @@ class BaseDistribution(BaseObject):
         -------
         2D np.ndarray, same shape as ``self``
             energy values w.r.t. the given points
+
+        Notes
+        -----
+        Uses an analytical shortcut when both ``"truncated_mean"`` and
+        ``"cdf"`` appear in the subclass's ``capabilities:exact`` tag.
+        In that case, the energy is computed via:
+
+        .. math::
+
+            \mathbb{E}[|X - c|]
+            = (\mathbb{E}[X \mid X > c] - c)(1 - F(c))
+            + (c - \mathbb{E}[X \mid X < c]) F(c)
+
+        When either capability is missing, falls back to Monte Carlo
+        via ``_energy_default``.
         """
+        exact_capas = self.get_tag("capabilities:exact", [])
+        has_exact_trunc = "truncated_mean" in exact_capas
+        has_exact_cdf = "cdf" in exact_capas
+
+        if has_exact_trunc and has_exact_cdf:
+            cdf_x = self._cdf(x)
+            x_float = np.asarray(x, dtype=float)
+            inf_arr = np.full_like(x_float, np.inf)
+            neg_inf_arr = np.full_like(x_float, -np.inf)
+
+            right_mean = self._truncated_mean(x_float, inf_arr)
+            left_mean = self._truncated_mean(neg_inf_arr, x_float)
+
+            right_mass = 1 - cdf_x
+            left_mass = cdf_x
+            zero_right = right_mass < 1e-15
+            zero_left = left_mass < 1e-15
+
+            right_term = np.where(zero_right, 0.0, (right_mean - x_float) * right_mass)
+            left_term = np.where(zero_left, 0.0, (x_float - left_mean) * left_mass)
+            energy_arr = right_term + left_term
+
+            if energy_arr.ndim > 0:
+                energy_arr = np.sum(energy_arr, axis=1)
+            return energy_arr
+
         return self._energy_default(x)
 
     def _energy_default(self, x=None):
@@ -1461,7 +1502,7 @@ class BaseDistribution(BaseObject):
         else:
             return spl.mean().iloc[0]
 
-    def mean(self):
+    def mean(self, lower=None, upper=None):
         r"""Return expected value of the distribution.
 
         {formula_hook}
@@ -1470,14 +1511,33 @@ class BaseDistribution(BaseObject):
         one for each entry of the distribution.
 
         Let :math:`X` be a random variable with the distribution of ``self``.
-        Returns the expectation :math:`\mathbb{E}[X]`
+
+        If both ``lower`` and ``upper`` are None (default), returns the
+        ordinary expectation :math:`\mathbb{E}[X]`.
+
+        If ``lower`` or ``upper`` are provided, returns the truncated mean
+        :math:`\mathbb{E}[X \mid \text{lower} < X < \text{upper}]`.
+
+        Parameters
+        ----------
+        lower : float or array-like or None, optional, default=None
+            Lower truncation bound. If None, no lower truncation is applied.
+        upper : float or array-like or None, optional, default=None
+            Upper truncation bound. If None, no upper truncation is applied.
 
         Returns
         -------
         ``pd.DataFrame`` with same rows, columns as ``self``
             expected value of distribution (entry-wise)
         """
-        return self._boilerplate("_mean")
+        if lower is None and upper is None:
+            return self._boilerplate("_mean")
+
+        if lower is None:
+            lower = -np.inf
+        if upper is None:
+            upper = np.inf
+        return self._boilerplate("_truncated_mean", lower=lower, upper=upper)
 
     def _mean(self):
         """Return expected value of the distribution.
@@ -1507,6 +1567,63 @@ class BaseDistribution(BaseObject):
 
         spl = self.sample(approx_spl_size)
         return self._sample_mean(spl)
+
+    def _truncated_mean(self, lower, upper):
+        r"""Return expected value of the distribution truncated to [lower, upper].
+
+        Private method, to be implemented by subclasses.
+
+        Parameters
+        ----------
+        lower : 2D np.ndarray, same shape as ``self``
+            lower truncation bound (entry-wise)
+        upper : 2D np.ndarray, same shape as ``self``
+            upper truncation bound (entry-wise)
+
+        Returns
+        -------
+        2D np.ndarray, same shape as ``self``
+            truncated expected value of distribution (entry-wise)
+        """
+        approx_spl_size = self.get_tag("approx_spl")
+
+        if self._has_implementation_of("_cdf") and self._has_implementation_of("_ppf"):
+            approx_method = (
+                "by approximating the truncated mean via ppf integration "
+                f"over the truncated CDF region, with {approx_spl_size} nodes"
+            )
+            warn(self._method_error_msg("truncated_mean", fill_in=approx_method))
+
+            cdf_l = self._cdf(lower)
+            cdf_u = self._cdf(upper)
+
+            ps = np.linspace(0, 1, approx_spl_size + 2)[1:-1]
+            qs = [self._ppf(cdf_l + p * (cdf_u - cdf_l)) for p in ps]
+            np3D = np.array(qs)
+            result = np.mean(np3D, axis=0)
+
+            zero_mass = np.abs(cdf_u - cdf_l) < 1e-15
+            if np.any(zero_mass):
+                result = np.where(zero_mass, np.nan, result)
+
+            return result
+
+        approx_method = (
+            "by approximating the truncated mean by the arithmetic mean of "
+            f"{approx_spl_size} samples filtered to the truncation bounds"
+        )
+        warn(self._method_error_msg("truncated_mean", fill_in=approx_method))
+
+        spl = self.sample(approx_spl_size)
+        spl_arr = spl.values if hasattr(spl, "values") else np.asarray(spl)
+        spl_arr = spl_arr.reshape(approx_spl_size, *lower.shape)
+
+        mask = (spl_arr >= lower) & (spl_arr <= upper)
+        masked = np.where(mask, spl_arr, np.nan)
+        with np.errstate(all="ignore"):
+            result = np.nanmean(masked, axis=0)
+
+        return result
 
     def var(self):
         r"""Return element/entry-wise variance of the distribution.

--- a/skpro/distributions/exponential.py
+++ b/skpro/distributions/exponential.py
@@ -48,6 +48,7 @@ class Exponential(_ScipyAdapter):
             "log_pdf",
             "cdf",
             "energy",
+            "truncated_mean",
         ],
         "distr:measuretype": "continuous",
         "broadcast_init": "on",
@@ -91,6 +92,56 @@ class Exponential(_ScipyAdapter):
         if energy_arr.ndim > 0:
             energy_arr = energy_arr.sum(axis=1)
         return energy_arr
+
+    def _truncated_mean(self, lower, upper):
+        r"""Return expected value of the distribution truncated to [lower, upper].
+
+        For :math:`X \sim \text{Exp}(\lambda)` with support :math:`[0, \infty)`:
+
+        .. math::
+
+            \mathbb{E}[X \mid a < X < b]
+            = \frac{(a + 1/\lambda) e^{-\lambda a}
+                  - (b + 1/\lambda) e^{-\lambda b}}
+                   {e^{-\lambda a} - e^{-\lambda b}}
+
+        where :math:`a = \max(\text{lower}, 0)`.
+
+        Parameters
+        ----------
+        lower : 2D np.ndarray, same shape as ``self``
+            lower truncation bound
+        upper : 2D np.ndarray, same shape as ``self``
+            upper truncation bound
+
+        Returns
+        -------
+        2D np.ndarray, same shape as ``self``
+            truncated expected value of distribution (entry-wise)
+        """
+        rate = self._bc_params["rate"]
+        inv_rate = 1.0 / rate
+
+        a = np.maximum(lower, 0.0)
+        b = np.asarray(upper, dtype=float)
+
+        b_safe = np.where(np.isfinite(b), b, 0.0)
+        exp_a = np.exp(-rate * a)
+        exp_b_raw = np.exp(-rate * b_safe)
+        is_b_finite = np.isfinite(b)
+
+        term_a = (a + inv_rate) * exp_a
+        term_b = np.where(is_b_finite, (b_safe + inv_rate) * exp_b_raw, 0.0)
+
+        numer = term_a - term_b
+        denom = exp_a - np.where(is_b_finite, exp_b_raw, 0.0)
+
+        safe_denom = np.where(np.abs(denom) < 1e-15, np.nan, denom)
+        result = numer / safe_denom
+
+        no_overlap = (a >= b) | ((upper <= 0) & np.isfinite(upper))
+        result = np.where(no_overlap, np.nan, result)
+        return result
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/skpro/distributions/exponential.py
+++ b/skpro/distributions/exponential.py
@@ -69,6 +69,7 @@ class Exponential(_ScipyAdapter):
             "log_pdf",
             "cdf",
             "energy",
+            "truncated_mean",
         ],
         "distr:measuretype": "continuous",
         "broadcast_init": "on",
@@ -158,6 +159,56 @@ class Exponential(_ScipyAdapter):
         if energy_arr.ndim > 0:
             energy_arr = energy_arr.sum(axis=1)
         return energy_arr
+
+    def _truncated_mean(self, lower, upper):
+        r"""Return expected value of the distribution truncated to [lower, upper].
+
+        For :math:`X \sim \text{Exp}(\lambda)` with support :math:`[0, \infty)`:
+
+        .. math::
+
+            \mathbb{E}[X \mid a < X < b]
+            = \frac{(a + 1/\lambda) e^{-\lambda a}
+                  - (b + 1/\lambda) e^{-\lambda b}}
+                   {e^{-\lambda a} - e^{-\lambda b}}
+
+        where :math:`a = \max(\text{lower}, 0)`.
+
+        Parameters
+        ----------
+        lower : 2D np.ndarray, same shape as ``self``
+            lower truncation bound
+        upper : 2D np.ndarray, same shape as ``self``
+            upper truncation bound
+
+        Returns
+        -------
+        2D np.ndarray, same shape as ``self``
+            truncated expected value of distribution (entry-wise)
+        """
+        rate = self._bc_params["rate"]
+        inv_rate = 1.0 / rate
+
+        a = np.maximum(lower, 0.0)
+        b = np.asarray(upper, dtype=float)
+
+        b_safe = np.where(np.isfinite(b), b, 0.0)
+        exp_a = np.exp(-rate * a)
+        exp_b_raw = np.exp(-rate * b_safe)
+        is_b_finite = np.isfinite(b)
+
+        term_a = (a + inv_rate) * exp_a
+        term_b = np.where(is_b_finite, (b_safe + inv_rate) * exp_b_raw, 0.0)
+
+        numer = term_a - term_b
+        denom = exp_a - np.where(is_b_finite, exp_b_raw, 0.0)
+
+        safe_denom = np.where(np.abs(denom) < 1e-15, np.nan, denom)
+        result = numer / safe_denom
+
+        no_overlap = (a >= b) | ((upper <= 0) & np.isfinite(upper))
+        result = np.where(no_overlap, np.nan, result)
+        return result
 
     @classmethod
     def get_test_params(cls, parameter_set="default"):

--- a/skpro/distributions/laplace.py
+++ b/skpro/distributions/laplace.py
@@ -48,7 +48,16 @@ class Laplace(BaseDistribution):
         # estimator tags
         # --------------
         "capabilities:approx": ["pdfnorm"],
-        "capabilities:exact": ["mean", "var", "energy", "pdf", "log_pdf", "cdf", "ppf"],
+        "capabilities:exact": [
+            "mean",
+            "var",
+            "energy",
+            "pdf",
+            "log_pdf",
+            "cdf",
+            "ppf",
+            "truncated_mean",
+        ],
         "distr:measuretype": "continuous",
         "distr:paramtype": "parametric",
         "broadcast_init": "on",
@@ -114,6 +123,63 @@ class Laplace(BaseDistribution):
             expected value of distribution (entry-wise)
         """
         return self._bc_params["mu"]
+
+    def _truncated_mean(self, lower, upper):
+        r"""Return expected value of the distribution truncated to [lower, upper].
+
+        Uses the partial expectation formula for Laplace:
+
+        .. math::
+
+            \mathbb{E}[X \cdot \mathbf{1}(X < c)] =
+            \begin{cases}
+            \frac{c - s}{2} e^{(c - \mu)/s} & c \le \mu \\
+            \mu - \frac{c + s}{2} e^{-{(c - \mu)/s}} & c > \mu
+            \end{cases}
+
+        where :math:`s` is the scale parameter.
+
+        Parameters
+        ----------
+        lower : 2D np.ndarray, same shape as ``self``
+            lower truncation bound
+        upper : 2D np.ndarray, same shape as ``self``
+            upper truncation bound
+
+        Returns
+        -------
+        2D np.ndarray, same shape as ``self``
+            truncated expected value of distribution (entry-wise)
+        """
+        mu = self._bc_params["mu"]
+        s = self._bc_params["scale"]
+
+        def _partial_expectation(c):
+            """E[X * 1(X < c)] for Laplace(mu, s).
+
+            At c = -inf the result is 0, at c = +inf the result is mu.
+            """
+            c = np.asarray(c, dtype=float)
+            is_neginf = np.isneginf(c)
+            is_posinf = np.isposinf(c)
+            c_safe = np.where(np.isfinite(c), c, mu)
+
+            below_mu = c_safe <= mu
+            e_below = 0.5 * (c_safe - s) * np.exp((c_safe - mu) / s)
+            e_above = mu - 0.5 * (c_safe + s) * np.exp(-(c_safe - mu) / s)
+            finite_result = np.where(below_mu, e_below, e_above)
+
+            return np.where(is_neginf, 0.0, np.where(is_posinf, mu, finite_result))
+
+        pe_upper = _partial_expectation(upper)
+        pe_lower = _partial_expectation(lower)
+
+        cdf_lower = self._cdf(lower)
+        cdf_upper = self._cdf(upper)
+        denom = cdf_upper - cdf_lower
+        safe_denom = np.where(np.abs(denom) < 1e-15, np.nan, denom)
+
+        return (pe_upper - pe_lower) / safe_denom
 
     def _var(self):
         r"""Return element/entry-wise variance of the distribution.

--- a/skpro/distributions/laplace.py
+++ b/skpro/distributions/laplace.py
@@ -48,7 +48,16 @@ class Laplace(BaseDistribution):
         # estimator tags
         # --------------
         "capabilities:approx": ["pdfnorm"],
-        "capabilities:exact": ["mean", "var", "energy", "pdf", "log_pdf", "cdf", "ppf"],
+        "capabilities:exact": [
+            "mean",
+            "var",
+            "energy",
+            "pdf",
+            "log_pdf",
+            "cdf",
+            "ppf",
+            "truncated_mean",
+        ],
         "distr:measuretype": "continuous",
         "distr:paramtype": "parametric",
         "broadcast_init": "on",
@@ -164,6 +173,63 @@ class Laplace(BaseDistribution):
             expected value of distribution (entry-wise)
         """
         return self._bc_params["mu"]
+
+    def _truncated_mean(self, lower, upper):
+        r"""Return expected value of the distribution truncated to [lower, upper].
+
+        Uses the partial expectation formula for Laplace:
+
+        .. math::
+
+            \mathbb{E}[X \cdot \mathbf{1}(X < c)] =
+            \begin{cases}
+            \frac{c - s}{2} e^{(c - \mu)/s} & c \le \mu \\
+            \mu - \frac{c + s}{2} e^{-{(c - \mu)/s}} & c > \mu
+            \end{cases}
+
+        where :math:`s` is the scale parameter.
+
+        Parameters
+        ----------
+        lower : 2D np.ndarray, same shape as ``self``
+            lower truncation bound
+        upper : 2D np.ndarray, same shape as ``self``
+            upper truncation bound
+
+        Returns
+        -------
+        2D np.ndarray, same shape as ``self``
+            truncated expected value of distribution (entry-wise)
+        """
+        mu = self._bc_params["mu"]
+        s = self._bc_params["scale"]
+
+        def _partial_expectation(c):
+            """E[X * 1(X < c)] for Laplace(mu, s).
+
+            At c = -inf the result is 0, at c = +inf the result is mu.
+            """
+            c = np.asarray(c, dtype=float)
+            is_neginf = np.isneginf(c)
+            is_posinf = np.isposinf(c)
+            c_safe = np.where(np.isfinite(c), c, mu)
+
+            below_mu = c_safe <= mu
+            e_below = 0.5 * (c_safe - s) * np.exp((c_safe - mu) / s)
+            e_above = mu - 0.5 * (c_safe + s) * np.exp(-(c_safe - mu) / s)
+            finite_result = np.where(below_mu, e_below, e_above)
+
+            return np.where(is_neginf, 0.0, np.where(is_posinf, mu, finite_result))
+
+        pe_upper = _partial_expectation(upper)
+        pe_lower = _partial_expectation(lower)
+
+        cdf_lower = self._cdf(lower)
+        cdf_upper = self._cdf(upper)
+        denom = cdf_upper - cdf_lower
+        safe_denom = np.where(np.abs(denom) < 1e-15, np.nan, denom)
+
+        return (pe_upper - pe_lower) / safe_denom
 
     def _var(self):
         r"""Return element/entry-wise variance of the distribution.

--- a/skpro/distributions/normal.py
+++ b/skpro/distributions/normal.py
@@ -45,7 +45,16 @@ class Normal(BaseDistribution):
         # estimator tags
         # --------------
         "capabilities:approx": ["pdfnorm"],
-        "capabilities:exact": ["mean", "var", "energy", "pdf", "log_pdf", "cdf", "ppf"],
+        "capabilities:exact": [
+            "mean",
+            "var",
+            "energy",
+            "pdf",
+            "log_pdf",
+            "cdf",
+            "ppf",
+            "truncated_mean",
+        ],
         "distr:measuretype": "continuous",
         "distr:paramtype": "parametric",
         "broadcast_init": "on",
@@ -112,6 +121,50 @@ class Normal(BaseDistribution):
             expected value of distribution (entry-wise)
         """
         return self._bc_params["mu"]
+
+    def _truncated_mean(self, lower, upper):
+        r"""Return expected value of the distribution truncated to [lower, upper].
+
+        For :math:`X \sim N(\mu, \sigma^2)`:
+
+        .. math::
+
+            \mathbb{E}[X \mid a < X < b]
+            = \mu + \sigma \frac{\phi(\alpha) - \phi(\beta)}
+                                {\Phi(\beta) - \Phi(\alpha)}
+
+        where :math:`\alpha = (a - \mu)/\sigma`,
+        :math:`\beta = (b - \mu)/\sigma`,
+        :math:`\phi` is the standard normal pdf,
+        and :math:`\Phi` is the standard normal cdf.
+
+        Parameters
+        ----------
+        lower : 2D np.ndarray, same shape as ``self``
+            lower truncation bound
+        upper : 2D np.ndarray, same shape as ``self``
+            upper truncation bound
+
+        Returns
+        -------
+        2D np.ndarray, same shape as ``self``
+            truncated expected value of distribution (entry-wise)
+        """
+        mu = self._bc_params["mu"]
+        sigma = self._bc_params["sigma"]
+
+        alpha = (lower - mu) / sigma
+        beta = (upper - mu) / sigma
+
+        phi_alpha = np.exp(-0.5 * alpha**2) / np.sqrt(2 * np.pi)
+        phi_beta = np.exp(-0.5 * beta**2) / np.sqrt(2 * np.pi)
+        Phi_alpha = 0.5 * (1 + erf(alpha / np.sqrt(2)))
+        Phi_beta = 0.5 * (1 + erf(beta / np.sqrt(2)))
+
+        denom = Phi_beta - Phi_alpha
+        safe_denom = np.where(np.abs(denom) < 1e-15, np.nan, denom)
+
+        return mu + sigma * (phi_alpha - phi_beta) / safe_denom
 
     def _var(self):
         r"""Return element/entry-wise variance of the distribution.

--- a/skpro/distributions/normal.py
+++ b/skpro/distributions/normal.py
@@ -45,7 +45,16 @@ class Normal(BaseDistribution):
         # estimator tags
         # --------------
         "capabilities:approx": ["pdfnorm"],
-        "capabilities:exact": ["mean", "var", "energy", "pdf", "log_pdf", "cdf", "ppf"],
+        "capabilities:exact": [
+            "mean",
+            "var",
+            "energy",
+            "pdf",
+            "log_pdf",
+            "cdf",
+            "ppf",
+            "truncated_mean",
+        ],
         "distr:measuretype": "continuous",
         "distr:paramtype": "parametric",
         "broadcast_init": "on",
@@ -166,6 +175,50 @@ class Normal(BaseDistribution):
             expected value of distribution (entry-wise)
         """
         return self._bc_params["mu"]
+
+    def _truncated_mean(self, lower, upper):
+        r"""Return expected value of the distribution truncated to [lower, upper].
+
+        For :math:`X \sim N(\mu, \sigma^2)`:
+
+        .. math::
+
+            \mathbb{E}[X \mid a < X < b]
+            = \mu + \sigma \frac{\phi(\alpha) - \phi(\beta)}
+                                {\Phi(\beta) - \Phi(\alpha)}
+
+        where :math:`\alpha = (a - \mu)/\sigma`,
+        :math:`\beta = (b - \mu)/\sigma`,
+        :math:`\phi` is the standard normal pdf,
+        and :math:`\Phi` is the standard normal cdf.
+
+        Parameters
+        ----------
+        lower : 2D np.ndarray, same shape as ``self``
+            lower truncation bound
+        upper : 2D np.ndarray, same shape as ``self``
+            upper truncation bound
+
+        Returns
+        -------
+        2D np.ndarray, same shape as ``self``
+            truncated expected value of distribution (entry-wise)
+        """
+        mu = self._bc_params["mu"]
+        sigma = self._bc_params["sigma"]
+
+        alpha = (lower - mu) / sigma
+        beta = (upper - mu) / sigma
+
+        phi_alpha = np.exp(-0.5 * alpha**2) / np.sqrt(2 * np.pi)
+        phi_beta = np.exp(-0.5 * beta**2) / np.sqrt(2 * np.pi)
+        Phi_alpha = 0.5 * (1 + erf(alpha / np.sqrt(2)))
+        Phi_beta = 0.5 * (1 + erf(beta / np.sqrt(2)))
+
+        denom = Phi_beta - Phi_alpha
+        safe_denom = np.where(np.abs(denom) < 1e-15, np.nan, denom)
+
+        return mu + sigma * (phi_alpha - phi_beta) / safe_denom
 
     def _var(self):
         r"""Return element/entry-wise variance of the distribution.

--- a/skpro/distributions/tests/test_all_distrs.py
+++ b/skpro/distributions/tests/test_all_distrs.py
@@ -274,6 +274,45 @@ class TestAllDistributions(PackageConfig, DistributionFixtureGenerator, QuickTes
         else:
             assert np.allclose(x, x_approx)
 
+    def test_mean_unbounded_equals_plain_mean(self, object_instance):
+        """Test that mean() with None bounds equals mean() with no args."""
+        d = object_instance
+        if not _has_capability(d, "truncated_mean") or not _has_capability(d, "mean"):
+            return None
+
+        mean_val = d.mean()
+        trunc_mean_val = d.mean(lower=None, upper=None)
+
+        if d.ndim > 0:
+            assert np.allclose(
+                mean_val.values, trunc_mean_val.values, rtol=1e-4, atol=1e-6
+            )
+        else:
+            assert np.allclose(mean_val, trunc_mean_val, rtol=1e-4, atol=1e-6)
+
+    def test_mean_with_bounds(self, object_instance):
+        """Test mean output format when called with truncation bounds."""
+        d = object_instance
+        if not _has_capability(d, "truncated_mean"):
+            return None
+
+        x = d.sample()
+        if d.ndim > 0:
+            lower = x.values
+            upper = lower + 1.0
+            res = d.mean(lower=lower, upper=upper)
+            assert res.shape == d.shape
+            assert (res.index == d.index).all()
+            assert (res.columns == d.columns).all()
+            assert isinstance(res, pd.DataFrame)
+            assert res.apply(pd.api.types.is_numeric_dtype).all()
+        else:
+            lower = x - 1.0
+            upper = x + 1.0
+            res = d.mean(lower=lower, upper=upper)
+            assert np.isscalar(res)
+            assert np.isreal(res)
+
     def test_index_columns_last_args(self, object_class):
         """Test that index and columns are the last arguments in __init__."""
         params = object_class.get_param_names(sort=False)

--- a/skpro/distributions/truncated.py
+++ b/skpro/distributions/truncated.py
@@ -57,8 +57,9 @@ class TruncatedDistribution(BaseDistribution):
         "authors": ["tingiskhan"],
         # estimator tags
         # --------------
-        "capabilities:approx": ["energy", "mean", "var"],
+        "capabilities:approx": ["energy", "var"],
         "capabilities:exact": [
+            "mean",
             "ppf",
             "log_pmf",
             "log_pdf",
@@ -107,6 +108,13 @@ class TruncatedDistribution(BaseDistribution):
             if capa not in distr_exact_capas:
                 self_exact_capas.remove(capa)
                 self_approx_capas.append(capa)
+
+        # if inner distribution has exact truncated_mean, our mean is also exact
+        if "truncated_mean" in distr_exact_capas:
+            if "mean" not in self_exact_capas:
+                self_exact_capas.append("mean")
+            if "mean" in self_approx_capas:
+                self_approx_capas.remove("mean")
 
         self.set_tags(**{"capabilities:exact": self_exact_capas})
         self.set_tags(**{"capabilities:approx": self_approx_capas})
@@ -202,6 +210,20 @@ class TruncatedDistribution(BaseDistribution):
 
     def _log_pmf(self, x):
         return self._calculate_density(x, self.distribution.log_pmf, as_log=True)
+
+    def _mean(self):
+        """Return expected value of the truncated distribution.
+
+        Uses the inner distribution's mean method with truncation bounds.
+
+        Returns
+        -------
+        2D np.ndarray, same shape as ``self``
+            expected value of distribution (entry-wise)
+        """
+        lower = self.lower if self.lower is not None else -np.inf
+        upper = self.upper if self.upper is not None else np.inf
+        return self.distribution.mean(lower=lower, upper=upper)
 
     def _iloc(self, rowidx=None, colidx=None):
         distr = self.distribution.iloc[rowidx, colidx]

--- a/skpro/distributions/uniform.py
+++ b/skpro/distributions/uniform.py
@@ -37,7 +37,16 @@ class Uniform(BaseDistribution):
     _tags = {
         "authors": ["an20805"],
         "capabilities:approx": ["pdfnorm"],
-        "capabilities:exact": ["pdf", "log_pdf", "cdf", "ppf", "mean", "var", "energy"],
+        "capabilities:exact": [
+            "pdf",
+            "log_pdf",
+            "cdf",
+            "ppf",
+            "mean",
+            "var",
+            "energy",
+            "truncated_mean",
+        ],
         "distr:measuretype": "continuous",
         "distr:paramtype": "parametric",
         "broadcast_init": "on",
@@ -161,6 +170,35 @@ class Uniform(BaseDistribution):
 
         mean_arr = (lower + upper) / 2
         return mean_arr
+
+    def _truncated_mean(self, lower, upper):
+        r"""Return expected value of the distribution truncated to [lower, upper].
+
+        For :math:`X \sim \text{Uniform}(a, b)`, the truncated mean on
+        :math:`[\ell, u]` is the midpoint of the overlap interval
+        :math:`[\max(a, \ell), \min(b, u)]`.
+
+        Parameters
+        ----------
+        lower : 2D np.ndarray, same shape as ``self``
+            lower truncation bound
+        upper : 2D np.ndarray, same shape as ``self``
+            upper truncation bound
+
+        Returns
+        -------
+        2D np.ndarray, same shape as ``self``
+            truncated expected value of distribution (entry-wise)
+        """
+        a = self._bc_params["lower"]
+        b = self._bc_params["upper"]
+
+        eff_lower = np.maximum(a, lower)
+        eff_upper = np.minimum(b, upper)
+
+        result = (eff_lower + eff_upper) / 2.0
+        result = np.where(eff_lower >= eff_upper, np.nan, result)
+        return result
 
     def _var(self):
         r"""Return element/entry-wise variance of the distribution.

--- a/skpro/distributions/uniform.py
+++ b/skpro/distributions/uniform.py
@@ -113,7 +113,16 @@ class Uniform(BaseDistribution):
     _tags = {
         "authors": ["an20805", "Vidit-lab"],
         "capabilities:approx": ["pdfnorm"],
-        "capabilities:exact": ["pdf", "log_pdf", "cdf", "ppf", "mean", "var", "energy"],
+        "capabilities:exact": [
+            "pdf",
+            "log_pdf",
+            "cdf",
+            "ppf",
+            "mean",
+            "var",
+            "energy",
+            "truncated_mean",
+        ],
         "distr:measuretype": "continuous",
         "distr:paramtype": "parametric",
         "broadcast_init": "on",
@@ -237,6 +246,35 @@ class Uniform(BaseDistribution):
 
         mean_arr = (lower + upper) / 2
         return mean_arr
+
+    def _truncated_mean(self, lower, upper):
+        r"""Return expected value of the distribution truncated to [lower, upper].
+
+        For :math:`X \sim \text{Uniform}(a, b)`, the truncated mean on
+        :math:`[\ell, u]` is the midpoint of the overlap interval
+        :math:`[\max(a, \ell), \min(b, u)]`.
+
+        Parameters
+        ----------
+        lower : 2D np.ndarray, same shape as ``self``
+            lower truncation bound
+        upper : 2D np.ndarray, same shape as ``self``
+            upper truncation bound
+
+        Returns
+        -------
+        2D np.ndarray, same shape as ``self``
+            truncated expected value of distribution (entry-wise)
+        """
+        a = self._bc_params["lower"]
+        b = self._bc_params["upper"]
+
+        eff_lower = np.maximum(a, lower)
+        eff_upper = np.minimum(b, upper)
+
+        result = (eff_lower + eff_upper) / 2.0
+        result = np.where(eff_lower >= eff_upper, np.nan, result)
+        return result
 
     def _var(self):
         r"""Return element/entry-wise variance of the distribution.

--- a/skpro/regression/base/_base.py
+++ b/skpro/regression/base/_base.py
@@ -171,6 +171,7 @@ class BaseProbaRegressor(BaseEstimator):
         capa_online = self.get_tag("capability:update")
         capa_surv = self.get_tag("capability:survival")
 
+        # TODO: Add the error message if the capability is not met
         if not capa_online:
             return self
 

--- a/skpro/regression/base/_base.py
+++ b/skpro/regression/base/_base.py
@@ -166,6 +166,7 @@ class BaseProbaRegressor(BaseEstimator):
         capa_online = self.get_tag("capability:update")
         capa_surv = self.get_tag("capability:survival")
 
+        # TODO: Add the error message if the capability is not met
         if not capa_online:
             return self
 


### PR DESCRIPTION
#### Reference Issues/PRs

Addresses #221. Closes #221.

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

Adds truncated_mean(lower, upper) to BaseDistribution. Returns E[X | lower < X < upper]. Closed-form implementations for Normal, Exponential, Laplace, and Uniform. Other distributions fall back to a ppf-based numerical approximation.

The base class _energy_x now uses truncated means when available: if a distribution has exact truncated_mean and cdf, it computes E[|X - c|] from the energy identity instead of Monte Carlo sampling.

TruncatedDistribution gets a _mean() that calls the inner distribution's truncated_mean, so TruncatedDistribution(Normal(...), lower=0).mean() is exact now.

#### Changes

- `base/_base.py` - new `truncated_mean` / `_truncated_mean` with ppf/MC default, updated `_energy_x`
- `normal.py` - exact `_truncated_mean`
- `exponential.py` - exact `_truncated_mean`
- `laplace.py` - exact `_truncated_mean`
- `uniform.py` - exact `_truncated_mean`
- `truncated.py` - `_mean()` via inner distribution's `truncated_mean`, updated tag logi

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new core dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core skpro package to a minimum.
-->
No
#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->
No
#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [X] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [X] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
