### PR TITLE
[DOC] Complete Related Software documentation page

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -256,6 +256,14 @@
         "code",
         "bug"
       ]
-    },
+    {
+      "login": "maniktyagi04",
+      "name": "Manik Tyagi",
+      "avatar_url": "https://avatars.githubusercontent.com/u/74643036?v=4",
+      "profile": "https://github.com/maniktyagi04",
+      "contributions": [
+        "doc"
+      ]
+    }
   ]
 }

--- a/docs/source/related_software.rst
+++ b/docs/source/related_software.rst
@@ -4,4 +4,54 @@
 Related Software
 ================
 
-TODO
+The following is a curated list of software packages related to ``skpro``
+in the probabilistic prediction and scientific Python ecosystem.
+
+Probabilistic Prediction & Forecasting
+---------------------------------------
+
+`sktime <https://www.sktime.net>`_
+    A unified framework for time series machine learning in Python.
+    ``skpro`` is maintained by the same community and integrates with ``sktime``
+    to enable probabilistic forecasting pipelines: an ``sktime`` probabilistic
+    forecaster can be built from an ``skpro`` probabilistic regressor.
+
+`ngboost <https://stanfordmlgroup.github.io/projects/ngboost/>`_
+    Natural Gradient Boosting for probabilistic prediction.
+    ``skpro`` provides a native interface to ``ngboost`` estimators via the
+    ``NGBoostRegressor`` and ``NGBoostSurvival`` classes.
+
+`cyclic-boosting <https://cyclic-boosting.readthedocs.io>`_
+    A Python package for probabilistic prediction using cyclic boosting algorithms.
+    ``skpro`` provides a native interface to ``cyclic-boosting`` estimators.
+
+Uncertainty Quantification & Conformal Prediction
+--------------------------------------------------
+
+`MAPIE <https://mapie.readthedocs.io>`_
+    Model Agnostic Prediction Interval Estimator.
+    A library for uncertainty quantification via conformal prediction, compatible
+    with ``scikit-learn``. ``skpro`` can interface with MAPIE for interval
+    and quantile prediction.
+
+Machine Learning Foundations
+-----------------------------
+
+`scikit-learn <https://scikit-learn.org>`_
+    The standard Python machine learning library.
+    ``skpro`` is fully ``scikit-learn``-compatible and ``scikit-base``-compliant,
+    extending ``scikit-learn`` regressors with probabilistic prediction capabilities.
+
+Survival & Time-to-Event Analysis
+-----------------------------------
+
+`lifelines <https://lifelines.readthedocs.io>`_
+    A complete survival analysis library for Python, implementing a wide range
+    of parametric and non-parametric survival models.
+
+Probabilistic Programming
+--------------------------
+
+`pymc <https://www.pymc.io>`_
+    A probabilistic programming library in Python for Bayesian statistical modeling
+    and inference using Markov Chain Monte Carlo (MCMC) and variational inference.


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #998.

#### What does this implement/fix? Explain your changes.
This PR populates the previously empty `docs/source/related_software.rst` file with a curated list of software packages related to `skpro` in the probabilistic prediction and scientific Python ecosystem.

The updated page now includes:
- **sktime** (unified framework integration)
- **scikit-learn** (compatibility and extension)
- **MAPIE** (uncertainty quantification)
- **ngboost** and **cyclic-boosting** (native interfaces)
- **lifelines** and **pymc** (broader ecosystem)

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
- RST formatting and link correctness.
- Completeness of the suggested package list.

#### Did you add any tests for the change?
No, this is a documentation-only change.

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
