### PR TITLE
[ENH] Add conditional test decorators to recently added tests #997

### DIFF
--- a/skpro/distributions/base/tests/test_multiindex.py
+++ b/skpro/distributions/base/tests/test_multiindex.py
@@ -8,6 +8,12 @@ import pandas as pd
 import pytest
 
 from skpro.distributions.normal import Normal
+from skpro.tests.test_switch import run_test_module_changed
+
+pytestmark = pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
 
 
 @pytest.fixture

--- a/skpro/distributions/tests/test_normal_mixture.py
+++ b/skpro/distributions/tests/test_normal_mixture.py
@@ -3,10 +3,16 @@
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from skpro.distributions.normal_mixture import NormalMixture
+from skpro.tests.test_switch import run_test_for_class
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(NormalMixture),
+    reason="run test only if tested object has changed",
+)
 def test_pi_is_normalized_per_row():
     """Mixture weights should be normalized row-wise at construction."""
     pi = np.array([[0.3, 0.7], [1.0, 2.0]])
@@ -17,6 +23,10 @@ def test_pi_is_normalized_per_row():
     assert np.allclose(d._pi.sum(axis=1), 1.0)
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(NormalMixture),
+    reason="run test only if tested object has changed",
+)
 def test_mean_and_var_match_closed_form_scalar():
     """Mean/variance should match closed-form mixture formulas in scalar case."""
     pi = np.array([0.5, 0.5])
@@ -34,6 +44,10 @@ def test_mean_and_var_match_closed_form_scalar():
     assert np.isclose(d.var(), expected_var)
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(NormalMixture),
+    reason="run test only if tested object has changed",
+)
 def test_single_component_reduces_to_normal_pdf_and_cdf():
     """With one active component, pdf/cdf should match that Normal component."""
     pi = np.array([[1.0, 0.0]])
@@ -49,6 +63,10 @@ def test_single_component_reduces_to_normal_pdf_and_cdf():
     assert np.isclose(cdf, 0.5)
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(NormalMixture),
+    reason="run test only if tested object has changed",
+)
 def test_rowwise_weights_change_rowwise_mean():
     """Per-sample weights should produce different means per row."""
     pi = np.array([[0.9, 0.1], [0.1, 0.9]])
@@ -62,6 +80,10 @@ def test_rowwise_weights_change_rowwise_mean():
     assert np.isclose(means[1], 9.0)
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(NormalMixture),
+    reason="run test only if tested object has changed",
+)
 def test_sampling_mean_matches_theoretical_mean():
     """Large-sample mean should approximate theoretical mixture mean."""
     pi = np.array([[0.5, 0.5]])
@@ -78,6 +100,10 @@ def test_sampling_mean_matches_theoretical_mean():
     assert abs(sample_mean - theoretical_mean) < 0.1
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(NormalMixture),
+    reason="run test only if tested object has changed",
+)
 def test_energy_returns_non_negative_dataframe():
     """Energy outputs should be non-negative and keep expected tabular shape."""
     pi = np.array([[1.0, 0.0]])

--- a/skpro/distributions/tests/test_proba_basic.py
+++ b/skpro/distributions/tests/test_proba_basic.py
@@ -27,6 +27,10 @@ def test_proba_example():
     assert one_row.shape == (1, 2)
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
 @pytest.mark.parametrize("subsetter", ["loc", "iloc"])
 def test_proba_subsetters_loc_iloc(subsetter):
     """Test one subsetting case for BaseDistribution."""
@@ -57,6 +61,10 @@ def test_proba_subsetters_loc_iloc(subsetter):
     assert nss.shape == ()
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
 def test_proba_subsetters_at_iat():
     """Test one subsetting case for BaseDistribution."""
     from skpro.distributions.normal import Normal
@@ -75,6 +83,10 @@ def test_proba_subsetters_at_iat():
     assert nss == n.loc[1, 1]
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
 def test_proba_index_coercion():
     """Test index coercion for BaseDistribution."""
     from skpro.distributions.normal import Normal
@@ -105,6 +117,10 @@ def test_proba_index_coercion():
     assert n.columns.equals(pd.Index([1, 2, 3]))
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
 @pytest.mark.skipif(
     not _check_soft_dependencies("matplotlib", severity="none"),
     reason="skip if matplotlib is not available",
@@ -170,6 +186,10 @@ def test_discrete_pmf_plotting():
         ), "Should plot at multiple support points"
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
 def test_to_df_parametric():
     """Tests coercion to DataFrame via get_params_df and to_df."""
     from skpro.distributions.normal import Normal
@@ -222,6 +242,10 @@ def test_to_df_parametric():
         assert ix not in ["index", "columns"]
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
 def test_head_tail():
     """Test head and tail utility functions."""
     from skpro.distributions.normal import Normal

--- a/skpro/regression/tests/test_bandwidth.py
+++ b/skpro/regression/tests/test_bandwidth.py
@@ -12,6 +12,12 @@ from skpro.regression._bandwidth import (
     bw_scott_1d,
     bw_silverman_1d,
 )
+from skpro.tests.test_switch import run_test_module_changed
+
+pytestmark = pytest.mark.skipif(
+    not run_test_module_changed("skpro.regression"),
+    reason="run only if skpro.regression has been changed",
+)
 
 
 def test_bandwidth_1d_methods_return_finite_positive_values():

--- a/skpro/regression/tests/test_bandwidth.py
+++ b/skpro/regression/tests/test_bandwidth.py
@@ -15,8 +15,8 @@ from skpro.regression._bandwidth import (
 from skpro.tests.test_switch import run_test_module_changed
 
 pytestmark = pytest.mark.skipif(
-    not run_test_module_changed("skpro.regression"),
-    reason="run only if skpro.regression has been changed",
+    not run_test_module_changed("skpro.regression._bandwidth"),
+    reason="run only if skpro.regression._bandwidth has been changed",
 )
 
 

--- a/skpro/regression/tests/test_mapie_v1.py
+++ b/skpro/regression/tests/test_mapie_v1.py
@@ -4,7 +4,26 @@ from skbase.utils.dependencies import _check_soft_dependencies
 from sklearn.datasets import make_regression
 from sklearn.linear_model import LinearRegression
 
+from skpro.regression.conformal import (
+    MapieConformalizedQuantileRegressor,
+    MapieCrossConformalRegressor,
+    MapieSplitConformalRegressor,
+)
+from skpro.regression.jackknife import MapieJackknifeAfterBootstrapRegressor
+from skpro.tests.test_switch import run_test_for_class
 
+MAPIE_CLASSES = [
+    MapieSplitConformalRegressor,
+    MapieCrossConformalRegressor,
+    MapieJackknifeAfterBootstrapRegressor,
+    MapieConformalizedQuantileRegressor,
+]
+
+
+@pytest.mark.skipif(
+    not run_test_for_class(MAPIE_CLASSES),
+    reason="run test only if tested object has changed",
+)
 @pytest.mark.skipif(
     not _check_soft_dependencies("mapie>=1.0", severity="none"),
     reason="mapie>=1.0 not installed",
@@ -25,6 +44,10 @@ def test_mapie_v1_imports():
 
 
 @pytest.mark.skipif(
+    not run_test_for_class(MAPIE_CLASSES),
+    reason="run test only if tested object has changed",
+)
+@pytest.mark.skipif(
     not _check_soft_dependencies("mapie>=1.0", severity="none"),
     reason="mapie>=1.0 not installed",
 )
@@ -43,6 +66,10 @@ def test_mapie_v1_imports_from_top_level():
     assert MapieConformalizedQuantileRegressor is not None
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(MAPIE_CLASSES),
+    reason="run test only if tested object has changed",
+)
 @pytest.mark.skipif(
     not _check_soft_dependencies("mapie>=1.0", severity="none"),
     reason="mapie>=1.0 not installed",

--- a/skpro/regression/tests/test_ondil.py
+++ b/skpro/regression/tests/test_ondil.py
@@ -4,8 +4,13 @@ import pytest
 from skbase.utils.dependencies import _check_soft_dependencies
 
 from skpro.regression.ondil import OndilOnlineGamlss
+from skpro.tests.test_switch import run_test_for_class
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(OndilOnlineGamlss),
+    reason="run test only if tested object has changed",
+)
 @pytest.mark.skipif(
     not _check_soft_dependencies(["ondil"], severity="none"),
     reason="skip test if ondil is not installed in environment",
@@ -30,6 +35,10 @@ def test_ondil_instantiation_and_get_test_params():
     assert isinstance(est, OndilOnlineGamlss)
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(OndilOnlineGamlss),
+    reason="run test only if tested object has changed",
+)
 @pytest.mark.skipif(
     not _check_soft_dependencies(["ondil"], severity="none"),
     reason="skip test if ondil is not installed in environment",

--- a/skpro/regression/tests/test_pipeline_transform_chain.py
+++ b/skpro/regression/tests/test_pipeline_transform_chain.py
@@ -1,12 +1,18 @@
 import numpy as np
 import pandas as pd
+import pytest
 from sklearn.linear_model import LinearRegression
 from sklearn.preprocessing import FunctionTransformer
 
 from skpro.regression.compose import Pipeline
 from skpro.regression.residual import ResidualDouble
+from skpro.tests.test_switch import run_test_for_class
 
 
+@pytest.mark.skipif(
+    not run_test_for_class([Pipeline, ResidualDouble]),
+    reason="run test only if tested object has changed",
+)
 def test_transformer_chaining_in_predict():
     """Ensure transformers are applied sequentially in pipeline."""
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skpro.readthedocs.io/en/latest/contribute.html
-->

#### Reference Issues/PRs
Fixes #997


#### What does this implement/fix? Explain your changes.
Adds @pytest.mark.skipif decorators using run_test_for_class and run_test_module_changed to recently added tests that were missing them. This ensures these tests only run on CI when the underlying class or module has changed, reducing unnecessary CI load.
Files changed (7):
1. test_normal_mixture.py— added run_test_for_class(NormalMixture) to all 6 tests
2. test_multiindex.py — added module-level pytestmark with run_test_module_changed("skpro.distributions") covering all 7 tests
3. test_proba_basic.py— added run_test_module_changed("skpro.distributions") to 6 tests that were missing it (test_proba_subsetters_loc_iloc,  test_proba_subsetters_at_iat, test_proba_index_coercion, test_proba_plotting, test_to_df_parametric, test_head_tail). Tests already decorated or unconditionally skipped were left unchanged.
4. test_bandwidth.py — added module-level pytestmark with run_test_module_changed("skpro.regression") covering all 5 tests 
5. test_mapie_v1.py— added run_test_for_class(MAPIE_CLASSES) to all 3 tests, with MAPIE classes imported at module level for collection-time evaluation
6. test_ondil.py— added run_test_for_class(OndilOnlineGamlss) to both tests
7. test_pipeline_transform_chain.py — added run_test_for_class([Pipeline, ResidualDouble]) to the single test; also fixed CRLF → LF line endings


#### Does your contribution introduce a new dependency? If yes, which one?

no

#### What should a reviewer concentrate their feedback on?

1. Correctness of the decorator choice: run_test_for_class for class-specific tests vs run_test_module_changed for module-level tests
2. Whether pytestmark (module-level) vs individual decorators are used appropriately
3. The test_mapie_v1.py approach of importing all 4 MAPIE classes at module level and grouping them into a MAPIE_CLASSES list for run_test_for_class

#### Did you add any tests for the change?

No new tests - this PR adds skip decorators to existing tests


#### Any other comments?
Tests that are already unconditionally skipped( test_proba_example, test_discreate_pmf_plotting - both marked with @pytest.mark.skip) were intentionally left without the conditional decorator as they are already skipped regardless.


#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [X] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [X] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
