### PR TITLE
[BUG] - bugfix, GridSearchCV scoring=None defaults to CRPS

### DIFF
--- a/skpro/model_selection/_tuning.py
+++ b/skpro/model_selection/_tuning.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 from sklearn.model_selection import ParameterGrid, ParameterSampler, check_cv
 
+from skpro.metrics import CRPS
 from skpro.benchmarking.evaluate import evaluate
 from skpro.regression.base._delegate import _DelegatedProbaRegressor
 from skpro.utils.parallel import parallelize
@@ -108,6 +109,8 @@ class BaseGridSearch(_DelegatedProbaRegressor):
 
         # scoring = check_scoring(self.scoring, obj=self)
         scoring = self.scoring
+        if scoring is None:
+            scoring = CRPS()
         scoring_name = f"test_{scoring.name}"
 
         backend = self.backend

--- a/skpro/model_selection/tests/__init__.py
+++ b/skpro/model_selection/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for model selection utilities."""

--- a/skpro/model_selection/tests/test_tuning.py
+++ b/skpro/model_selection/tests/test_tuning.py
@@ -1,0 +1,53 @@
+"""Tests for model selection tuning utilities."""
+
+import pandas as pd
+import pytest
+from sklearn.model_selection import KFold
+
+from skpro.model_selection import GridSearchCV, RandomizedSearchCV
+from skpro.regression.dummy import DummyProbaRegressor
+from skpro.tests.test_switch import run_test_module_changed
+
+
+def _get_test_data():
+    X = pd.DataFrame({"x": [1, 2, 3, 4]})
+    y = pd.DataFrame({"y": [1.0, 2.0, 3.0, 4.0]})
+    return X, y
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.model_selection"),
+    reason="Test only if skpro.model_selection has been changed",
+)
+def test_gridsearch_scoring_none_defaults_to_crps():
+    """GridSearchCV should use CRPS when scoring is None."""
+    X, y = _get_test_data()
+
+    gscv = GridSearchCV(
+        estimator=DummyProbaRegressor(),
+        cv=KFold(n_splits=2),
+        param_grid={"strategy": ["empirical"]},
+        scoring=None,
+    )
+    gscv.fit(X, y)
+
+    assert "mean_test_CRPS" in gscv.cv_results_.columns
+
+
+def test_randomizedsearch_scoring_none_defaults_to_crps():
+    """RandomizedSearchCV should use CRPS when scoring is None."""
+    X, y = _get_test_data()
+
+    rscv = RandomizedSearchCV(
+        estimator=DummyProbaRegressor(),
+        cv=KFold(n_splits=2),
+        param_distributions={"strategy": ["empirical"]},
+        n_iter=1,
+        scoring=None,
+        backend_params={"n_jobs": 1},
+    )
+    rscv.fit(X, y)
+
+    assert "mean_test_CRPS" in rscv.cv_results_.columns
+
+


### PR DESCRIPTION
If scoring= None, set it to CRPS().

<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skpro.readthedocs.io/en/latest/contribute.html
-->

#### Reference Issues/PRs

Fixes #1009.

#### What does this implement/fix? Explain your changes.
If scoring= None, set it to CRPS(). in _tuning.py

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?
No. I don't think a separate test is necessary here.



#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
