### PR TITLE
fix: handle scoring=None in GridSearchCV._fit to avoid AttributeError (#1009)

### DIFF
--- a/skpro/model_selection/_tuning.py
+++ b/skpro/model_selection/_tuning.py
@@ -108,7 +108,7 @@ class BaseGridSearch(_DelegatedProbaRegressor):
 
         # scoring = check_scoring(self.scoring, obj=self)
         scoring = self.scoring
-        scoring_name = f"test_{scoring.name}"
+        scoring_name = f"test_{scoring.name}" if scoring is not None else "test_CPRS"
 
         backend = self.backend
         backend_params = self.backend_params if self.backend_params else {}


### PR DESCRIPTION
## Fix Issue #1009: GridSearchCV scoring=None gives AttributeError

**Problem:** When `scoring=None` is passed to `GridSearchCV.fit()`, line 111 crashes with `AttributeError: 'NoneType' object has no attribute 'name'` because `scoring.name` is called without checking if `scoring` is `None`.

**Fix:** Check if `scoring is not None` before accessing `scoring.name`. When `None`, use `"test_CPRS"` as the scoring name, matching the documented behavior that `scoring=None` defaults to CRPS.

```python
# Before
scoring_name = f"test_{scoring.name}"  # crashes when scoring is None

# After
scoring_name = f"test_{scoring.name}" if scoring is not None else "test_CPRS"  # safe fallback
```