### PR TITLE
DOC: add Examples to DummyProbaRegressor

### DIFF
--- a/skpro/regression/dummy.py
+++ b/skpro/regression/dummy.py
@@ -38,6 +38,23 @@ class DummyProbaRegressor(BaseProbaRegressor):
     distribution_ : skpro.distribution
         Normal distribution or Empirical distribution, depending on chosen strategy.
         Scalar version of the distribution that is returned by ``predict_proba``.
+        Examples
+    --------
+        from skpro.regression.dummy import DummyProbaRegressor
+        from sklearn.datasets import load_diabetes
+        X, y = load_diabetes(return_X_y=True, as_frame=True)
+        X_train, X_test = X.iloc[:400], X.iloc[400:]
+        y_train = y.iloc[:400]
+        reg = DummyProbaRegressor()
+        reg.fit(X_train, y_train)
+        DummyProbaRegressor(...)
+        reg.predict_proba(X_test)
+        Empirical(...)
+        reg_normal = DummyProbaRegressor(strategy="normal")
+        reg_normal.fit(X_train, y_train)
+        DummyProbaRegressor(strategy='normal')
+        reg_normal.predict_proba(X_test)
+        Normal(...)
     """
 
     _tags = {


### PR DESCRIPTION
#### Reference Issues/PRs
No specific issue - adding missing docstring examples.

#### What does this implement/fix? Explain your changes.
Added a working `Examples` section to the `DummyProbaRegressor`
class docstring. The class had no usage examples, making it
harder for new users to understand how to use both strategies.
Examples cover both "empirical" (default) and "normal" strategies
and are verified to run end-to-end.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
Correctness of the examples and whether the output repr strings
match expected format.

#### Did you add any tests for the change?
No - this is a documentation-only change.

#### Any other comments?
This is my first contribution to skpro. Happy to adjust anything
based on feedback.

#### PR checklist
##### For all contributions
- [x] I've added myself to the list of contributors with the `doc` badge
- [x] The PR title starts with [DOC]