### PR TITLE
Add optional lower-bound clipping for ResidualDouble quantiles 

### DIFF
--- a/skpro/regression/residual.py
+++ b/skpro/regression/residual.py
@@ -97,6 +97,9 @@ class ResidualDouble(BaseProbaRegressor):
     min_scale : float, default=1e-10
         minimum scale parameter. If smaller scale parameter is predicted by
         ``estimator_resid``, will be clipped to this value
+    response_lb : float or None, default=None
+        optional lower bound for target support.
+        If provided, quantile and interval predictions are clipped below this value.
 
     Attributes
     ----------
@@ -136,6 +139,7 @@ class ResidualDouble(BaseProbaRegressor):
         use_y_pred=False,
         cv=None,
         min_scale=1e-10,
+        response_lb=None,
     ):
         self.estimator = estimator
         self.estimator_resid = estimator_resid
@@ -146,6 +150,7 @@ class ResidualDouble(BaseProbaRegressor):
         self.use_y_pred = use_y_pred
         self.cv = cv
         self.min_scale = min_scale
+        self.response_lb = response_lb
 
         super().__init__()
 
@@ -366,6 +371,15 @@ class ResidualDouble(BaseProbaRegressor):
         y_pred = distr_type(**params)
         return y_pred
 
+    def _predict_quantiles(self, X, alpha):
+        """Compute/return quantile predictions, with optional lower-bound clipping."""
+        quantiles = super()._predict_quantiles(X=X, alpha=alpha)
+
+        if self.response_lb is not None:
+            quantiles = quantiles.clip(lower=self.response_lb)
+
+        return quantiles
+
     @classmethod
     def get_test_params(cls, parameter_set="default"):
         """Return testing parameter settings for the estimator.
@@ -405,6 +419,7 @@ class ResidualDouble(BaseProbaRegressor):
             "distr_type": "t",
             "distr_params": {"df": 3},
             "cv": KFold(n_splits=3),
+            "response_lb": 0,
         }
         params4 = {"estimator": RandomForestRegressor(), "cv": KFold(n_splits=3)}
 

--- a/skpro/regression/tests/test_residual.py
+++ b/skpro/regression/tests/test_residual.py
@@ -1,0 +1,52 @@
+"""Tests for residual probabilistic regressors."""
+
+import numpy as np
+import pandas as pd
+from sklearn.dummy import DummyRegressor
+from sklearn.linear_model import TweedieRegressor
+
+from skpro.regression.residual import ResidualDouble
+
+
+def _make_positive_data(n=200, p=5, seed=42):
+    """Create synthetic positive-response data for Tweedie-style models."""
+    rng = np.random.RandomState(seed)
+    X = rng.rand(n, p)
+    beta = rng.uniform(-0.5, 0.8, size=p)
+    mu = np.exp(X @ beta)
+
+    X = pd.DataFrame(X, columns=[f"feat_{i}" for i in range(p)])
+    y = pd.Series(mu, name="y")
+    return X, y
+
+
+def test_residual_double_response_lb_clips_quantiles_and_intervals():
+    """Quantile/interval outputs should respect configured lower bound."""
+    X, y = _make_positive_data()
+
+    reg_mean = TweedieRegressor(power=1.5, link="log")
+    reg_resid = DummyRegressor(strategy="constant", constant=3.0)
+
+    reg_unclipped = ResidualDouble(reg_mean, reg_resid, min_scale=1e-6)
+    reg_unclipped.fit(X, y)
+    q_unclipped = reg_unclipped.predict_quantiles(X, alpha=[0.05, 0.5, 0.95])
+
+    reg_clipped = ResidualDouble(
+        reg_mean,
+        reg_resid,
+        min_scale=1e-6,
+        response_lb=0.0,
+    )
+    reg_clipped.fit(X, y)
+    q_clipped = reg_clipped.predict_quantiles(X, alpha=[0.05, 0.5, 0.95])
+    i_clipped = reg_clipped.predict_interval(X, coverage=[0.9])
+
+    # test is meaningful: unclipped lower quantiles should contain negatives
+    assert (q_unclipped < 0).to_numpy().any()
+
+    # clipping is active and exact for quantiles
+    expected = q_unclipped.clip(lower=0.0)
+    pd.testing.assert_frame_equal(q_clipped, expected)
+
+    # interval lower/upper bounds must be >= 0 when response_lb=0
+    assert (i_clipped >= 0).to_numpy().all()


### PR DESCRIPTION
Adding opt-in [response_lb](vscode-file://vscode-app/c:/Users/USER/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) clipping in [ResidualDouble](vscode-file://vscode-app/c:/Users/USER/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) so quantile/interval outputs respect non-negative support (for example [response_lb=0.0](vscode-file://vscode-app/c:/Users/USER/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)), with regression tests added and passing. 
#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [x] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [x] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [x] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
