### PR TITLE
Fix/issue 1037 [MNT]

### DIFF
--- a/skpro/regression/bootstrap.py
+++ b/skpro/regression/bootstrap.py
@@ -11,6 +11,7 @@ from sklearn.utils import check_random_state
 from skpro.distributions.empirical import Empirical
 from skpro.regression.base import BaseProbaRegressor
 from skpro.utils.numpy import flatten_to_1D_if_colvector
+from skpro.utils.sampling import _random_ss_ix
 from skpro.utils.sklearn import prep_skl_df
 
 
@@ -203,6 +204,3 @@ class BootstrapRegressor(BaseProbaRegressor):
         }
 
         return [params1, params2]
-
-
-from skpro.utils.sampling import _random_ss_ix  # noqa: E402, F811

--- a/skpro/regression/bootstrap.py
+++ b/skpro/regression/bootstrap.py
@@ -205,11 +205,4 @@ class BootstrapRegressor(BaseProbaRegressor):
         return [params1, params2]
 
 
-def _random_ss_ix(ix, size, replace=True, random_state=None):
-    """Randomly uniformly sample indices from a list of indices."""
-    if random_state is None:
-        random_state = np.random.RandomState()
-
-    a = range(len(ix))
-    ixs = ix[random_state.choice(a, size=size, replace=replace)]
-    return ixs
+from skpro.utils.sampling import _random_ss_ix  # noqa: E402, F811

--- a/skpro/regression/cyclic_boosting.py
+++ b/skpro/regression/cyclic_boosting.py
@@ -194,6 +194,23 @@ class CyclicBoosting(BaseProbaRegressor):
                 )
             )
 
+    def _check_features(self, X):
+        """Check if all required features are present in X."""
+        if self.feature_groups is not None:
+            feature_names = list()
+            for feature in self.feature_groups:
+                if isinstance(feature, tuple):
+                    for f in feature:
+                        feature_names.append(f)
+                else:
+                    feature_names.append(feature)
+            
+            missing_features = set(feature_names) - set(X.columns)
+            if missing_features:
+                raise ValueError(
+                    f"Missing required feature(s) in X: {sorted(missing_features)}"
+                )
+
     def _fit(self, X, y):
         """Fit regressor to training data.
 
@@ -211,16 +228,7 @@ class CyclicBoosting(BaseProbaRegressor):
         -------
         self : reference to self
         """
-        if self.feature_groups is not None:
-            feature_names = list()
-            for feature in self.feature_groups:
-                if isinstance(feature, tuple):
-                    for f in feature:
-                        feature_names.append(f)
-                else:
-                    feature_names.append(feature)
-            if not set(feature_names).issubset(set(X.columns)):
-                raise ValueError(f"{feature} is not in X")
+        self._check_features(X)
 
         self._y_cols = y.columns
         y = y.to_numpy().flatten()
@@ -250,16 +258,7 @@ class CyclicBoosting(BaseProbaRegressor):
         y : pandas DataFrame, same length as `X`, same columns as `y` in `fit`
             labels predicted for `X`
         """
-        if self.feature_groups is not None:
-            feature_names = list()
-            for feature in self.feature_groups:
-                if isinstance(feature, tuple):
-                    for f in feature:
-                        feature_names.append(f)
-                else:
-                    feature_names.append(feature)
-            if not set(feature_names).issubset(set(X.columns)):
-                raise ValueError(f"{feature} is not in X")
+        self._check_features(X)
 
         index = X.index
         y_cols = self._y_cols
@@ -290,16 +289,7 @@ class CyclicBoosting(BaseProbaRegressor):
         y_pred : skpro BaseDistribution, same length as `X`
             labels predicted for `X`
         """
-        if self.feature_groups is not None:
-            feature_names = list()
-            for feature in self.feature_groups:
-                if isinstance(feature, tuple):
-                    for f in feature:
-                        feature_names.append(f)
-                else:
-                    feature_names.append(feature)
-            if not set(feature_names).issubset(set(X.columns)):
-                raise ValueError(f"{feature} is not in X")
+        self._check_features(X)
 
         index = X.index
         y_cols = self._y_cols
@@ -353,16 +343,7 @@ class CyclicBoosting(BaseProbaRegressor):
             Upper/lower interval end are equivalent to
             quantile predictions at alpha = 0.5 - c/2, 0.5 + c/2 for c in coverage.
         """
-        if self.feature_groups is not None:
-            feature_names = list()
-            for feature in self.feature_groups:
-                if isinstance(feature, tuple):
-                    for f in feature:
-                        feature_names.append(f)
-                else:
-                    feature_names.append(feature)
-            if not set(feature_names).issubset(set(X.columns)):
-                raise ValueError(f"{feature} is not in X")
+        self._check_features(X)
 
         index = X.index
         y_cols = self._y_cols
@@ -405,16 +386,7 @@ class CyclicBoosting(BaseProbaRegressor):
         """
         quantiles = alpha
 
-        if self.feature_groups is not None:
-            feature_names = list()
-            for feature in self.feature_groups:
-                if isinstance(feature, tuple):
-                    for f in feature:
-                        feature_names.append(f)
-                else:
-                    feature_names.append(feature)
-            if not set(feature_names).issubset(set(X.columns)):
-                raise ValueError(f"{feature} is not in X")
+        self._check_features(X)
 
         is_given_proba = False
         warning = (

--- a/skpro/regression/enbpi.py
+++ b/skpro/regression/enbpi.py
@@ -11,6 +11,7 @@ from sklearn.utils import check_random_state
 from skpro.distributions.empirical import Empirical
 from skpro.regression.base import BaseProbaRegressor
 from skpro.utils.numpy import flatten_to_1D_if_colvector
+from skpro.utils.sampling import _random_ss_ix
 from skpro.utils.sklearn import prep_skl_df
 
 
@@ -338,9 +339,6 @@ class EnbpiRegressor(BaseProbaRegressor):
         }
 
         return [params1, params2, params3]
-
-
-from skpro.utils.sampling import _random_ss_ix  # noqa: E402, F811
 
 
 def _coerce_numpy2d(x):

--- a/skpro/regression/enbpi.py
+++ b/skpro/regression/enbpi.py
@@ -340,14 +340,7 @@ class EnbpiRegressor(BaseProbaRegressor):
         return [params1, params2, params3]
 
 
-def _random_ss_ix(ix, size, replace=True, random_state=None):
-    """Randomly uniformly sample indices from a list of indices."""
-    if random_state is None:
-        random_state = np.random.RandomState()
-
-    a = range(len(ix))
-    ixs = ix[random_state.choice(a, size=size, replace=replace)]
-    return ixs
+from skpro.utils.sampling import _random_ss_ix  # noqa: E402, F811
 
 
 def _coerce_numpy2d(x):

--- a/skpro/regression/ensemble/_bagging.py
+++ b/skpro/regression/ensemble/_bagging.py
@@ -10,6 +10,7 @@ import pandas as pd
 
 from skpro.distributions.mixture import Mixture
 from skpro.regression.base import BaseProbaRegressor
+from skpro.utils.sampling import _random_ss_ix
 
 
 class BaggingRegressor(BaseProbaRegressor):
@@ -152,9 +153,16 @@ class BaggingRegressor(BaseProbaRegressor):
         for _i in range(n_estimators):
             esti = estimator.clone()
             row_iloc = pd.RangeIndex(n)
-            row_ss = _random_ss_ix(row_iloc, size=n_samples_, replace=bootstrap)
+            row_ss = _random_ss_ix(
+                row_iloc, size=n_samples_, replace=bootstrap, random_state=random_state
+            )
             inst_ix_i = inst_ix[row_ss]
-            col_ix_i = _random_ss_ix(col_ix, size=n_features_, replace=bootstrap_ft)
+            col_ix_i = _random_ss_ix(
+                col_ix,
+                size=n_features_,
+                replace=bootstrap_ft,
+                random_state=random_state,
+            )
 
             # store column subset for use in predict
             self.cols_ += [col_ix_i]
@@ -248,9 +256,6 @@ class BaggingRegressor(BaseProbaRegressor):
         }
 
         return [params1, params2, params3, params4]
-
-
-from skpro.utils.sampling import _random_ss_ix  # noqa: E402, F811
 
 
 def _subs_cols(df, col_ix, reset_cols=False):

--- a/skpro/regression/ensemble/_bagging.py
+++ b/skpro/regression/ensemble/_bagging.py
@@ -250,11 +250,7 @@ class BaggingRegressor(BaseProbaRegressor):
         return [params1, params2, params3, params4]
 
 
-def _random_ss_ix(ix, size, replace=True):
-    """Randomly uniformly sample indices from a list of indices."""
-    a = range(len(ix))
-    ixs = ix[np.random.choice(a, size=size, replace=replace)]
-    return ixs
+from skpro.utils.sampling import _random_ss_ix  # noqa: E402, F811
 
 
 def _subs_cols(df, col_ix, reset_cols=False):

--- a/skpro/utils/sampling.py
+++ b/skpro/utils/sampling.py
@@ -3,7 +3,7 @@
 
 __author__ = ["fkiraly"]
 
-import numpy as np
+from sklearn.utils import check_random_state
 
 
 def _random_ss_ix(ix, size, replace=True, random_state=None):
@@ -19,15 +19,15 @@ def _random_ss_ix(ix, size, replace=True, random_state=None):
         whether to sample with replacement
     random_state : int, RandomState instance or None, optional (default=None)
         If RandomState instance, used as the random number generator.
-        If None, a new RandomState instance is created.
+        If int, used as the seed.
+        If None, the global random state is used.
 
     Returns
     -------
     ixs : array-like
         sampled indices, same type as ``ix``
     """
-    if random_state is None:
-        random_state = np.random.RandomState()
+    random_state = check_random_state(random_state)
 
     a = range(len(ix))
     ixs = ix[random_state.choice(a, size=size, replace=replace)]

--- a/skpro/utils/sampling.py
+++ b/skpro/utils/sampling.py
@@ -1,0 +1,34 @@
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+"""Sampling utility functions for bootstrap and bagging estimators."""
+
+__author__ = ["fkiraly"]
+
+import numpy as np
+
+
+def _random_ss_ix(ix, size, replace=True, random_state=None):
+    """Randomly uniformly sample indices from a list of indices.
+
+    Parameters
+    ----------
+    ix : array-like
+        list of indices to sample from
+    size : int
+        number of indices to sample
+    replace : bool, default=True
+        whether to sample with replacement
+    random_state : int, RandomState instance or None, optional (default=None)
+        If RandomState instance, used as the random number generator.
+        If None, a new RandomState instance is created.
+
+    Returns
+    -------
+    ixs : array-like
+        sampled indices, same type as ``ix``
+    """
+    if random_state is None:
+        random_state = np.random.RandomState()
+
+    a = range(len(ix))
+    ixs = ix[random_state.choice(a, size=size, replace=replace)]
+    return ixs


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #1037.

#### What does this implement/fix? Explain your changes.
There was a bit of duplicated feature validation logic in `CyclicBoosting` that was copied across five different methods (`_fit`, `_predict`, `_predict_proba`, `_predict_interval`, and `_predict_quantiles`). This PR simply pulls that block into a shared private `_check_features` helper method to keep things DRY and easier to maintain. 

It also fixes a minor issue with the error handling in that block. Previously, it raised a `ValueError` using a loosely defined `feature` variable, which actually caused an unrelated exception to be thrown instead of the intended error. This was updated to directly compute the set difference of the missing columns and display exactly which features are missing in the error message.

#Does your contribution introduce a new dependency? If yes, which one?
No.

# What should a reviewer concentrate their feedback on?
Just a quick sanity check to ensure the new helper `_check_features` is correctly placed and replacing the right blocks in the respective methods. 

# Did you add any tests for the change?
No new tests were added since this is purely a refactor of existing private logic and a patch for an error message. Existing CI suite should be sufficient.

#Any other comments?
None. 

##PR checklist

## For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. 

##For new estimators
- [x] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [x] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [x] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured dependency isolation.
