### PR TITLE
[MNT] allow `scikit-base<1.1` in the dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "numpy>=1.21.0,<2.5",
     "pandas>=1.1.0,<3.1.0",
     "packaging",
-    "scikit-base>=0.6.1,<0.14.0",
+    "scikit-base>=0.6.1,<1.1.0",
     "scikit-learn>=0.24.0,<1.8.0",
     "scipy<2.0.0,>=1.2.0",
 ]


### PR DESCRIPTION
Raises the `scikit-base` upper bound to `scikit-base<1.1`