### PR TITLE
[ENH] add sample_weight to probabilistic forecasting metrics

### DIFF
--- a/skpro/metrics/base.py
+++ b/skpro/metrics/base.py
@@ -90,6 +90,9 @@ class BaseProbaMetric(BaseObject):
             must have same index and columns as y_true
             Predicted values, i-th row is prediction for i-th row of ``y_true``.
 
+        sample_weight : 1D array-like, optional, default=None
+            Sample weights for each instance/time point.
+
         Returns
         -------
         loss : float or 1-column pd.DataFrame with calculated metric value(s)
@@ -155,6 +158,9 @@ class BaseProbaMetric(BaseObject):
             must have same index and columns as y_true
             Predicted values, i-th row is prediction for i-th row of ``y_true``.
 
+        sample_weight : 1D array-like, optional, default=None
+            Sample weights for each instance/time point.
+
         Returns
         -------
         loss : pd.DataFrame of shape (, n_outputs), calculated loss metric.
@@ -162,7 +168,13 @@ class BaseProbaMetric(BaseObject):
         # Default implementation relies on implementation of evaluate_by_index
         try:
             index_df = self._evaluate_by_index(y_true, y_pred)
-            out_df = pd.DataFrame(index_df.mean(axis=0)).T
+            sample_weight = kwargs.get("sample_weight", None)
+            if sample_weight is not None:
+                out_df = pd.DataFrame(
+                    np.average(index_df, weights=sample_weight, axis=0)
+                ).T
+            else:
+                out_df = pd.DataFrame(index_df.mean(axis=0)).T
             out_df.columns = index_df.columns
             return out_df
         except RecursionError as _err:
@@ -183,6 +195,9 @@ class BaseProbaMetric(BaseObject):
         y_pred : return object of probabilistic predictition method scitype:y_pred
             must have same index and columns as y_true
             Predicted values, i-th row is prediction for i-th row of ``y_true``.
+
+        sample_weight : 1D array-like, optional, default=None
+            Sample weights for each instance/time point.
 
         Returns
         -------
@@ -250,6 +265,9 @@ class BaseProbaMetric(BaseObject):
         y_pred : return object of probabilistic predictition method scitype:y_pred
             must have same index and columns as ``y_true``.
             Predicted values, i-th row is prediction for i-th row of ``y_true``.
+
+        sample_weight : 1D array-like, optional, default=None
+            Sample weights for each instance/time point.
         """
         n = y_true.shape[0]
         out_series = pd.Series(index=y_pred.index)
@@ -433,6 +451,9 @@ class BaseDistrMetric(BaseProbaMetric):
             must have same index and columns as y_true
             Predicted values, i-th row is prediction for i-th row of ``y_true``.
 
+        sample_weight : 1D array-like, optional, default=None
+            Sample weights for each instance/time point.
+
         Returns
         -------
         loss : float or 1-column pd.DataFrame with calculated metric value(s)
@@ -446,7 +467,11 @@ class BaseDistrMetric(BaseProbaMetric):
         multivariate = self.multivariate
 
         index_df = self.evaluate_by_index(y_true, y_pred, **kwargs)
-        out_df = pd.DataFrame(index_df.mean(axis=0)).T
+        sample_weight = kwargs.get("sample_weight", None)
+        if sample_weight is not None:
+            out_df = pd.DataFrame(np.average(index_df, weights=sample_weight, axis=0)).T
+        else:
+            out_df = pd.DataFrame(index_df.mean(axis=0)).T
         out_df.columns = index_df.columns
 
         if multioutput == "uniform_average" and not multivariate:
@@ -595,6 +620,9 @@ class BaseSurvDistrMetric(BaseDistrMetric):
             0 = uncensored, 1 = (right) censored
             if None, all observations are assumed to be uncensored
 
+        sample_weight : 1D array-like, optional, default=None
+            Sample weights for each instance/time point.
+
         Returns
         -------
         loss : float or 1-column pd.DataFrame with calculated metric value(s)
@@ -622,6 +650,9 @@ class BaseSurvDistrMetric(BaseDistrMetric):
             should have entries 0 and 1 (float or int)
             0 = uncensored, 1 = (right) censored
             if None, all observations are assumed to be uncensored
+
+        sample_weight : 1D array-like, optional, default=None
+            Sample weights for each instance/time point.
 
         Returns
         -------

--- a/skpro/metrics/tests/test_probabilistic_metrics.py
+++ b/skpro/metrics/tests/test_probabilistic_metrics.py
@@ -1,4 +1,5 @@
 """Tests for probabilistic quantile and interval metrics."""
+import numpy as np
 import pandas as pd
 import pytest
 from sklearn.datasets import load_diabetes
@@ -214,3 +215,49 @@ def test_evaluate_alpha_negative(Metric, y_pred, y_true):
         # 0.3 not in test quantile data so raise error.
         Loss = Metric.create_test_instance().set_params(alpha=0.3)
         res = Loss(y_true=y_true, y_pred=y_pred)  # noqa
+
+
+@pytest.mark.parametrize("metric", all_metrics)
+@pytest.mark.parametrize("score_average", [True, False])
+def test_sample_weight_probabilistic(metric, score_average):
+    """Test that sample_weight is correctly applied in probabilistic metrics."""
+    # Data generation
+    y_true = pd.Series([1.0, -1.0, 2.0, 3.0])
+    y_pred = pd.DataFrame(
+        {
+            0: [0.8, -0.9, 1.8, 2.7],
+            1: [1.2, -1.1, 2.2, 3.3],
+        }
+    )
+
+    if metric in interval_metrics:
+        # Use interval columns
+        y_pred.columns = pd.MultiIndex.from_tuples(
+            [("y", 0.9, "lower"), ("y", 0.9, "upper")],
+            names=["variable", "coverage", "lower_upper"],
+        )
+    else:
+        # Use quantile columns
+        y_pred.columns = pd.MultiIndex.from_tuples(
+            [("y", 0.05), ("y", 0.95)], names=["variable", "alpha"]
+        )
+
+    # Weights that heavily emphasize the first observation
+    sample_weight = np.array([10.0, 0.1, 0.1, 0.1])
+
+    # Instantiate metric
+    loss = metric.create_test_instance()
+    loss.set_params(score_average=score_average, multioutput="uniform_average")
+
+    eval_loss_unweighted = loss(y_true, y_pred)
+    eval_loss_weighted = loss(y_true, y_pred, sample_weight=sample_weight)
+
+    # Assert types remain identical
+    if score_average:
+        assert isinstance(eval_loss_weighted, float)
+    else:
+        assert isinstance(eval_loss_weighted, pd.Series)
+
+    # The weighted and unweighted loss should differ unless mathematically
+    # identical by coincidence
+    assert not np.all(np.isclose(eval_loss_unweighted, eval_loss_weighted))


### PR DESCRIPTION
Fixes #369
Related to sktime/sktime#6548

This PR adds `sample_weight` support to all probabilistic forecasting metrics.

Changes:
- Added `sample_weight` to the `BaseProbaMetric` and `BaseDistrMetric` evaluation workflows.
- Extracted weights from `**kwargs` and applied them using `np.average(..., weights=sample_weight)` in the temporal aggregation steps.
- Naturally inherited by all specific metrics (PinballLoss, CRPS, LogLoss, etc.).
- Added an interface-level unit test to verify correctness across all quantile and interval metrics.


#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [ ] Optionally, for added estimators: I've added myself and possibly to the `maintainers` tag
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].

##### For new estimators
- [ ] I've added the estimator to the API reference
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag
