### PR TITLE
[ENH] added `update` capability in `GridSearchCV` and `RandomizedSearchCV`

### DIFF
--- a/skpro/model_selection/_tuning.py
+++ b/skpro/model_selection/_tuning.py
@@ -14,10 +14,40 @@ from skpro.utils.parallel import parallelize
 
 
 class BaseGridSearch(_DelegatedProbaRegressor):
+    """Base class for hyperparameter search with cross-validation.
+
+    Parameters
+    ----------
+    estimator : estimator object
+        Probabilistic regressor to tune.
+    cv : cross-validation generator or an iterable
+        Cross-validation splitting strategy.
+    backend : str, optional (default="loky")
+        Parallel backend for candidate evaluation.
+    refit : bool, optional (default=True)
+        Whether to refit the best estimator on all data.
+    scoring : skpro metric, str, or callable, optional (default=None)
+        Metric used to score candidate parameter settings.
+    verbose : int, optional (default=0)
+        Verbosity level.
+    return_n_best_estimators : int, optional (default=1)
+        Number of top-ranked fitted estimators to retain.
+    error_score : numeric or "raise", optional (default=np.nan)
+        Score assigned when a candidate fit fails.
+    backend_params : dict, optional
+        Additional parameters passed to the parallel backend.
+    update_behaviour : str, optional (default="no_update")
+        one of ``{"no_update", "inner_only", "full_refit"}``
+
+        Controls behaviour when ``update`` is called on a fitted tuner.
+        See :class:`GridSearchCV` for a full description of each option.
+    """
+
     _tags = {
         "estimator_type": "regressor",
         "capability:multioutput": True,
         "capability:missing": True,
+        "capability:update": True,
     }
 
     def __init__(
@@ -31,6 +61,7 @@ class BaseGridSearch(_DelegatedProbaRegressor):
         return_n_best_estimators=1,
         error_score=np.nan,
         backend_params=None,
+        update_behaviour="no_update",
     ):
         self.estimator = estimator
         self.cv = cv
@@ -41,6 +72,7 @@ class BaseGridSearch(_DelegatedProbaRegressor):
         self.return_n_best_estimators = return_n_best_estimators
         self.error_score = error_score
         self.backend_params = backend_params
+        self.update_behaviour = update_behaviour
 
         super().__init__()
 
@@ -50,6 +82,22 @@ class BaseGridSearch(_DelegatedProbaRegressor):
             "capability:survival",
         ]
         self.clone_tags(estimator, tags_to_clone)
+        self._set_update_capability_tag(estimator)
+
+    def _set_update_capability_tag(self, estimator):
+        """Set ``capability:update`` from ``update_behaviour`` and inner estimator."""
+        behaviour = self.update_behaviour
+        if behaviour == "no_update":
+            self.set_tags(**{"capability:update": False})
+        elif behaviour == "full_refit":
+            self.set_tags(**{"capability:update": True})
+        elif behaviour == "inner_only":
+            self.clone_tags(estimator, ["capability:update"])
+        else:
+            raise ValueError(
+                f"Unknown update_behaviour={behaviour!r}, must be one of "
+                "'no_update', 'inner_only', 'full_refit'."
+            )
 
     # attribute for _DelegatedProbaRegressor, which then delegates
     #     all non-overridden methods are same as of getattr(self, _delegate_name)
@@ -222,7 +270,83 @@ class BaseGridSearch(_DelegatedProbaRegressor):
             score = results[f"mean_{scoring_name}"].iloc[i]
             self.n_best_scores_.append(score)
 
+        if self.update_behaviour == "full_refit":
+            self._X = X
+            self._y = y
+            self._C = C
+
         return self
+
+    def _update(self, X, y, C=None):
+        """Update fitted tuner with a new batch of training data.
+
+        Behaviour is controlled by ``update_behaviour``:
+
+        - ``"no_update"``: return without changing fitted state.
+        - ``"inner_only"``: call ``best_estimator_.update(X, y, C=C)``.
+        - ``"full_refit"``: concatenate new data with stored training data
+          and re-run ``_fit`` (requires ``update_behaviour="full_refit"`` at
+          construction and ``fit`` time so training data is retained).
+
+        State required:
+            Requires state to be "fitted".
+
+        Writes to self:
+            Updates fitted model attributes ending in "_".
+
+        Parameters
+        ----------
+        X : pandas DataFrame
+            feature instances to update regressor with
+        y : pd.DataFrame, must be same length as X
+            labels to update regressor with
+        C : pd.DataFrame, optional (default=None)
+            censoring information for survival analysis
+
+        Returns
+        -------
+        self : reference to self
+        """
+        behaviour = self.update_behaviour
+
+        if behaviour == "full_refit":
+            if not hasattr(self, "_X"):
+                raise RuntimeError(
+                    f"In {self.__class__.__name__}, update_behaviour='full_refit' "
+                    "requires training data to be stored at fit time. "
+                    "Set update_behaviour='full_refit' before calling fit."
+                )
+            self._X = self._update_data(self._X, X)
+            self._y = self._update_data(self._y, y)
+            self._C = self._update_data(self._C, C)
+            self._fit(self._X, self._y, C=self._C)
+        elif behaviour == "inner_only":
+            self.best_estimator_.update(X=X, y=y, C=C)
+        elif behaviour == "no_update":
+            pass
+
+        return self
+
+    def _update_data(self, X, X_new):
+        """Concatenate old and new data, resetting index.
+
+        Parameters
+        ----------
+        X : pandas DataFrame or None
+        X_new : pandas DataFrame or None
+
+        Returns
+        -------
+        X_updated : pandas DataFrame or None
+            concatenated data with reset index
+        """
+        if X is None and X_new is None:
+            return None
+        if X is None:
+            return X_new.reset_index(drop=True)
+        if X_new is None:
+            return X.reset_index(drop=True)
+        return pd.concat([X, X_new], ignore_index=True)
 
     def _get_delegate(self):
         if self.is_fitted and not self.refit:
@@ -332,6 +456,23 @@ class GridSearchCV(BaseGridSearch):
           will default to ``joblib`` defaults.
         - "dask": any valid keys for ``dask.compute`` can be passed, e.g., ``scheduler``
 
+    update_behaviour : str, optional (default="no_update")
+        one of ``{"no_update", "inner_only", "full_refit"}``
+
+        Behaviour of the tuner when calling ``update``.
+        Only has an effect if the inner estimator supports ``update``
+        (i.e., has the ``capability:update`` tag set to ``True``).
+
+        * ``"no_update"`` = neither tuning parameters nor inner estimator
+          are updated. This is the default and matches pre-update behaviour.
+        * ``"inner_only"`` = tuning parameters are not re-tuned; only the
+          inner estimator (``best_estimator_``) is updated via its ``update``
+          method.
+        * ``"full_refit"`` = accumulate all training data seen so far and
+          re-run the full hyperparameter search. Training data is stored in
+          memory at ``fit`` time; use only when incremental refitting is
+          required, as this can be memory-intensive for large datasets.
+
     Attributes
     ----------
     best_index_ : int
@@ -398,6 +539,7 @@ class GridSearchCV(BaseGridSearch):
         backend="loky",
         error_score=np.nan,
         backend_params=None,
+        update_behaviour="no_update",
     ):
         super().__init__(
             estimator=estimator,
@@ -409,6 +551,7 @@ class GridSearchCV(BaseGridSearch):
             backend=backend,
             error_score=error_score,
             backend_params=backend_params,
+            update_behaviour=update_behaviour,
         )
         self.param_grid = param_grid
 
@@ -488,7 +631,19 @@ class GridSearchCV(BaseGridSearch):
             "scoring": PinballLoss(),
             "error_score": "raise",
         }
-        params = [param1, param2, params3]
+
+        from skpro.regression.online._refit import OnlineRefit
+
+        params4 = {
+            "estimator": OnlineRefit(ResidualDouble(LinearRegression())),
+            "cv": KFold(n_splits=3),
+            "param_grid": {"estimator__fit_intercept": [True, False]},
+            "scoring": CRPS(),
+            "error_score": "raise",
+            "update_behaviour": "inner_only",
+        }
+
+        params = [param1, param2, params3, params4]
 
         return params
 
@@ -601,6 +756,23 @@ class RandomizedSearchCV(BaseGridSearch):
           will default to ``joblib`` defaults.
         - "dask": any valid keys for ``dask.compute`` can be passed, e.g., ``scheduler``
 
+    update_behaviour : str, optional (default="no_update")
+        one of ``{"no_update", "inner_only", "full_refit"}``
+
+        Behaviour of the tuner when calling ``update``.
+        Only has an effect if the inner estimator supports ``update``
+        (i.e., has the ``capability:update`` tag set to ``True``).
+
+        * ``"no_update"`` = neither tuning parameters nor inner estimator
+          are updated. This is the default and matches pre-update behaviour.
+        * ``"inner_only"`` = tuning parameters are not re-tuned; only the
+          inner estimator (``best_estimator_``) is updated via its ``update``
+          method.
+        * ``"full_refit"`` = accumulate all training data seen so far and
+          re-run the full hyperparameter search. Training data is stored in
+          memory at ``fit`` time; use only when incremental refitting is
+          required, as this can be memory-intensive for large datasets.
+
     Attributes
     ----------
     best_index_ : int
@@ -662,6 +834,7 @@ class RandomizedSearchCV(BaseGridSearch):
         random_state=None,
         error_score=np.nan,
         backend_params=None,
+        update_behaviour="no_update",
     ):
         super().__init__(
             estimator=estimator,
@@ -672,6 +845,7 @@ class RandomizedSearchCV(BaseGridSearch):
             return_n_best_estimators=return_n_best_estimators,
             error_score=error_score,
             backend_params=backend_params,
+            update_behaviour=update_behaviour,
         )
         self.param_distributions = param_distributions
         self.n_iter = n_iter
@@ -732,6 +906,18 @@ class RandomizedSearchCV(BaseGridSearch):
             "scoring": PinballLoss(),
             "error_score": "raise",
         }
-        params = [param1, param2, params3]
+
+        from skpro.regression.online._refit import OnlineRefit
+
+        params4 = {
+            "estimator": OnlineRefit(ResidualDouble(LinearRegression())),
+            "cv": KFold(n_splits=3),
+            "param_distributions": {"estimator__fit_intercept": [True, False]},
+            "scoring": CRPS(),
+            "error_score": "raise",
+            "update_behaviour": "inner_only",
+        }
+
+        params = [param1, param2, params3, params4]
 
         return params


### PR DESCRIPTION

<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skpro.readthedocs.io/en/latest/contribute.html
-->

#### Reference Issues/PRs

#1050 
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

This add the update capability for GridSearchCV and RandomizedSearchCV

BaseGridSearch:

- Added update_behaviour="full_refit" parameter to __init__
- Added "capability:update" to tags_to_clone so the tag propagates from the inner estimator
- Added self._X, self._y, self._C storage at end of _fit() for data accumulation
- Added _update() method with three strategies: "full_refit", "inner_only", "no_update"
- Added _update_data() helper for concatenating old + new data

GridSearchCV: 
- Added update_behaviour parameter to __init__, passed through to super 
- Added update_behaviour docstring entry 
- Added test params with OnlineRefit-wrapped estimator

RandomizedSearchCV: 
- Same three changes as GridSearchCV (parameter, docstring, test params)


#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new core dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core skpro package to a minimum.
-->

No

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [x] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
