### PR TITLE
[ENH] Fixes #1051: add hyperactive tuner as importable

### DIFF
--- a/skpro/model_selection/__init__.py
+++ b/skpro/model_selection/__init__.py
@@ -1,5 +1,6 @@
 """Tuning and model selection."""
 
-__all__ = ["GridSearchCV", "RandomizedSearchCV"]
+__all__ = ["GridSearchCV", "RandomizedSearchCV", "ProbaRegOptCV"]
 
 from skpro.model_selection._tuning import GridSearchCV, RandomizedSearchCV
+from skpro.model_selection._hyperactive import ProbaRegOptCV

--- a/skpro/model_selection/_hyperactive.py
+++ b/skpro/model_selection/_hyperactive.py
@@ -20,6 +20,7 @@ class ProbaRegOptCV(_DelegatedProbaRegressor):
         "capability:multioutput": True,
         "capability:missing": True,
         "python_dependencies": "hyperactive",
+        "tests:vm": True,
     }
 
     def __init__(

--- a/skpro/model_selection/_hyperactive.py
+++ b/skpro/model_selection/_hyperactive.py
@@ -1,0 +1,57 @@
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+"""Hyperactive Search CV tuning for probabilistic regressors."""
+
+from skpro.registry._placeholder_rec import _placeholder_record
+from skpro.regression.base._delegate import _DelegatedProbaRegressor
+
+@_placeholder_record(
+    dependency="hyperactive",
+    import_path="hyperactive.integrations.skpro.ProbaRegOptCV"
+)
+class ProbaRegOptCV(_DelegatedProbaRegressor):
+    """Hyperparameter search cross-validation using Hyperactive tuner.
+
+    Performs hyperparameter optimization of probabilistic regressors
+    using the hyperactive optimization backend.
+    """
+
+    _tags = {
+        "estimator_type": "regressor",
+        "capability:multioutput": True,
+        "capability:missing": True,
+        "python_dependencies": "hyperactive",
+    }
+
+    def __init__(
+        self,
+        estimator,
+        optimizer,
+        cv=None,
+        scoring=None,
+        refit=True,
+        error_score=None,
+        backend=None,
+        backend_params=None,
+    ):
+        self.estimator = estimator
+        self.optimizer = optimizer
+        self.cv = cv
+        self.scoring = scoring
+        self.refit = refit
+        self.error_score = error_score
+        self.backend = backend
+        self.backend_params = backend_params
+
+        super().__init__()
+
+        # Clone tags from base estimator
+        tags_to_clone = [
+            "capability:multioutput",
+            "capability:missing",
+            "capability:survival",
+        ]
+        self.clone_tags(estimator, tags_to_clone)
+
+    def _fit(self, X, y, C=None):
+        """Fit stub placeholder."""
+        pass

--- a/skpro/registry/__init__.py
+++ b/skpro/registry/__init__.py
@@ -10,6 +10,7 @@ from skpro.registry._base_classes import (
 )
 from skpro.registry._craft import craft, deps, imports
 from skpro.registry._lookup import all_objects, all_tags
+from skpro.registry._placeholder_rec import _placeholder_record
 from skpro.registry._scitype import scitype
 from skpro.registry._tags import (
     OBJECT_TAG_LIST,
@@ -33,4 +34,5 @@ __all__ = [
     "get_test_class_for_str",
     "imports",
     "scitype",
+    "_placeholder_record",
 ]

--- a/skpro/registry/_placeholder_rec.py
+++ b/skpro/registry/_placeholder_rec.py
@@ -1,0 +1,41 @@
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+"""Placeholder registry utilities for optional soft dependencies."""
+
+import importlib
+from functools import wraps
+
+def _placeholder_record(dependency, import_path):
+    """Decorator to mark a class as a placeholder for a soft dependency.
+    
+    If the soft dependency is installed, the class is transparently
+    replaced with the actual class from the external package.
+    If it is not installed, the stub class is returned. Any attempt
+    to instantiate it will raise an ImportError explaining how to
+    install the soft dependency.
+    """
+    def decorator(cls):
+        from skbase.utils.dependencies import _check_soft_dependencies
+        
+        # Check if the soft dependency is installed in the environment
+        if _check_soft_dependencies(dependency, severity="none"):
+            try:
+                module_path, class_name = import_path.rsplit(".", 1)
+                module = importlib.import_module(module_path)
+                real_class = getattr(module, class_name)
+                return real_class
+            except (ImportError, AttributeError):
+                pass
+        
+        # If not installed, wrap __init__ to raise a clear soft-dependency error
+        original_init = cls.__init__
+        
+        @wraps(original_init)
+        def new_init(self, *args, **kwargs):
+            from skbase.utils.dependencies import _check_soft_dependencies
+            _check_soft_dependencies(dependency, severity="error", obj=self)
+            original_init(self, *args, **kwargs)
+            
+        cls.__init__ = new_init
+        return cls
+        
+    return decorator


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skpro.readthedocs.io/en/latest/contribute.html
-->

#### Reference Issues/PRs
Fixes #1051 


#### What does this implement/fix? Explain your changes.
This PR implements the dynamic _placeholder_record forwarding pattern in skpro registry (similar to sktime Prophetverse integration) and registers the ProbaRegOptCV hyperactive-tuner wrapper as an importable placeholder class.

Specifically:

1) Added _placeholder_record decorator: Created skpro/registry/_placeholder_rec.py containing a dynamic registry utility decorator. If the soft dependency hyperactive is installed in the runtime environment, the class is transparently swapped with the actual external package class (hyperactive.integrations.skpro.ProbaRegOptCV). Otherwise, it keeps the stub class and wraps its __init__ to raise a clean and descriptive soft-dependency ImportError on instantiation.
2) Created stub class ProbaRegOptCV: Created skpro/model_selection/_hyperactive.py to define the ProbaRegOptCV stub. This contains necessary search tags like "python_dependencies": "hyperactive" to enable registry indexing and documentation generators to find it without requiring the installation of hyperactive beforehand.
3) Namespace Registration: Exposed _placeholder_record in skpro/registry/__init__.py and exposed the tuner ProbaRegOptCV in skpro/model_selection/__init__.py.

#### Does your contribution introduce a new dependency? If yes, which one?

Yes, it introduces hyperactive as an optional soft dependency. It does not introduce any new hard dependencies

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

No direct standalone test was added

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
