### PR TITLE
[BUG] fix diamond tag inheritance bug in regressor `Pipeline`

### DIFF
--- a/skpro/regression/compose/_pipeline.py
+++ b/skpro/regression/compose/_pipeline.py
@@ -25,6 +25,8 @@ class _Pipeline(BaseMetaEstimator, BaseProbaRegressor):
     # the fitted estimators should be in fitted_named_object_parameters
     # this must be an iterable of (name: str, estimator, ...) tuples for the default
     _tags = {
+        "object_type": "regressor_proba",  # type of object, e.g., "distribution"
+        "estimator_type": "regressor_proba",  # type of estimator, e.g., "regressor"
         "named_object_parameters": "_steps",
         "fitted_named_object_parameters": "steps_",
     }


### PR DESCRIPTION
Fixes an unreported diamond tag inheritance bug in regressor `Pipeline`.

The `object_type` tag was incorrectly set to `"estimator"` by inheritance, but it should be `"regressor_proba"`. This is fixed by explicitly overriding the tag in the youngest class, `Pipeline` itself.