### PR TITLE
[ENH] add online update to BaggingRegressor

### DIFF
--- a/skpro/regression/ensemble/_bagging.py
+++ b/skpro/regression/ensemble/_bagging.py
@@ -21,6 +21,15 @@ class BaggingRegressor(BaseProbaRegressor):
 
     On ``predict_proba``, the mixture of probabilistic predictions is returned.
 
+    In ``update``, each fitted clone is updated on a row subsample of the new
+    batch. The row subsample fraction is the same as in ``fit`` (for integer
+    ``n_samples``, the fraction ``n_samples / n_fit`` is stored at ``fit`` and
+    applied to each update batch). The same ``bootstrap`` setting and feature
+    subset ``cols_[i]`` as at ``fit`` are reused (column sampling is not
+    repeated). Meaningful online learning requires an inner regressor with true
+    ``update`` support (for example a River wrapper); batch-only inners ignore
+    the delegated update calls.
+
     The estimator allows to choose sample sizes for instances, variables,
     and whether sampling is with or without replacement.
 
@@ -79,6 +88,7 @@ class BaggingRegressor(BaseProbaRegressor):
     _tags = {
         "capability:missing": True,
         "capability:survival": True,
+        "capability:update": True,
     }
 
     def __init__(
@@ -137,10 +147,8 @@ class BaggingRegressor(BaseProbaRegressor):
         n = len(inst_ix)
         m = len(col_ix)
 
-        if isinstance(n_samples, float):
-            n_samples_ = ceil(n_samples * n)
-        else:
-            n_samples_ = n_samples
+        self.n_samples_frac_ = _as_sample_fraction(n_samples, n)
+        n_samples_ = _resolve_subsample_size(self.n_samples_frac_, n, bootstrap)
 
         if isinstance(n_features, float):
             n_features_ = ceil(n_features * m)
@@ -178,6 +186,56 @@ class BaggingRegressor(BaseProbaRegressor):
                 Ci = C.loc[inst_ix_i].reset_index(drop=True)
 
             self.estimators_ += [esti.fit(Xi, yi, Ci)]
+
+        return self
+
+    def _update(self, X, y, C=None):
+        """Update each bagged estimator on a subsample of the new batch.
+
+        Row subsampling mirrors ``_fit``: the stored ``n_samples_frac_`` and
+        ``bootstrap`` are applied to the update batch size. Feature subsets
+        ``cols_`` from ``fit`` are reused without resampling.
+
+        Parameters
+        ----------
+        X : pandas DataFrame
+            feature instances in the update batch
+        y : pandas DataFrame, must be same length as X
+            labels in the update batch
+        C : pandas DataFrame, optional (default=None)
+            censoring indicator
+
+        Returns
+        -------
+        self : reference to self
+        """
+        bootstrap = self.bootstrap
+        bootstrap_ft = self.bootstrap_features
+        random_state = self.random_state
+
+        inst_ix = X.index
+        n = len(inst_ix)
+        n_samples_ = _resolve_subsample_size(self.n_samples_frac_, n, bootstrap)
+        reset_cols = bootstrap_ft
+
+        for esti, col_ix_i in zip(self.estimators_, self.cols_):
+            row_iloc = pd.RangeIndex(n)
+            row_ss = _random_ss_ix(
+                row_iloc, size=n_samples_, replace=bootstrap, random_state=random_state
+            )
+            inst_ix_i = inst_ix[row_ss]
+
+            Xi = _subs_cols(X.loc[inst_ix_i], col_ix_i, reset_cols=reset_cols)
+            Xi = Xi.reset_index(drop=True)
+
+            yi = y.loc[inst_ix_i].reset_index(drop=True)
+
+            if C is None:
+                Ci = None
+            else:
+                Ci = C.loc[inst_ix_i].reset_index(drop=True)
+
+            esti.update(Xi, yi, Ci)
 
         return self
 
@@ -256,6 +314,21 @@ class BaggingRegressor(BaseProbaRegressor):
         }
 
         return [params1, params2, params3, params4]
+
+
+def _as_sample_fraction(n_samples, n):
+    """Convert ``n_samples`` (int or float) to a row subsample fraction."""
+    if isinstance(n_samples, float):
+        return n_samples
+    return n_samples / n
+
+
+def _resolve_subsample_size(n_samples_frac, n, bootstrap):
+    """Row subsample size for ``n`` rows from a fraction, respecting ``bootstrap``."""
+    n_samples_ = ceil(n_samples_frac * n)
+    if not bootstrap:
+        n_samples_ = min(n_samples_, n)
+    return n_samples_
 
 
 def _subs_cols(df, col_ix, reset_cols=False):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skpro.readthedocs.io/en/latest/contribute.html
-->

#### Reference Issues/PRs

Partially addresses #1049.

#### What does this implement/fix? Explain your changes.

Adds online `update` support to `BaggingRegressor`.

On `update`, each fitted bagged clone is updated on a row subsample of the incoming batch, using the same `n_samples` and `bootstrap` settings as in `fit`. Feature subsets `cols_[i]` from `fit` are reused (column sampling is not repeated). Sets `capability:update=True` on the meta-estimator so the public `update` path runs; meaningful incremental learning still depends on the inner regressor (batch-only inners effectively no-op). When `bootstrap=False`, subsample size is capped at the update batch size so small batches do not error.

Docstring updated to describe `update` behaviour.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

- Whether `_update` row subsampling matches `fit` semantics (including `bootstrap=False` on small update batches).

#### Did you add any tests for the change?

No dedicated tests added. Covered by existing `test_online_update` in `test_all_regressors.py` for `BaggingRegressor` via `get_test_params()`.

#### Any other comments?

Follow-up for #1049 may include `EnbpiRegressor` and a River wrapper for online inner estimators.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).