### PR TITLE
[ENH] reject non-positive sigma/scale in Normal and Laplace #959

### DIFF
--- a/skpro/distributions/laplace.py
+++ b/skpro/distributions/laplace.py
@@ -56,6 +56,8 @@ class Laplace(BaseDistribution):
 
     def __init__(self, mu, scale, index=None, columns=None):
         self.mu = mu
+        if np.any(np.asarray(scale) <=0 ) :
+            raise ValueError("scale must be strictly positive .")
         self.scale = scale
 
         super().__init__(index=index, columns=columns)

--- a/skpro/distributions/normal.py
+++ b/skpro/distributions/normal.py
@@ -53,6 +53,8 @@ class Normal(BaseDistribution):
 
     def __init__(self, mu, sigma, index=None, columns=None):
         self.mu = mu
+        if np.any(np.asarray(sigma) <= 0) :
+            raise ValueError("sigma must be strictly positive.")
         self.sigma = sigma
 
         super().__init__(index=index, columns=columns)

--- a/skpro/distributions/tests/test_parameter_validation.py
+++ b/skpro/distributions/tests/test_parameter_validation.py
@@ -1,0 +1,20 @@
+import pytest
+from skpro.distributions.normal import Normal
+from skpro.distributions.laplace import Laplace
+
+def test_negative_param_validation():
+    """Verify that distributions raise ValueError for non-positive scale parameters."""
+    
+    # 1. Test Normal distribution boundary condition
+    with pytest.raises(ValueError, match="sigma must be strictly positive."):
+        Normal(mu=0, sigma=-1)
+        
+    with pytest.raises(ValueError, match="sigma must be strictly positive."):
+        Normal(mu=0, sigma=0)
+
+    # 2. Test Laplace distribution boundary condition
+    with pytest.raises(ValueError, match="scale must be strictly positive."):
+        Laplace(mu=0, scale=-1)
+        
+    with pytest.raises(ValueError, match="scale must be strictly positive."):
+        Laplace(mu=0, scale=0)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #959

#### What does this implement/fix? Explain your changes.
This PR adds input parameter validation to the constructors (`__init__`) of both the `Normal` and `Laplace` distributions to enforce strictly positive scale parameters (`sigma` for Normal and `scale` for Laplace). 

Previously, passing non-positive values allowed mathematically invalid negative values to propagate to the `_pdf` calculation. The input validation uses a robust vectorized numpy check `np.any(np.asarray(...) <= 0)` to seamlessly handle both scalar values and multi-dimensional array structures without crashing.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
The vector/array validation logic implementation using `np.any(np.asarray(...) <= 0)` inside the constructors.

#### Did you add any tests for the change?
Yes, added a new automated unit test file:
`skpro/distributions/tests/test_parameter_validation.py` which verifies that both distributions throw a descriptive `ValueError` on negative and zero boundary values.

#### Any other comments?
This is my first contribution to skpro ,  Excited to hear feedback.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the list of contributors with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].