### PR TITLE
[ENH] `VotingProbaRegressor` - heterogeneous ensemble compositor

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -245,7 +245,7 @@
       "name": "Khush Agrawal",
       "profile": "https://github.com/Khushmagrawal",
       "contributions": [
-        "code",
+        "code"
       ]
     },
     {

--- a/docs/source/api_reference/regression.rst
+++ b/docs/source/api_reference/regression.rst
@@ -141,7 +141,6 @@ Formally, these algorithms are reduction algorithms, to tabular regression.
 
     BaggingRegressor
     NGBoostRegressor
-    VotingProbaRegressor
 
 .. currentmodule:: skpro.regression.cyclic_boosting
 
@@ -161,6 +160,18 @@ Reduction to probabilistic classification
     :template: class.rst
 
     HistBinnedProbaRegressor
+
+Heterogeneous ensembles of probabilistic regressors
+---------------------------------------------------
+
+.. currentmodule:: skpro.regression.ensemble
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    VotingProbaRegressor
+
 
 Distributional boosting
 -----------------------

--- a/docs/source/api_reference/regression.rst
+++ b/docs/source/api_reference/regression.rst
@@ -141,6 +141,7 @@ Formally, these algorithms are reduction algorithms, to tabular regression.
 
     BaggingRegressor
     NGBoostRegressor
+    VotingProbaRegressor
 
 .. currentmodule:: skpro.regression.cyclic_boosting
 

--- a/skpro/regression/ensemble/__init__.py
+++ b/skpro/regression/ensemble/__init__.py
@@ -1,7 +1,8 @@
-"""Natural Gradient Boosting Regressor models."""
+"""Ensemble probabilistic regressors."""
 # copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
 
 from skpro.regression.ensemble._bagging import BaggingRegressor
 from skpro.regression.ensemble._ngboost import NGBoostRegressor
+from skpro.regression.ensemble._voting import VotingProbaRegressor
 
-__all__ = ["BaggingRegressor", "NGBoostRegressor"]
+__all__ = ["BaggingRegressor", "NGBoostRegressor", "VotingProbaRegressor"]

--- a/skpro/regression/ensemble/_voting.py
+++ b/skpro/regression/ensemble/_voting.py
@@ -1,0 +1,173 @@
+"""Voting ensemble of heterogeneous probabilistic regressors."""
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+
+__author__ = ["Ashish-Kumar-Dash"]
+__all__ = ["VotingProbaRegressor"]
+
+from skpro.base import BaseMetaEstimator
+from skpro.distributions.mixture import Mixture
+from skpro.regression.base import BaseProbaRegressor
+
+
+class VotingProbaRegressor(BaseMetaEstimator, BaseProbaRegressor):
+    """Voting ensemble of heterogeneous probabilistic regressors.
+
+    Fits multiple probabilistic regressors on the same training data.
+    On ``predict_proba``, returns a ``Mixture`` distribution of the
+    component predictions, with user-specified or uniform weights.
+
+    Generalizes ``sklearn``'s ``VotingRegressor`` to the probabilistic
+    regression setting, where predictions are full distributions
+    rather than point predictions.
+
+    Parameters
+    ----------
+    estimators : list of (str, estimator) tuples or list of estimators
+        The ensemble members. Each estimator must be a descendant of
+        ``BaseProbaRegressor``.
+        If a plain list of estimators is passed, names are generated
+        automatically from class names.
+    weights : array-like of float, optional, default=None
+        Mixture weights for the component predictions.
+        If None, uniform weights are used.
+        Weights are normalized to sum to 1 internally by ``Mixture``.
+
+    Attributes
+    ----------
+    estimators_ : list of (str, estimator) tuples
+        Fitted clones of the estimators passed in ``estimators``.
+
+    Examples
+    --------
+    >>> from skpro.regression.ensemble import VotingProbaRegressor
+    >>> from skpro.regression.residual import ResidualDouble
+    >>> from sklearn.linear_model import LinearRegression
+    >>> from sklearn.datasets import load_diabetes
+    >>> from sklearn.model_selection import train_test_split
+    >>>
+    >>> X, y = load_diabetes(return_X_y=True, as_frame=True)
+    >>> X_train, X_test, y_train, y_test = train_test_split(X, y)
+    >>>
+    >>> reg1 = ResidualDouble(LinearRegression())
+    >>> reg2 = ResidualDouble(LinearRegression())
+    >>>
+    >>> voter = VotingProbaRegressor(
+    ...     estimators=[("r1", reg1), ("r2", reg2)],
+    ... )
+    >>> voter.fit(X_train, y_train)
+    VotingProbaRegressor(...)
+    >>> y_pred = voter.predict_proba(X_test)
+    """
+
+    _tags = {
+        "object_type": "regressor_proba",
+        "estimator_type": "regressor_proba",
+        "named_object_parameters": "_estimators",
+        "fitted_named_object_parameters": "estimators_",
+        "capability:missing": True,
+        "capability:survival": True,
+    }
+
+    def __init__(self, estimators, weights=None):
+        self.estimators = estimators
+        self.weights = weights
+
+        super().__init__()
+
+        # set capability tags as AND over all component estimators
+        # ensemble can only handle missing/survival if ALL components can
+        tags_to_and = ["capability:missing", "capability:survival"]
+        est_list = self._estimators
+        for tag in tags_to_and:
+            tag_val = all(est.get_tag(tag, False) for _, est in est_list)
+            self.set_tags(**{tag: tag_val})
+
+    @property
+    def _estimators(self):
+        return self._coerce_to_named_object_tuples(self.estimators, clone=False)
+
+    @_estimators.setter
+    def _estimators(self, value):
+        self.estimators = value
+
+    def _fit(self, X, y, C=None):
+        """Fit all component regressors to training data.
+
+        Parameters
+        ----------
+        X : pandas DataFrame
+            feature instances to fit regressor to
+        y : pandas DataFrame, must be same length as X
+            labels to fit regressor to
+        C : pandas DataFrame, optional (default=None)
+            censoring information for survival analysis
+
+        Returns
+        -------
+        self : reference to self
+        """
+        self.estimators_ = []
+
+        for name, est in self._estimators:
+            fitted_est = est.clone().fit(X, y, C=C)
+            self.estimators_.append((name, fitted_est))
+
+        return self
+
+    def _predict_proba(self, X):
+        """Predict distribution over labels for data from features.
+
+        Returns a ``Mixture`` of predictions from all fitted regressors.
+
+        Parameters
+        ----------
+        X : pandas DataFrame, must have same columns as X in ``fit``
+            data to predict labels for
+
+        Returns
+        -------
+        y_pred : skpro ``Mixture`` distribution, same length as ``X``
+            mixture of probabilistic predictions from all component regressors
+        """
+        y_probas = [(name, est.predict_proba(X)) for name, est in self.estimators_]
+
+        return Mixture(distributions=y_probas, weights=self.weights)
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return ``"default"`` set.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            ``MyClass(**params)`` or ``MyClass(**params[i])`` creates a valid test
+            instance.
+            ``create_test_instance`` uses the first (or only) dictionary in ``params``
+        """
+        from sklearn.linear_model import LinearRegression
+
+        from skpro.regression.residual import ResidualDouble
+
+        reg1 = ResidualDouble(LinearRegression())
+        reg2 = ResidualDouble(LinearRegression())
+
+        params1 = {
+            "estimators": [("r1", reg1), ("r2", reg2)],
+        }
+        params2 = {
+            "estimators": [("r1", reg1), ("r2", reg2)],
+            "weights": [0.7, 0.3],
+        }
+        params3 = {
+            "estimators": [reg1, reg2],
+        }
+
+        return [params1, params2, params3]

--- a/skpro/regression/ensemble/_voting.py
+++ b/skpro/regression/ensemble/_voting.py
@@ -41,6 +41,7 @@ class VotingProbaRegressor(BaseMetaEstimator, BaseProbaRegressor):
     --------
     >>> from skpro.regression.ensemble import VotingProbaRegressor
     >>> from skpro.regression.residual import ResidualDouble
+    >>> from skpro.regression.linear import BayesianRidge
     >>> from sklearn.linear_model import LinearRegression
     >>> from sklearn.datasets import load_diabetes
     >>> from sklearn.model_selection import train_test_split
@@ -49,7 +50,7 @@ class VotingProbaRegressor(BaseMetaEstimator, BaseProbaRegressor):
     >>> X_train, X_test, y_train, y_test = train_test_split(X, y)
     >>>
     >>> reg1 = ResidualDouble(LinearRegression())
-    >>> reg2 = ResidualDouble(LinearRegression())
+    >>> reg2 = BayesianRidge()
     >>>
     >>> voter = VotingProbaRegressor(
     ...     estimators=[("r1", reg1), ("r2", reg2)],
@@ -154,10 +155,11 @@ class VotingProbaRegressor(BaseMetaEstimator, BaseProbaRegressor):
         """
         from sklearn.linear_model import LinearRegression
 
+        from skpro.regression.linear import BayesianRidge
         from skpro.regression.residual import ResidualDouble
 
         reg1 = ResidualDouble(LinearRegression())
-        reg2 = ResidualDouble(LinearRegression())
+        reg2 = BayesianRidge()
 
         params1 = {
             "estimators": [("r1", reg1), ("r2", reg2)],

--- a/skpro/regression/ensemble/_voting.py
+++ b/skpro/regression/ensemble/_voting.py
@@ -74,13 +74,13 @@ class VotingProbaRegressor(BaseMetaEstimator, BaseProbaRegressor):
 
         super().__init__()
 
-        # set capability tags as AND over all component estimators
-        # ensemble can only handle missing/survival if ALL components can
-        tags_to_and = ["capability:missing", "capability:survival"]
         est_list = self._estimators
-        for tag in tags_to_and:
-            tag_val = all(est.get_tag(tag, False) for _, est in est_list)
-            self.set_tags(**{tag: tag_val})
+
+        # self can handle missing data if and only if all components can
+        self._anytagis_then_set("capability:missing", False, True, est_list)
+
+        # self can handle survival data if and only if at least one component can
+        self._anytagis_then_set("capability:survival", True, False, est_list)
 
     @property
     def _estimators(self):


### PR DESCRIPTION
#### Reference Issues/PRs

  None 

  #### What does this implement/fix? Explain your changes.

  Adds `VotingProbaRegressor`, a heterogeneous ensemble that fits multiple
  probabilistic regressors on the same data and returns a `Mixture` distribution
  of their predictions.

  Probabilistic generalization of sklearn's `VotingRegressor` — instead of
  averaging point predictions, it combines full predictive distributions via
  weighted mixture.

  Key decisions for the basis of this PR:
  - Inherits from `BaseMetaEstimator, BaseProbaRegressor` — follows the
  `Pipeline` pattern for heterogeneous estimator lists
  (`named_object_parameters`, property-based `_estimators`)
  - Capability tags use AND logic across components
  - Delegates all distribution math to `Mixture`

  #### Does your contribution introduce a new dependency? If yes, which one?

  No.

  #### What should a reviewer concentrate their feedback on?

  - The AND logic for capability tag cloning (lines 80-84) — this is different
  from single-estimator `clone_tags` used elsewhere
  - Whether `_estimators` as a property (mirroring `Pipeline._steps`) is the
  preferred pattern here

  #### Did you add any tests for the change?

  The estimator is auto-discovered by the existing test framework via
  `get_test_params` (3 parameter sets). All pass:
  - `test_all_estimators` — 67 passed
  - `test_all_regressors` — 21 passed

  #### Any other comments?

  No.

  #### PR checklist

  ##### For all contributions
  - [ ] I've added myself to the list of contributors with any new badges I've
  earned :-)
  - [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].

  ##### For new estimators
  - [x] I've added the estimator to the API reference - in
  `docs/source/api_reference/regression.rst`
  - [x] I've added one or more illustrative usage examples to the docstring, in
  a pydocstyle compliant `Examples` section.
  - [x] If the estimator relies on a soft dependency, I've set the
  `python_dependencies` tag and ensured dependency isolation. (N/A — no soft
  dependencies)
