### PR TITLE
[MNT] move frozen 2024 dependencies test to `uv` dependency freeze mechanism from dedicated depset

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -300,15 +300,16 @@ jobs:
         run: python -c "import sys; print(sys.version)"
 
       - name: Install sktime and dependencies
-        run: pip install .[dev,dependencies_2024]
+        run: >
+          uv pip install .[dev]
+          --exclude-newer-package "setuptools=false"
+          --exclude-newer-package "scikit-base=false"
         env:
           UV_SYSTEM_PYTHON: 1
+          UV_EXCLUDE_NEWER: "2024-09-01"
 
       - name: Show dependencies
-        run: python -m pip list
-
-      - name: Show available branches
-        run: git branch -a
+        run: uv pip list
 
       - name: Run tests
         run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -299,7 +299,7 @@ jobs:
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
 
-      - name: Install sktime and dependencies
+      - name: Install skpro and dependencies
         run: >
           uv pip install .[dev]
           --exclude-newer-package "setuptools=false"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,17 +85,6 @@ docs = [
     "tabulate",
 ]
 
-# CI related soft dependency sets - not for users of sktime, only for developers
-# these are for special uses and may be changed or removed at any time
-
-# August 2024 (briefly after numpy2 release)
-dependencies_2024 = [
-    "numpy==2.1.0",
-    "pandas==2.3.2",
-    "scikit-learn==1.5.1",
-    "scipy==1.14.1",
-]
-
 [project.urls]
 Homepage = "https://github.com/sktime/skpro"
 Repository = "https://github.com/sktime/skpro"

--- a/skpro/regression/compose/_pipeline.py
+++ b/skpro/regression/compose/_pipeline.py
@@ -25,6 +25,8 @@ class _Pipeline(BaseMetaEstimator, BaseProbaRegressor):
     # the fitted estimators should be in fitted_named_object_parameters
     # this must be an iterable of (name: str, estimator, ...) tuples for the default
     _tags = {
+        "object_type": "regressor_proba",  # type of object, e.g., "distribution"
+        "estimator_type": "regressor_proba",  # type of estimator, e.g., "regressor"
         "named_object_parameters": "_steps",
         "fitted_named_object_parameters": "steps_",
     }


### PR DESCRIPTION
This PR replaces the dedicated `pyproject` depset mechanism to test `skpro` against frozen 2024 dependencies by the `uv` native feature for frozen dependency sets.