### PR TITLE
[BUG] Fixing bounds in `cdf` in `TruncatedDistribution` 

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -264,6 +264,13 @@
         "bug",
         "doc"
       ]
+    },
+    {
+      "login": "siddharth7113",
+      "name": "Siddharth",
+      "contributions": [
+        "bug"
+      ]
     }
   ]
 }

--- a/skpro/distributions/truncated.py
+++ b/skpro/distributions/truncated.py
@@ -186,10 +186,10 @@ class TruncatedDistribution(BaseDistribution):
 
     def _cdf(self, x):
         prob_at_lower, prob_at_upper = self._get_low_high_prob()
-
-        return (self.distribution.cdf(x) - prob_at_lower) / (
+        cdf = (self.distribution.cdf(x) - prob_at_lower) / (
             prob_at_upper - prob_at_lower
         )
+        return np.clip(cdf, 0.0, 1.0)
 
     def _log_pdf(self, x):
         return self._calculate_density(x, self.distribution.log_pdf, as_log=True)


### PR DESCRIPTION

<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skpro.readthedocs.io/en/latest/contribute.html
-->

#### Reference Issues/PRs
Fixes #1079
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
`cdf` is monotone and bounded in [0, 1]: `0 for x < lower, and 1 for x >= upper`. For the example above, `cdf(1.0)` and `cdf(3.0)` should both be 1.0.

A minimal fix is to clamp the result in _cdf:

```python
cdf = (self.distribution.cdf(x) - prob_at_lower) / (prob_at_upper - prob_at_lower)
return np.clip(cdf, 0.0, 1.0)
```



#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.


<!--
Thanks for contributing!
-->
