### PR TITLE
[DOC] add missing `Gumbel` distribution to distributions API reference

### DIFF
--- a/docs/source/api_reference/distributions.rst
+++ b/docs/source/api_reference/distributions.rst
@@ -36,6 +36,7 @@ Continuous support - full reals
     :template: class.rst
 
     Cauchy
+    Gumbel
     Laplace
     Logistic
     Normal


### PR DESCRIPTION
Adds the missing `Gumbel` distribution to the distributions API reference