### PR TITLE
ENH: Fork cyclic_boosting into skpro and update NumPy compatibility (Fixes #1090)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,6 +68,7 @@ repos:
     hooks:
       - id: pydocstyle
         args: ["--config=setup.cfg"]
+        exclude: "^skpro/libs/"
 
   # We use the Python version instead of the original version which seems to require Docker
   # https://github.com/koalaman/shellcheck-precommit

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ ignore = E121, E123, E126, E226, E24, E704, W503, W504
 max-line-length = 88
 exclude =
     skpro/_contrib/*
+    skpro/libs/*
 extend-ignore =
     # See https://github.com/PyCQA/pycodestyle/issues/373
     E203

--- a/skpro/libs/__init__.py
+++ b/skpro/libs/__init__.py
@@ -1,0 +1,1 @@
+"""Libraries bundled with skpro for compatibility."""

--- a/skpro/libs/cyclic_boosting/GBSregression.py
+++ b/skpro/libs/cyclic_boosting/GBSregression.py
@@ -1,0 +1,109 @@
+"""
+Cyclic Boosting Regression for Generalized Background Subtraction regression.
+"""
+
+
+import logging
+
+import numpy as np
+from sklearn.base import RegressorMixin
+import pandas as pd
+
+from skpro.libs.cyclic_boosting.base import CyclicBoostingBase, Feature, CBLinkPredictionsFactors
+from skpro.libs.cyclic_boosting.link import IdentityLinkMixin
+from typing import Tuple, Union
+
+_logger = logging.getLogger(__name__)
+
+
+class CBGBSRegressor(RegressorMixin, CyclicBoostingBase, IdentityLinkMixin):
+    r"""
+    Variant form of Cyclic Boosting's location regressor, that corresponds to
+    the regression of the outcome of a previous statistical subtraction of two
+    classes of observations from each other (e.g. groups A and B: A - B).
+
+    For this, the target y has to be set to positive values for group A and
+    negative values for group B.
+
+    Additional Parameter
+    --------------------
+    regalpha: float
+        A hyperparameter to steer the strength of regularization, i.e. a
+        shrinkage of the regression result for A _B to 0. A value of 0
+        corresponds to no regularization.
+    """
+
+    def __init__(
+        self,
+        feature_groups=None,
+        hierarchical_feature_groups=None,
+        feature_properties=None,
+        weight_column=None,
+        minimal_loss_change=1e-10,
+        minimal_factor_change=1e-10,
+        maximal_iterations=10,
+        observers=None,
+        smoother_choice=None,
+        output_column=None,
+        learn_rate=None,
+        regalpha=0.0,
+        aggregate=True,
+    ):
+        CyclicBoostingBase.__init__(
+            self,
+            feature_groups=feature_groups,
+            hierarchical_feature_groups=hierarchical_feature_groups,
+            feature_properties=feature_properties,
+            weight_column=weight_column,
+            minimal_loss_change=minimal_loss_change,
+            minimal_factor_change=minimal_factor_change,
+            maximal_iterations=maximal_iterations,
+            observers=observers,
+            smoother_choice=smoother_choice,
+            output_column=output_column,
+            learn_rate=learn_rate,
+            aggregate=aggregate,
+        )
+
+        self.regalpha = regalpha
+
+    def calc_parameters(
+        self, feature: Feature, y: np.ndarray, pred: CBLinkPredictionsFactors, prefit_data
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        lex_binnumbers = feature.lex_binned_data
+        minlength = feature.n_bins
+        prediction = pred.predict_link()
+
+        n = (y - prediction) * self.weights
+        d = self.weights * (1 + self.regalpha)
+
+        sum_n, sum_d, sum_nd, sum_n2, sum_d2 = (
+            np.bincount(lex_binnumbers, weights=w, minlength=minlength) for w in [n, d, n * d, n * n, d * d]
+        )
+
+        sum_d += 1
+        sum_d2 += 1**2
+
+        summand = sum_n / sum_d
+        variance_summand = (sum_d**2 * sum_n2 - 2.0 * sum_n * sum_d * sum_nd + sum_n**2 * sum_d2) / sum_d**4
+
+        return summand, np.sqrt(variance_summand)
+
+    def _check_y(self, y: np.ndarray):
+        pass
+
+    def _init_global_scale(self, X: Union[pd.DataFrame, np.ndarray], y: np.ndarray) -> None:
+        if self.weights is None:
+            raise RuntimeError("The weights have to be initialized.")
+        self.global_scale_link_ = (y * self.weights).sum() / self.weights.sum()
+
+    def loss(self, prediction: np.ndarray, y: np.ndarray, weights: np.ndarray) -> float:
+        wvisitsum = ((y != 0).astype(int) * weights).sum()
+        loss = (weights * (prediction - y) ** 2).sum() / wvisitsum
+        return loss
+
+    def precalc_parameters(self, feature: Feature, y: np.ndarray, pred: CBLinkPredictionsFactors) -> None:
+        return None
+
+
+__all__ = ["CBGBSRegressor"]

--- a/skpro/libs/cyclic_boosting/GBSregression.py
+++ b/skpro/libs/cyclic_boosting/GBSregression.py
@@ -4,14 +4,18 @@ Cyclic Boosting Regression for Generalized Background Subtraction regression.
 
 
 import logging
+from typing import Tuple, Union
 
 import numpy as np
-from sklearn.base import RegressorMixin
 import pandas as pd
+from sklearn.base import RegressorMixin
 
-from skpro.libs.cyclic_boosting.base import CyclicBoostingBase, Feature, CBLinkPredictionsFactors
+from skpro.libs.cyclic_boosting.base import (
+    CBLinkPredictionsFactors,
+    CyclicBoostingBase,
+    Feature,
+)
 from skpro.libs.cyclic_boosting.link import IdentityLinkMixin
-from typing import Tuple, Union
 
 _logger = logging.getLogger(__name__)
 
@@ -68,7 +72,11 @@ class CBGBSRegressor(RegressorMixin, CyclicBoostingBase, IdentityLinkMixin):
         self.regalpha = regalpha
 
     def calc_parameters(
-        self, feature: Feature, y: np.ndarray, pred: CBLinkPredictionsFactors, prefit_data
+        self,
+        feature: Feature,
+        y: np.ndarray,
+        pred: CBLinkPredictionsFactors,
+        prefit_data,
     ) -> Tuple[np.ndarray, np.ndarray]:
         lex_binnumbers = feature.lex_binned_data
         minlength = feature.n_bins
@@ -78,21 +86,26 @@ class CBGBSRegressor(RegressorMixin, CyclicBoostingBase, IdentityLinkMixin):
         d = self.weights * (1 + self.regalpha)
 
         sum_n, sum_d, sum_nd, sum_n2, sum_d2 = (
-            np.bincount(lex_binnumbers, weights=w, minlength=minlength) for w in [n, d, n * d, n * n, d * d]
+            np.bincount(lex_binnumbers, weights=w, minlength=minlength)
+            for w in [n, d, n * d, n * n, d * d]
         )
 
         sum_d += 1
         sum_d2 += 1**2
 
         summand = sum_n / sum_d
-        variance_summand = (sum_d**2 * sum_n2 - 2.0 * sum_n * sum_d * sum_nd + sum_n**2 * sum_d2) / sum_d**4
+        variance_summand = (
+            sum_d**2 * sum_n2 - 2.0 * sum_n * sum_d * sum_nd + sum_n**2 * sum_d2
+        ) / sum_d**4
 
         return summand, np.sqrt(variance_summand)
 
     def _check_y(self, y: np.ndarray):
         pass
 
-    def _init_global_scale(self, X: Union[pd.DataFrame, np.ndarray], y: np.ndarray) -> None:
+    def _init_global_scale(
+        self, X: Union[pd.DataFrame, np.ndarray], y: np.ndarray
+    ) -> None:
         if self.weights is None:
             raise RuntimeError("The weights have to be initialized.")
         self.global_scale_link_ = (y * self.weights).sum() / self.weights.sum()
@@ -102,7 +115,9 @@ class CBGBSRegressor(RegressorMixin, CyclicBoostingBase, IdentityLinkMixin):
         loss = (weights * (prediction - y) ** 2).sum() / wvisitsum
         return loss
 
-    def precalc_parameters(self, feature: Feature, y: np.ndarray, pred: CBLinkPredictionsFactors) -> None:
+    def precalc_parameters(
+        self, feature: Feature, y: np.ndarray, pred: CBLinkPredictionsFactors
+    ) -> None:
         return None
 
 

--- a/skpro/libs/cyclic_boosting/LICENSE
+++ b/skpro/libs/cyclic_boosting/LICENSE
@@ -1,0 +1,277 @@
+Eclipse Public License - v 2.0
+
+    THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+    PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+    OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+
+  a) in the case of the initial Contributor, the initial content
+     Distributed under this Agreement, and
+
+  b) in the case of each subsequent Contributor:
+     i) changes to the Program, and
+     ii) additions to the Program;
+  where such changes and/or additions to the Program originate from
+  and are Distributed by that particular Contributor. A Contribution
+  "originates" from a Contributor if it was added to the Program by
+  such Contributor itself or anyone acting on such Contributor's behalf.
+  Contributions do not include changes or additions to the Program that
+  are not Modified Works.
+
+"Contributor" means any person or entity that Distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which
+are necessarily infringed by the use or sale of its Contribution alone
+or when combined with the Program.
+
+"Program" means the Contributions Distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement
+or any Secondary License (as applicable), including Contributors.
+
+"Derivative Works" shall mean any work, whether in Source Code or other
+form, that is based on (or derived from) the Program and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship.
+
+"Modified Works" shall mean any work in Source Code or other form that
+results from an addition to, deletion from, or modification of the
+contents of the Program, including, for purposes of clarity any new file
+in Source Code form that contains any contents of the Program. Modified
+Works shall not include works that contain only declarations,
+interfaces, types, classes, structures, or files of the Program solely
+in each case in order to link to, bind by name, or subclass the Program
+or Modified Works thereof.
+
+"Distribute" means the acts of a) distributing or b) making available
+in any manner that enables the transfer of a copy.
+
+"Source Code" means the form of a Program preferred for making
+modifications, including but not limited to software source code,
+documentation source, and configuration files.
+
+"Secondary License" means either the GNU General Public License,
+Version 2.0, or any later versions of that license, including any
+exceptions or additional permissions as identified by the initial
+Contributor.
+
+2. GRANT OF RIGHTS
+
+  a) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free copyright
+  license to reproduce, prepare Derivative Works of, publicly display,
+  publicly perform, Distribute and sublicense the Contribution of such
+  Contributor, if any, and such Derivative Works.
+
+  b) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free patent
+  license under Licensed Patents to make, use, sell, offer to sell,
+  import and otherwise transfer the Contribution of such Contributor,
+  if any, in Source Code or other form. This patent license shall
+  apply to the combination of the Contribution and the Program if, at
+  the time the Contribution is added by the Contributor, such addition
+  of the Contribution causes such combination to be covered by the
+  Licensed Patents. The patent license shall not apply to any other
+  combinations which include the Contribution. No hardware per se is
+  licensed hereunder.
+
+  c) Recipient understands that although each Contributor grants the
+  licenses to its Contributions set forth herein, no assurances are
+  provided by any Contributor that the Program does not infringe the
+  patent or other intellectual property rights of any other entity.
+  Each Contributor disclaims any liability to Recipient for claims
+  brought by any other entity based on infringement of intellectual
+  property rights or otherwise. As a condition to exercising the
+  rights and licenses granted hereunder, each Recipient hereby
+  assumes sole responsibility to secure any other intellectual
+  property rights needed, if any. For example, if a third party
+  patent license is required to allow Recipient to Distribute the
+  Program, it is Recipient's responsibility to acquire that license
+  before distributing the Program.
+
+  d) Each Contributor represents that to its knowledge it has
+  sufficient copyright rights in its Contribution, if any, to grant
+  the copyright license set forth in this Agreement.
+
+  e) Notwithstanding the terms of any Secondary License, no
+  Contributor makes additional grants to any Recipient (other than
+  those set forth in this Agreement) as a result of such Recipient's
+  receipt of the Program under the terms of a Secondary License
+  (if permitted under the terms of Section 3).
+
+3. REQUIREMENTS
+
+3.1 If a Contributor Distributes the Program in any form, then:
+
+  a) the Program must also be made available as Source Code, in
+  accordance with section 3.2, and the Contributor must accompany
+  the Program with a statement that the Source Code for the Program
+  is available under this Agreement, and informs Recipients how to
+  obtain it in a reasonable manner on or through a medium customarily
+  used for software exchange; and
+
+  b) the Contributor may Distribute the Program under a license
+  different than this Agreement, provided that such license:
+     i) effectively disclaims on behalf of all other Contributors all
+     warranties and conditions, express and implied, including
+     warranties or conditions of title and non-infringement, and
+     implied warranties or conditions of merchantability and fitness
+     for a particular purpose;
+
+     ii) effectively excludes on behalf of all other Contributors all
+     liability for damages, including direct, indirect, special,
+     incidental and consequential damages, such as lost profits;
+
+     iii) does not attempt to limit or alter the recipients' rights
+     in the Source Code under section 3.2; and
+
+     iv) requires any subsequent distribution of the Program by any
+     party to be under a license that satisfies the requirements
+     of this section 3.
+
+3.2 When the Program is Distributed as Source Code:
+
+  a) it must be made available under this Agreement, or if the
+  Program (i) is combined with other material in a separate file or
+  files made available under a Secondary License, and (ii) the initial
+  Contributor attached to the Source Code the notice described in
+  Exhibit A of this Agreement, then the Program may be made available
+  under the terms of such Secondary Licenses, and
+
+  b) a copy of this Agreement must be included with each copy of
+  the Program.
+
+3.3 Contributors may not remove or alter any copyright, patent,
+trademark, attribution notices, disclaimers of warranty, or limitations
+of liability ("notices") contained within the Program from any copy of
+the Program which they Distribute, provided that Contributors may add
+their own appropriate notices.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities
+with respect to end users, business partners and the like. While this
+license is intended to facilitate the commercial use of the Program,
+the Contributor who includes the Program in a commercial product
+offering should do so in a manner which does not create potential
+liability for other Contributors. Therefore, if a Contributor includes
+the Program in a commercial product offering, such Contributor
+("Commercial Contributor") hereby agrees to defend and indemnify every
+other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits
+and other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such
+Commercial Contributor in connection with its distribution of the Program
+in a commercial product offering. The obligations in this section do not
+apply to any claims or Losses relating to any actual or alleged
+intellectual property infringement. In order to qualify, an Indemnified
+Contributor must: a) promptly notify the Commercial Contributor in
+writing of such claim, and b) allow the Commercial Contributor to control,
+and cooperate with the Commercial Contributor in, the defense and any
+related settlement negotiations. The Indemnified Contributor may
+participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial
+product offering, Product X. That Contributor is then a Commercial
+Contributor. If that Commercial Contributor then makes performance
+claims, or offers warranties related to Product X, those performance
+claims and warranties are such Commercial Contributor's responsibility
+alone. Under this section, the Commercial Contributor would have to
+defend claims against the other Contributors related to those performance
+claims and warranties, and if a court requires any other Contributor to
+pay any damages as a result, the Commercial Contributor must pay
+those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN "AS IS"
+BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF
+TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR
+PURPOSE. Each Recipient is solely responsible for determining the
+appropriateness of using and distributing the Program and assumes all
+risks associated with its exercise of rights under this Agreement,
+including but not limited to the risks and costs of program errors,
+compliance with applicable laws, damage to or loss of data, programs
+or equipment, and unavailability or interruption of operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS
+SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST
+PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of
+the remainder of the terms of this Agreement, and without further
+action by the parties hereto, such provision shall be reformed to the
+minimum extent necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that the
+Program itself (excluding combinations of the Program with other software
+or hardware) infringes such Recipient's patent(s), then such Recipient's
+rights granted under Section 2(b) shall terminate as of the date such
+litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it
+fails to comply with any of the material terms or conditions of this
+Agreement and does not cure such failure in a reasonable period of
+time after becoming aware of such noncompliance. If all Recipient's
+rights under this Agreement terminate, Recipient agrees to cease use
+and distribution of the Program as soon as reasonably practicable.
+However, Recipient's obligations under this Agreement and any licenses
+granted by Recipient relating to the Program shall continue and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement,
+but in order to avoid inconsistency the Agreement is copyrighted and
+may only be modified in the following manner. The Agreement Steward
+reserves the right to publish new versions (including revisions) of
+this Agreement from time to time. No one other than the Agreement
+Steward has the right to modify this Agreement. The Eclipse Foundation
+is the initial Agreement Steward. The Eclipse Foundation may assign the
+responsibility to serve as the Agreement Steward to a suitable separate
+entity. Each new version of the Agreement will be given a distinguishing
+version number. The Program (including Contributions) may always be
+Distributed subject to the version of the Agreement under which it was
+received. In addition, after a new version of the Agreement is published,
+Contributor may elect to Distribute the Program (including its
+Contributions) under the new version.
+
+Except as expressly stated in Sections 2(a) and 2(b) above, Recipient
+receives no rights or licenses to the intellectual property of any
+Contributor under this Agreement, whether expressly, by implication,
+estoppel or otherwise. All rights in the Program not expressly granted
+under this Agreement are reserved. Nothing in this Agreement is intended
+to be enforceable by any entity that is not a Contributor or Recipient.
+No third-party beneficiary rights are created under this Agreement.
+
+Exhibit A - Form of Secondary Licenses Notice
+
+"This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set forth
+in the Eclipse Public License, v. 2.0 are satisfied: {name license(s),
+version(s), and exceptions or additional permissions here}."
+
+  Simply including a copy of this Agreement, including this Exhibit A
+  is not sufficient to license the Source Code under Secondary Licenses.
+
+  If it is not possible or desirable to put the notice in a particular
+  file, then You may include the notice in a location (such as a LICENSE
+  file in a relevant directory) where a recipient would be likely to
+  look for such a notice.
+
+  You may add additional accurate notices of copyright ownership.

--- a/skpro/libs/cyclic_boosting/__init__.py
+++ b/skpro/libs/cyclic_boosting/__init__.py
@@ -1,0 +1,101 @@
+"""This package contains the Cyclic Boosting family of machine learning
+algorithms.
+
+If you are looking for conceptional explanations of the Cyclic Boosting
+algorithm, you might have a look at the two papers
+https://arxiv.org/abs/2002.03425 and https://arxiv.org/abs/2009.07052.
+
+API reference of the different Cyclic Boosting methods:
+
+Multiplicative Regression
+
+- :class:`~.CBPoissonRegressor`
+- :class:`~.CBNBinomRegressor`
+- :class:`~.CBExponential`
+- :class:`~.CBMultiplicativeQuantileRegressor`
+- :class:`~.CBMultiplicativeGenericCRegressor`
+
+Additive Regression
+
+- :class:`~.CBLocationRegressor`
+- :class:`~.CBLocPoissonRegressor`
+- :class:`~.CBAdditiveQuantileRegressor`
+- :class:`~.CBAdditiveGenericCRegressor`
+
+PDF Prediction
+
+- :class:`~.CBNBinomC`
+
+Classification
+
+- :class:`~.CBClassifier`
+- :class:`~.CBGenericClassifier`
+
+Background Subtraction
+
+- :class:`~.CBGBSRegressor`
+"""
+
+
+
+from skpro.libs.cyclic_boosting.base import CyclicBoostingBase
+from skpro.libs.cyclic_boosting.regression import CBNBinomRegressor, CBPoissonRegressor
+from skpro.libs.cyclic_boosting.price import CBExponential
+from skpro.libs.cyclic_boosting.location import CBLocationRegressor, CBLocPoissonRegressor
+from skpro.libs.cyclic_boosting.nbinom import CBNBinomC
+from skpro.libs.cyclic_boosting.classification import CBClassifier
+from skpro.libs.cyclic_boosting.GBSregression import CBGBSRegressor
+from skpro.libs.cyclic_boosting.generic_loss import (
+    CBMultiplicativeQuantileRegressor,
+    CBAdditiveQuantileRegressor,
+    CBMultiplicativeGenericRegressor,
+    CBAdditiveGenericRegressor,
+    CBGenericClassifier,
+)
+from skpro.libs.cyclic_boosting.pipelines import (
+    pipeline_CBPoissonRegressor,
+    pipeline_CBNBinomRegressor,
+    pipeline_CBClassifier,
+    pipeline_CBLocationRegressor,
+    pipeline_CBExponential,
+    pipeline_CBLocPoissonRegressor,
+    pipeline_CBNBinomC,
+    pipeline_CBGBSRegressor,
+    pipeline_CBMultiplicativeQuantileRegressor,
+    pipeline_CBAdditiveQuantileRegressor,
+    pipeline_CBMultiplicativeGenericRegressor,
+    pipeline_CBAdditiveGenericRegressor,
+    pipeline_CBGenericClassifier,
+)
+
+__all__ = [
+    "CyclicBoostingBase",
+    "CBPoissonRegressor",
+    "CBNBinomRegressor",
+    "CBExponential",
+    "CBLocationRegressor",
+    "CBLocPoissonRegressor",
+    "CBNBinomC",
+    "CBClassifier",
+    "CBGBSRegressor",
+    "CBMultiplicativeQuantileRegressor",
+    "CBAdditiveQuantileRegressor",
+    "CBMultiplicativeGenericRegressor",
+    "CBAdditiveGenericRegressor",
+    "CBGenericClassifier",
+    "pipeline_CBPoissonRegressor",
+    "pipeline_CBNBinomRegressor",
+    "pipeline_CBClassifier",
+    "pipeline_CBLocationRegressor",
+    "pipeline_CBExponential",
+    "pipeline_CBLocPoissonRegressor",
+    "pipeline_CBNBinomC",
+    "pipeline_CBGBSRegressor",
+    "pipeline_CBMultiplicativeQuantileRegressor",
+    "pipeline_CBAdditiveQuantileRegressor",
+    "pipeline_CBMultiplicativeGenericRegressor",
+    "pipeline_CBAdditiveGenericRegressor",
+    "pipeline_CBGenericClassifier",
+]
+
+__version__ = "1.4.0"

--- a/skpro/libs/cyclic_boosting/__init__.py
+++ b/skpro/libs/cyclic_boosting/__init__.py
@@ -37,36 +37,38 @@ Background Subtraction
 """
 
 
-
 from skpro.libs.cyclic_boosting.base import CyclicBoostingBase
-from skpro.libs.cyclic_boosting.regression import CBNBinomRegressor, CBPoissonRegressor
-from skpro.libs.cyclic_boosting.price import CBExponential
-from skpro.libs.cyclic_boosting.location import CBLocationRegressor, CBLocPoissonRegressor
-from skpro.libs.cyclic_boosting.nbinom import CBNBinomC
 from skpro.libs.cyclic_boosting.classification import CBClassifier
 from skpro.libs.cyclic_boosting.GBSregression import CBGBSRegressor
 from skpro.libs.cyclic_boosting.generic_loss import (
-    CBMultiplicativeQuantileRegressor,
-    CBAdditiveQuantileRegressor,
-    CBMultiplicativeGenericRegressor,
     CBAdditiveGenericRegressor,
+    CBAdditiveQuantileRegressor,
     CBGenericClassifier,
+    CBMultiplicativeGenericRegressor,
+    CBMultiplicativeQuantileRegressor,
 )
+from skpro.libs.cyclic_boosting.location import (
+    CBLocationRegressor,
+    CBLocPoissonRegressor,
+)
+from skpro.libs.cyclic_boosting.nbinom import CBNBinomC
 from skpro.libs.cyclic_boosting.pipelines import (
-    pipeline_CBPoissonRegressor,
-    pipeline_CBNBinomRegressor,
-    pipeline_CBClassifier,
-    pipeline_CBLocationRegressor,
-    pipeline_CBExponential,
-    pipeline_CBLocPoissonRegressor,
-    pipeline_CBNBinomC,
-    pipeline_CBGBSRegressor,
-    pipeline_CBMultiplicativeQuantileRegressor,
-    pipeline_CBAdditiveQuantileRegressor,
-    pipeline_CBMultiplicativeGenericRegressor,
     pipeline_CBAdditiveGenericRegressor,
+    pipeline_CBAdditiveQuantileRegressor,
+    pipeline_CBClassifier,
+    pipeline_CBExponential,
+    pipeline_CBGBSRegressor,
     pipeline_CBGenericClassifier,
+    pipeline_CBLocationRegressor,
+    pipeline_CBLocPoissonRegressor,
+    pipeline_CBMultiplicativeGenericRegressor,
+    pipeline_CBMultiplicativeQuantileRegressor,
+    pipeline_CBNBinomC,
+    pipeline_CBNBinomRegressor,
+    pipeline_CBPoissonRegressor,
 )
+from skpro.libs.cyclic_boosting.price import CBExponential
+from skpro.libs.cyclic_boosting.regression import CBNBinomRegressor, CBPoissonRegressor
 
 __all__ = [
     "CyclicBoostingBase",

--- a/skpro/libs/cyclic_boosting/__init__.py
+++ b/skpro/libs/cyclic_boosting/__init__.py
@@ -1,6 +1,11 @@
 """This package contains the Cyclic Boosting family of machine learning
 algorithms.
 
+Vendored from https://github.com/Blue-Yonder-OSS/cyclic-boosting
+(unmaintained upstream), with imports and internal references adapted to
+run inside ``skpro`` and to be compatible with current ``numpy``.
+See ``LICENSE`` in this directory for the upstream license (EPL-2.0).
+
 If you are looking for conceptional explanations of the Cyclic Boosting
 algorithm, you might have a look at the two papers
 https://arxiv.org/abs/2002.03425 and https://arxiv.org/abs/2009.07052.
@@ -35,7 +40,6 @@ Background Subtraction
 
 - :class:`~.CBGBSRegressor`
 """
-
 
 from skpro.libs.cyclic_boosting.base import CyclicBoostingBase
 from skpro.libs.cyclic_boosting.classification import CBClassifier

--- a/skpro/libs/cyclic_boosting/base.py
+++ b/skpro/libs/cyclic_boosting/base.py
@@ -1,0 +1,1388 @@
+
+import abc
+import logging
+import warnings
+
+import numexpr
+import numpy as np
+import pandas as pd
+from pandas.api.extensions import ExtensionArray
+import scipy.special
+
+from sklearn import base as sklearnb
+
+from skpro.libs.cyclic_boosting import common_smoothers, learning_rate, link
+from skpro.libs.cyclic_boosting.binning import get_feature_column_names_or_indices
+from skpro.libs.cyclic_boosting.common_smoothers import SmootherChoice
+from skpro.libs.cyclic_boosting.features import create_features, Feature, FeatureList, FeatureTypes, create_feature_id
+from skpro.libs.cyclic_boosting.link import IdentityLinkMixin, LogLinkMixin
+from skpro.libs.cyclic_boosting.utils import (
+    slice_finite_semi_positive,
+    nans,
+    get_X_column,
+    ConvergenceError,
+    ConvergenceParameters,
+)
+
+from skpro.libs.cyclic_boosting.utils import get_normalized_values
+
+from typing import Any, Dict, Optional, Union, Tuple, List, Set
+
+_logger = logging.getLogger(__name__)
+
+
+def get_influence_category(feature: Feature, influence_categories: dict) -> Union[None, str]:
+    influence_category = None
+    if influence_categories is not None:
+        influence_category = influence_categories.get(feature.feature_group, None)
+        if (
+            influence_category is None
+        ):  # this is due to the flaws in create features, i would propose to only allow tuple
+            if len(feature.feature_group) == 1:
+                fg = feature.feature_group[0]
+                influence_category = influence_categories.get(fg, None)
+        if influence_category is None:
+            raise KeyError(f"Please add {feature.feature_group} to influence_categories")
+    return influence_category
+
+
+class UpdateMixin(object):
+    def __init__(self, df: Optional[pd.DataFrame] = None, price_feature_seen: Optional[bool] = None):
+        self.df = df
+        self.price_feature_seen = price_feature_seen
+
+    def include_price_contrib(self, pred: np.ndarray) -> None:
+        self.df["exponents"] += pred
+        self.price_feature_seen = True
+
+    def include_factor_contrib(self, pred: np.ndarray, influence_category: Union[None, str]) -> None:
+        self.df["factors"] += pred
+        if influence_category is not None:
+            if influence_category in self.df.columns:
+                self.df[influence_category] += pred
+            else:
+                self.df[influence_category] = pred
+
+    def remove_price_contrib(self, pred) -> None:
+        self.df["exponents"] -= pred
+
+    def remove_factor_contrib(self, pred: np.ndarray, influence_category: Union[None, str]) -> None:
+        self.df["factors"] -= pred
+        if influence_category is not None:
+            if influence_category in self.df.columns:
+                self.df[influence_category] -= pred
+            else:
+                self.df[influence_category] = pred
+
+    def update_predictions(
+        self, pred: np.ndarray, feature: Feature, influence_categories: Optional[dict] = None
+    ) -> None:
+        if feature.feature_type == FeatureTypes.external:
+            self.include_price_contrib(pred)
+        else:
+            self.include_factor_contrib(pred, get_influence_category(feature, influence_categories))
+
+    def remove_predictions(
+        self, pred: np.ndarray, feature: Feature, influence_categories: Optional[dict] = None
+    ) -> None:
+        if feature.feature_type == FeatureTypes.external:
+            self.remove_price_contrib(pred)
+        else:
+            self.remove_factor_contrib(pred, get_influence_category(feature, influence_categories))
+
+
+class CBLinkPredictionsFactors(UpdateMixin):
+    """Support for prediction of type log(p) = factors"""
+
+    def __init__(self, predictions: np.ndarray):
+        super().__init__(df=pd.DataFrame({"factors": predictions}))
+
+    def predict_link(self) -> Union[ExtensionArray, np.ndarray]:
+        return self.factors()
+
+    def factors(self) -> Union[ExtensionArray, np.ndarray]:
+        return self.df["factors"].values
+
+
+class ZeroSmoother(sklearnb.BaseEstimator, sklearnb.RegressorMixin):
+    def fit(self, X_for_smoother: np.ndarray, y: np.ndarray) -> Union[sklearnb.BaseEstimator, sklearnb.RegressorMixin]:
+        return self
+
+    def predict(self, X: np.ndarray) -> np.ndarray:
+        return np.repeat(0.0, len(X))
+
+
+def _predict_factors(feature: Feature, X_for_smoother: np.ndarray, neutral_factor: float) -> np.ndarray:
+    isfinite_all = slice_finite_semi_positive(X_for_smoother)
+    prediction_smoother = nans(len(X_for_smoother))
+
+    if isfinite_all.any() and (feature.smoother is not None):
+        prediction_smoother[isfinite_all] = feature.learn_rate * feature.smoother.predict(X_for_smoother[isfinite_all])
+
+    prediction_smoother[~isfinite_all] = feature.factors_link[-1]
+    prediction_smoother[~np.isfinite(prediction_smoother)] = neutral_factor
+
+    return prediction_smoother
+
+
+def _factors_deviation(features: FeatureList) -> float:
+    """Calculate mean absolute deviation of all factors.
+
+    Parameters
+    ----------
+
+    features: :class:`~cyclic_boosting.base.FeatureList`
+        Collection of all features.
+    """
+    mean_factor_devs = [np.mean(np.abs(feature.factors_link - feature.factors_link_old)) for feature in features]
+    return np.mean(mean_factor_devs)
+
+
+
+class CyclicBoostingBase(
+    link.LinkFunction,
+    sklearnb.BaseEstimator,
+    metaclass=abc.ABCMeta,
+):
+    r"""The ``CyclicBoostingBase`` class implements the core skeleton for all
+    Cyclic Boosting algorithms. It learns parameters (e.g., factors) for each
+    feature-bin combination and applies smoothing algorithms (supplied by the
+    ``smoother`` argument) on the parameters.
+
+    By virtue of the ``feature_group`` parameter, each
+    :mod:`cyclic_boosting` estimator can consider one- or higher-dimensional
+    feature combinations.
+
+    The parameter estimates are iteratively optimized until one of the stop
+    criteria (``min_loss_change``, ``minimal_factor_change``,
+    ``maximal_iterations``) is reached.
+
+    Parameters
+    ----------
+
+    feature_groups: sequence of column labels
+        (:obj:`str` or :obj:`int`) or tuples of such labels or
+        :class:`cyclic_boosting.base.FeatureID`.
+        For each feature or feature tuple in the sequence, a
+        one- or multidimensional factor profile will be determined,
+        respectively, and used in the prediction.
+
+        If this argument is omitted, all columns except a possible
+        ``weight_column`` are considered as one-dimensional feature_groups.
+
+    hierarchical_feature_groups: sequence of column labels
+        (:obj:`str` or :obj:`int`) or tuples of such labels or
+        :class:`cyclic_boosting.base.FeatureID`.
+        In the first three iterations of the training, only the feature groups
+        defined here are used, i.e., all other feature groups are excluded.
+        From the fourth iteration onwards, all feature groups are used. The
+        idea of such hierarchical iterations is to support the modeling of
+        hierarchical or causal effects (e.g., mitigate confounding).
+
+        If this argument is not explicitly set, no such hierarchical iterations
+        are run.
+
+    feature_properties: :obj:`dict` of :obj:`int`
+        Dictionary listing the names of all features for the training as keys
+        and their pre-processing flags as values. When using a numpy feature
+        matrix X with no column names the keys of the feature properties are
+        the column indices.
+
+        By default, ``flags.HAS_MISSING`` is assumed.
+        If ``flags.MISSING_NOT_LEARNED`` is set for a feature group,
+        the neutral factor 1 is used for all non-finite values.
+
+    weight_column: string or int
+        Column name or index used to include a weight column presented in X.
+        If weight_column is ``None`` (default) equal weights for all samples
+        are used.
+
+    prior_prediction_column: string, int or None
+        Column name or index used to include prior predictions. Instead of
+        the target mean (``prior_prediction_column=None``), the predictions
+        found in the ``prior_prediction_column`` column are used as a base
+        model in :meth:`fit` and :meth:`predict`.
+
+    minimal_loss_change: float
+        Stop if the relative loss change of current
+        and previous prediction falls below this value.
+
+    minimal_factor_change: float
+        Stop if the mean of the factor change falls below this value. The
+        mean of the factor change is the mean of all absolute factor
+        differences between the current and the previous iteration for each
+        factor.
+
+    maximal_iterations: int
+        Maximal number of iteration.
+
+    observers : list
+        list of observer objects from the
+        :mod:`~cyclic_boosting.observers` module.
+
+    smoother_choice: subclass of :class:`cyclic_boosting.SmootherChoice`
+        Selects smoothers
+
+    output_column: string
+        In case of the usage as a transformer, this column is added and
+        filled with the predictions
+
+    learn_rate: Functor or None
+        Functor that defines the learning rate of each cyclic boosting iteration.
+        It has to satisfy the interface of type :func:`learning_rate.constant_learn_rate_one`.
+        If None is specified, which is the default, the learning rate is always 1.
+
+    aggregate: boolean or None
+        Description is required
+
+    Notes
+    -----
+
+    **Preconditions**
+
+    * Non-negative integer values starting at 0 **without gaps** are expected
+      in each feature column.
+    * The number of unique values in each feature column ``n_unique_feature``
+      should be much smaller than the number of samples ``n``.
+
+    Features transformed by
+    :class:`cyclic_boosting.binning.BinNumberTransformer` satisfy these
+    preconditions.
+
+    * The target ``y`` has to be positive semi-definite.
+
+    Attributes
+    ----------
+
+    global_scale_link_ : float
+       The global scale of the target ``y`` in the linked space.
+
+    stop_criteria_ : tuple
+        tuple of three stop criteria are satisfied:
+        ``(stop_iterations, stop_factor_change, stop_loss_change)``
+    """
+    supports_pandas = True
+    inc_fitting = False
+    no_deepcopy = {"feature_properties"}
+
+    def __init__(
+        self,
+        feature_groups=None,
+        hierarchical_feature_groups=None,
+        training_iterations_hierarchical_features=3,
+        feature_properties: Optional[Dict[int, int]] = None,
+        weight_column: Optional[Union[str, int, None]] = None,
+        prior_prediction_column: Optional[Union[str, int, None]] = None,
+        minimal_loss_change: Optional[float] = 1e-6,
+        minimal_factor_change: Optional[float] = 1e-4,
+        maximal_iterations: Optional[int] = 10,
+        observers: Optional[list] = None,
+        smoother_choice: Optional[SmootherChoice] = None,
+        output_column: Optional[str] = None,
+        learn_rate: Optional[float] = None,
+        aggregate: Optional[bool] = True,
+    ):
+        if smoother_choice is None:
+            self.smoother_choice = common_smoothers.SmootherChoiceWeightedMean()
+        else:
+            self.smoother_choice = smoother_choice
+            if not isinstance(smoother_choice, common_smoothers.SmootherChoice):
+                raise ValueError("smoother_choice needs to be of type SmootherChoice")
+
+        self.feature_groups = feature_groups
+        self.hierarchical_feature_groups = hierarchical_feature_groups
+        self.feature_properties = feature_properties
+
+        self.features = None
+        self.hierarchical_features = []
+        if self.hierarchical_feature_groups is not None:
+            for fg in self.hierarchical_feature_groups:
+                hierarchical_feature = create_feature_id(fg)
+                self.hierarchical_features.append(hierarchical_feature.feature_group)
+        self.training_iterations_hierarchical_features = training_iterations_hierarchical_features
+        self.feature_importances = {}
+        self.aggregate = aggregate
+
+        self.weight_column = weight_column
+        self.weights = None
+        self.prior_prediction_column = prior_prediction_column
+        self.prior_pred_link_offset_ = 0
+        self.global_scale_link_ = None
+
+        self._check_parameters()
+        self.minimal_loss_change = minimal_loss_change
+        self.minimal_factor_change = minimal_factor_change
+        self.maximal_iterations = maximal_iterations
+        self.observers = observers
+        if self.observers is None:
+            self.observers = []
+
+        self.iteration_ = None
+        self.insample_loss_ = None
+        self.stop_criteria_ = None
+        self.neutral_factor_link = 0.0
+        self.output_column = output_column
+        if learn_rate is None:
+            self.learn_rate = learning_rate.half_linear_learn_rate
+        else:
+            self.learn_rate = learn_rate
+        if hierarchical_feature_groups is not None:
+            self.learn_rate = learning_rate.constant_learn_rate_one
+        self._init_features()
+
+    def loss(self, prediction: np.ndarray, y: np.ndarray, weights: np.ndarray) -> np.ndarray:
+        if not len(y) > 0:
+            raise ValueError("Loss cannot be computed on empty data")
+        else:
+            sum_weighted_error = numexpr.evaluate("sum((prediction - y) * (prediction - y) * weights)")
+            sum_weights = numexpr.evaluate("sum(weights)")
+            return sum_weighted_error / sum_weights
+
+    @property
+    def global_scale_(self) -> np.ndarray:
+        """
+        Obtain the global scale in the space of the original target ``y``.
+        """
+        return self.unlink_func(self.global_scale_link_)
+
+    def learning_rate(self, feature: Feature) -> float:
+        lr = self.learn_rate(self.iteration_ + 1, self.maximal_iterations, feature)
+        return lr
+
+    def _init_weight_column(self, X: Union[pd.DataFrame, np.ndarray]) -> None:
+        """Sets the ``weights``.
+
+        If a ``weight_column`` is given, it is retrieved
+        from ``X``, else all weights are set to one.
+
+        Parameters
+        ----------
+
+        X: np.ndarray
+            samples features matrix
+        """
+        if self.weight_column is None:
+            self.weights = np.ones(len(X))
+        else:
+            self.weights = get_X_column(X, self.weight_column)
+
+    def _init_external_column(self, X: Union[pd.DataFrame, np.ndarray], is_fit: bool) -> None:
+        """Init the external column.
+
+        Parameters
+        ----------
+
+        X: np.ndarray
+            samples features matrix
+        is_fit: bool
+           are we called in fit() ?
+        """
+
+    def _init_default_feature_groups(self, X: Union[pd.DataFrame, np.ndarray]) -> None:
+        """
+        Initializes the ``feature_groups`` to be a list of all
+        columns available in ``X`` except the ``prior_prediction_column`` and
+        the ``weight_column``.
+        """
+        exclude_columns = []
+        if self.prior_prediction_column is not None:
+            exclude_columns.append(self.prior_prediction_column)
+        if self.weight_column is not None:
+            exclude_columns.append(self.weight_column)
+
+        self.feature_groups = get_feature_column_names_or_indices(X, exclude_columns=exclude_columns)
+
+    def _init_global_scale(self, X: Union[pd.DataFrame, np.ndarray], y: np.ndarray) -> None:
+        """
+        Initializes the ``global_scale_link_`` and the
+        ``prior_pred_link_offset_``. The ``global_scale_link_`` is set to the
+        weighted mean of the target ``y`` transformed into the link space.
+        The ``prior_pred_link_offset_`` is the difference between the
+        ``global_scale_link_`` and the weighted mean of the prior prediction
+        transformed to the link space.
+        """
+        if self.weights is None:
+            raise RuntimeError("The weights have to be initialized.")
+
+        minimal_prediction = 0.001
+        self.global_scale_link_ = self.link_func(np.sum(y * self.weights) / np.sum(self.weights) + minimal_prediction)
+
+        if self.prior_prediction_column is not None:
+            prior_pred = get_X_column(X, self.prior_prediction_column)
+            finite = np.isfinite(prior_pred)
+
+            if not np.all(finite):
+                _logger.warning(
+                    "Found a total number of {} non-finite values in the prior prediction column".format(
+                        np.sum(~finite)
+                    )
+                )
+
+            prior_pred_mean = np.sum(prior_pred[finite] * self.weights[finite]) / np.sum(self.weights[finite])
+
+            prior_pred_link_mean = self.link_func(prior_pred_mean)
+
+            if np.isfinite(prior_pred_link_mean):
+                self.prior_pred_link_offset_ = self.global_scale_link_ - prior_pred_link_mean
+            else:
+                warnings.warn(
+                    "The mean prior prediction in link-space is not finite. "
+                    "Therefore no individualization is done "
+                    "and no prior mean subtraction is necessary."
+                )
+                self.prior_pred_link_offset_ = float(self.global_scale_link_)
+
+    def _check_weights(self) -> None:
+        if self.weights is None:
+            raise RuntimeError("The weights have to be initialized.")
+
+    def _init_features(self) -> None:
+        """
+        Initializes the ``features`` and binds the data belonging to a feature
+        to it.
+        """
+        self.features = create_features(self.feature_groups, self.feature_properties, self.smoother_choice)
+
+    def _get_prior_predictions(self, X: Union[pd.DataFrame, np.ndarray]) -> np.ndarray:
+        if self.prior_prediction_column is None:
+            prior_prediction_link = np.repeat(self.global_scale_link_, X.shape[0])
+        else:
+            prior_pred = get_X_column(X, self.prior_prediction_column)
+            prior_prediction_link = self.link_func(prior_pred) + self.prior_pred_link_offset_
+            finite = np.isfinite(prior_prediction_link)
+            prior_prediction_link[~finite] = self.global_scale_link_
+
+        return prior_prediction_link
+
+    def _feature_contribution(self, feature: Feature, contribution: np.ndarray) -> np.ndarray:
+        """The contribution of a feature group to the full model in link space.
+
+        The link spaces have been chosen such that contributions in link space
+        are always additive.
+
+        Parameters
+        ----------
+
+        feature: :class:`Feature`
+            feature providing the contribution
+
+        contribution: ndarray
+            the smoothed values in link space for input samples and the given
+            feature group
+
+        Returns
+        -------
+
+        ndarray
+            the contribution to the full model in link space;
+        """
+        return contribution
+
+    def is_diverged(self, loss) -> bool:
+        return loss > self.initial_loss_ * 2
+
+    def _check_convergence(self) -> None:
+        msg = (
+            "Your cyclic boosting training seems to be "
+            "diverging. In the {0}. iteration the "
+            "current loss: {1}, is greater "
+            "than the trivial loss with just mean "
+            "predictions: {2}.".format(self.iteration_ + 1, self.insample_loss_, self.initial_loss_)
+        )
+
+        if self.is_diverged(self.insample_loss_):
+            self.is_diverging = True
+            self.diverging += 1
+            warnings.warn(msg)
+            if self.diverging >= 5:
+                raise ConvergenceError(msg)
+        else:
+            self.is_diverging = False
+
+    def _update_loss(self, prediction: np.ndarray, y: np.ndarray) -> float:
+        insample_loss_old = self.insample_loss_
+
+        self.insample_loss_ = self.loss(prediction, y, self.weights)
+
+        self.insample_msd_ = self.insample_loss_
+
+        loss_change = insample_loss_old - self.insample_loss_
+        self._check_convergence()
+
+        if insample_loss_old != 0:
+            loss_change /= insample_loss_old
+
+        return loss_change
+
+    def _log_iteration_info(self, convergence_parameters: ConvergenceParameters) -> None:
+        if self.iteration_ == 0:
+            _logger.info("Factor model iteration 1")
+        else:
+            _logger.info(
+                "Factor model iteration: {iteration}, "
+                "factors_deviation = {deviation}, "
+                "loss_change = {loss_change}".format(
+                    iteration=self.iteration_ + 1,
+                    loss_change=convergence_parameters.loss_change,
+                    deviation=convergence_parameters.delta,
+                )
+            )
+
+    def _call_observe_feature_iterations(
+        self, iteration: int, i: int, X: np.ndarray, y: np.ndarray, prediction: np.ndarray
+    ) -> None:
+        for observer in self.observers:
+            observer.observe_feature_iterations(iteration, i, X, y, prediction, self.weights, self.get_state())
+
+    def _call_observe_iterations(self, iteration, X, y, prediction, delta) -> None:
+        for observer in self.observers:
+            observer.observe_iterations(iteration, X, y, prediction, self.weights, self.get_state(), delta)
+
+    def get_state(self) -> Dict[str, Any]:
+        est_state = {
+            "link_function": self,
+            "features": self.features,
+            "globale_scale": self.global_scale_,
+            "insample_loss": self.insample_loss_,
+        }
+        if (
+            self.hierarchical_feature_groups is not None
+            and self.iteration_ < self.training_iterations_hierarchical_features
+        ):
+            est_state["features"] = [
+                feature for feature in self.features if feature.feature_group in self.hierarchical_features
+            ]
+        return est_state
+
+    def remove_preds(self, pred: CBLinkPredictionsFactors, X: np.ndarray) -> None:
+        for feature in self.features:
+            if feature.feature_type is None:
+                weights = self.weights
+            else:
+                weights = self.weights_external
+
+            feature.bind_data(X, weights)
+            feature_predictions = self._pred_feature(X, feature, True)
+
+            pred.remove_predictions(feature_predictions, feature)
+
+            feature.fitted_aggregated -= feature.factors_link
+            feature.unbind_data()
+
+    def _set_factors_per_feature(self, feature: Feature) -> Tuple[float, int]:
+        if feature.feature_type is not None:
+            if len(feature.feature_group) == 1:
+                min_f = 0.05
+                max_f = 20
+            else:
+                min_f = 0.1
+                max_f = 5
+        else:
+            if len(feature.feature_group) == 1:
+                min_f = 0.01
+                max_f = 1000
+            else:
+                min_f = 0.1
+                max_f = 100
+        return min_f, max_f
+
+    def visit_factors(
+        self, feature: Feature, unfitted_factors, X: np.ndarray, y: np.ndarray, pred: CBLinkPredictionsFactors
+    ) -> None:
+        clip = isinstance(self, LogLinkMixin)
+
+        if clip and self.aggregate:
+            # Maximal/Minimal updates
+            feature.factors_link = np.clip(feature.factors_link, np.log(0.5), np.log(2), out=feature.factors_link)
+
+            # Absolute size of factors/exponents per feature
+            if feature.is_fitted:
+                min_f, max_f = self._set_factors_per_feature(feature=feature)
+
+                feature.factors_link = np.clip(
+                    feature.factors_link,
+                    np.log(min_f) - feature.fitted_aggregated,
+                    np.log(max_f) - feature.fitted_aggregated,
+                    out=feature.factors_link,
+                )
+
+            if self.is_diverging:
+
+                def check_diverged() -> bool:
+                    feature_predictions = self._pred_feature(X, feature, True)
+                    pred.update_predictions(feature_predictions, feature)
+
+                    prediction = self.unlink_func(pred.predict_link())
+
+                    loss = self.loss(prediction, y, self.weights)
+                    pred.remove_predictions(feature_predictions, feature)
+
+                    return self.is_diverged(loss)
+
+                if self.diverging > 1:
+                    if check_diverged():
+                        msg = "Feature factors for {} will be ignored due to diverging loss".format(
+                            feature.feature_group
+                        )
+                        warnings.warn(msg)
+                        feature.factors_link = -feature.fitted_aggregated
+                        feature.smoother = ZeroSmoother()
+                elif check_diverged():
+                    msg = "Feature factors for {} will be clipped due to diverging loss".format(feature.feature_group)
+                    warnings.warn(msg)
+                    np.clip(
+                        feature.factors_link,
+                        unfitted_factors + np.log(0.8),
+                        unfitted_factors + np.log(1.2),
+                        out=feature.factors_link,
+                    )
+
+        if feature.is_fitted:
+            if self.aggregate:
+                feature.fitted_aggregated += feature.factors_link
+            else:
+                feature.fitted_aggregated = feature.factors_link.copy()
+        else:
+            feature.fitted_aggregated = feature.factors_link.copy()
+            feature.is_fitted = True
+
+    def feature_iteration(
+        self, X: np.ndarray, y: np.ndarray, feature: Feature, pred: CBLinkPredictionsFactors, prefit_data
+    ):
+        if not self.aggregate:
+            feature_predictions = self._pred_feature(X, feature, True)
+            pred.remove_predictions(feature_predictions, feature)
+
+        factors_link, uncertainties_link = self.calc_parameters(feature, y, pred, prefit_data=prefit_data)
+
+        X_for_smoother = feature.update_factors(
+            factors_link.copy(),
+            uncertainties_link,
+            self.neutral_factor_link,
+            self.learning_rate(feature),
+        )
+
+        feature.factors_link = _predict_factors(
+            feature=feature, X_for_smoother=X_for_smoother[:, : feature.dim], neutral_factor=self.neutral_factor_link
+        )
+
+        feature.factors_link = self.calibrate_to_weighted_mean(feature)
+
+        self.visit_factors(feature, factors_link, X, y, pred)
+        feature_predictions = self._pred_feature(X, feature, is_fit=True)
+        pred.update_predictions(feature_predictions, feature)
+
+        return pred
+
+    def cb_features(
+        self, X: np.ndarray, y: np.ndarray, pred: CBLinkPredictionsFactors, prefit_data
+    ) -> Tuple[int, Any, Any]:
+        for i, feature in enumerate(self.features):
+            if feature.feature_type is None:
+                weights = self.weights
+            else:
+                weights = self.weights_external
+            if self.iteration_ == 0:
+                feature.bind_data(X, weights)
+                feature.factors_link = np.ones(feature.n_bins) * self.neutral_factor_link
+                if prefit_data is not None:
+                    prefit_data[i] = self.precalc_parameters(feature, y, pred)
+            else:
+                feature.bind_data(X, weights)
+            yield i, feature, prefit_data[i]
+
+    def fit(
+        self, X: Union[pd.DataFrame, np.ndarray], y: Optional[np.ndarray] = None
+    ) -> Union[link.LinkFunction, sklearnb.BaseEstimator]:
+        _ = self._fit_predict(X, y)
+        return self
+
+    def _init_fit(self, X: pd.DataFrame, y: np.ndarray) -> None:
+        self._check_len_data(X, y)
+        self._check_y(y)
+        self._init_weight_column(X)
+        self._init_external_column(X, True)
+
+        if self.feature_groups is None:
+            self._init_default_feature_groups(X)
+
+        self._check_weights()
+        self._init_features()
+        self._init_global_scale(X, y)
+
+    def _fit_main(self, X: np.ndarray, y: np.ndarray, pred: CBLinkPredictionsFactors) -> np.ndarray:
+        self.diverging = 0
+        self.is_diverging = False
+
+        _logger.info("Cyclic Boosting global scale {}".format(self.global_scale_))
+
+        prediction = self.unlink_func(pred.predict_link())
+
+        self.insample_loss_ = self.loss(prediction, y, self.weights)
+        self.initial_loss_ = self.insample_loss_
+        self.initial_msd_ = self.insample_loss_
+        self.iteration_ = 0
+        prefit_data = [None for _ in self.features]
+
+        convergence_parameters = ConvergenceParameters()
+
+        while (not self._check_stop_criteria(self.iteration_, convergence_parameters)) or self.is_diverging:
+            self._call_observe_iterations(self.iteration_, X, y, prediction, convergence_parameters.delta)
+
+            self._log_iteration_info(convergence_parameters)
+            for i, feature, pf_data in self.cb_features(X, y, pred, prefit_data):
+                if (
+                    self.hierarchical_feature_groups is not None
+                    and self.iteration_ < self.training_iterations_hierarchical_features
+                    and feature.feature_group not in self.hierarchical_features
+                ):
+                    feature.factors_link_old = feature.factors_link.copy()
+                    continue
+                pred = self.feature_iteration(X, y, feature, pred, pf_data)
+                self._call_observe_feature_iterations(self.iteration_, i, X, y, prediction)
+
+                if feature.factor_sum is None:
+                    feature.factor_sum = [np.sum(np.abs(feature.fitted_aggregated))]
+                else:
+                    feature.factor_sum.append(np.sum(np.abs(feature.fitted_aggregated)))
+
+            prediction = self.unlink_func(pred.predict_link())
+
+            updated_loss_change = self._update_loss(prediction, y)
+            convergence_parameters.set_loss_change(updated_loss_change=updated_loss_change)
+
+            updated_delta = _factors_deviation(self.features)
+            convergence_parameters.set_delta(updated_delta=updated_delta)
+
+            if self.is_diverging:
+                self.remove_preds(pred, X)
+
+            self.iteration_ += 1
+
+        # compute feature importances
+        self.set_feature_importances()
+
+        if len(self.observers) > 0:
+            self.prepare_plots(X, y, prediction)
+
+        self._call_observe_iterations(-1, X, y, prediction, convergence_parameters.delta)
+        self._check_convergence()
+
+        _logger.info("Cyclic Boosting, final global scale {}".format(self.global_scale_))
+
+        for feature in self.features:
+            feature.clear_feature_reference(observers=self.observers)
+
+        return prediction
+
+    def prepare_plots(self, X: np.ndarray, y: np.ndarray, prediction: np.ndarray) -> None:
+        for feature in self.features:
+            if feature.feature_type is None:
+                weights = self.weights
+            else:
+                weights = self.weights_external
+
+            feature.bind_data(X, weights)
+
+            sum_w, sum_yw, sum_pw = (
+                np.bincount(feature.lex_binned_data, weights=w, minlength=feature.n_bins)
+                for w in [weights, weights * y, weights * prediction]
+            )
+
+            mean_target_binned = (sum_yw + 1) / (sum_w + 1)
+
+            if feature.n_bins > 1:
+                mean_y_finite = np.sum(sum_yw[:-1]) / np.sum(sum_w[:-1])
+                mean_prediction_finite = np.sum(sum_pw[:-1]) / np.sum(sum_w[:-1])
+            else:
+                mean_y_finite = np.mean(y)
+                mean_prediction_finite = np.mean(prediction)
+
+            mean_prediction_binned = (sum_pw + 1) / (sum_w + 1)
+
+            if isinstance(self, IdentityLinkMixin):
+                feature.mean_dev = mean_prediction_binned - mean_target_binned
+                feature.y = mean_target_binned - mean_y_finite
+                feature.prediction = mean_prediction_binned - mean_prediction_finite
+            else:
+                feature.mean_dev = np.log(mean_prediction_binned + 1e-12) - np.log(mean_target_binned + 1e-12)
+                feature.y = np.log(mean_target_binned / mean_y_finite + 1e-12)
+                feature.prediction = np.log(mean_prediction_binned / mean_prediction_finite + 1e-12)
+
+            feature.y_finite = mean_y_finite
+            feature.prediction_finite = mean_prediction_finite
+
+            feature.learn_rate = 1.0
+
+    def _fit_predict(self, X: Union[pd.DataFrame, np.ndarray], y: Optional[np.ndarray] = None) -> np.ndarray:
+        """Fit the estimator to the training samples.
+
+        Iterate to calculate the factors and the global scale.
+        """
+        y = np.asarray(y)
+        self._init_fit(X, y)
+        pred = CBLinkPredictionsFactors(self._get_prior_predictions(X))
+        prediction = self._fit_main(X, y, pred)
+
+        del self.weights
+
+        return prediction
+
+    def _pred_feature(self, X: Union[pd.DataFrame, np.ndarray], feature: Feature, is_fit: bool):
+        if is_fit:
+            return feature.factors_link[feature.lex_binned_data]
+        else:
+            X_for_predict = get_X_column(X, feature.feature_group, array_for_1_dim=False)
+            pred = _predict_factors(feature, X_for_predict, self.neutral_factor_link)
+            return pred
+
+    def predict(self, X: Union[pd.DataFrame, np.ndarray], y: Optional[np.ndarray] = None) -> np.ndarray:
+        pred = self.predict_extended(X, None)
+        return self.unlink_func(pred.predict_link())
+
+    def predict_extended(
+        self, X: Union[pd.DataFrame, np.ndarray], influence_categories: Optional[dict] = None
+    ) -> CBLinkPredictionsFactors:
+        self._check_fitted()
+        self._init_external_column(X, False)
+
+        prediction_link = self._get_prior_predictions(X)
+        pred = CBLinkPredictionsFactors(prediction_link)
+
+        for feature in self.features:
+            feature_predictions = self._pred_feature(X, feature, is_fit=False)
+            pred.update_predictions(feature_predictions, feature, influence_categories)
+
+        return pred
+
+    def fit_transform(self, X: pd.DataFrame, y: Optional[np.ndarray] = None) -> pd.DataFrame:
+        if not self.output_column:
+            raise KeyError("output_column not defined")
+        try:
+            if self.output_column in X.columns:
+                raise KeyError("""output_column "{}" exists already""".format(self.output_column))
+        except AttributeError:
+            raise TypeError("data needs to be a dataframe for the usage as a fit_transformer")
+        X[self.output_column] = self._fit_predict(X, y)
+        return X
+
+    def transform(self, X: pd.DataFrame, y: Optional[np.ndarray] = None) -> pd.DataFrame:
+        if not self.output_column:
+            raise KeyError("output_column not defined")
+        try:
+            if self.output_column in X.columns:
+                raise KeyError("""output_column "{}" exists already""".format(self.output_column))
+        except AttributeError:
+            raise TypeError("data needs to be a dataframe for the usage as a transformer")
+        X[self.output_column] = self.predict(X=X, y=y)
+        return X
+
+    def _check_stop_criteria(self, iterations: int, convergence_parameters: ConvergenceParameters) -> bool:
+        """
+        Checks the stop criteria and returns True if at least one is satisfied.
+
+        You can check the stop criteria in the estimated parameter
+        `stop_criteria_`.
+
+        :rtype: bool
+        """
+        stop_iterations = False
+        stop_factor_change = False
+        stop_loss_change = False
+        veto_hierarchical = False
+
+        delta = convergence_parameters.delta
+        loss_change = convergence_parameters.loss_change
+
+        if iterations >= self.maximal_iterations:
+            _logger.info(
+                "Cyclic Boosting stopped because the number of "
+                "iterations reached the maximum of {}.".format(self.maximal_iterations)
+            )
+            stop_iterations = True
+
+        if delta <= self.minimal_factor_change:
+            _logger.info(
+                "Cyclic Boosting stopped because the change of "
+                "the factors {0} was lower than the "
+                "required minimum {1}.".format(delta, self.minimal_factor_change)
+            )
+            stop_factor_change = True
+
+        if abs(loss_change) <= self.minimal_loss_change:
+            _logger.info(
+                "Cyclic Boosting stopped because the change of "
+                "the loss {0} was lower "
+                "than the required minimum {1}.".format(loss_change, self.minimal_loss_change)
+            )
+            stop_loss_change = True
+
+        if loss_change < 0:
+            _logger.warning(
+                "Encountered negative change of loss. "
+                "This might not be a problem, as long as the "
+                "model converges. Check the LOSS changes in the "
+                "analysis plots."
+            )
+
+        if (
+            iterations <= self.training_iterations_hierarchical_features
+            and self.hierarchical_feature_groups is not None
+        ):
+            veto_hierarchical = True
+
+        self.stop_criteria_ = (stop_iterations, stop_factor_change, stop_loss_change)
+        return (stop_iterations or stop_factor_change or stop_loss_change) and not veto_hierarchical
+
+    def _check_parameters(self) -> None:
+        if self.feature_groups is not None and len(self.feature_groups) == 0:
+            raise ValueError("Please add some elements to `feature_groups`")
+
+    def _check_fitted(self) -> None:
+        """Check if fit was called"""
+        if self.features is None:
+            raise ValueError("fit must be called first.")
+
+    def _check_len_data(self, X: Union[pd.DataFrame, np.ndarray], y: np.ndarray) -> None:
+        """Check that input arrays are not empty"""
+        if len(X) == 0 | len(y) == 0:
+            raise ValueError("Estimator should be applied on non-empty data")
+
+    def _check_y(self, y: np.ndarray) -> None:
+        """Check that y has the correct values. Has to be
+        implemented by the child class.
+        """
+        raise NotImplementedError(
+            "You have to implement the function _check_y" " to ensure your target has correct values."
+        )
+
+    def get_subestimators_as_items(self, prototypes=True) -> List[Tuple]:
+        """
+        For prototypes=False, the clones are indexed by the column name
+        or index.
+        """
+        if prototypes:
+            return []
+        else:
+            self._check_fitted()
+            return [(feature.feature_id, feature.smoother) for feature in self.features]
+
+    def set_feature_importances(self) -> None:
+        for feature in self.features:
+            feature.prepare_feature()
+            feature.set_feature_bin_deviations_from_neutral(self.neutral_factor_link)
+            self.feature_importances[feature] = feature.bin_weighted_average
+
+    def get_feature_importances(self) -> Dict[str, float]:
+        """
+        Returns the relative importance of each input feature.
+        """
+        if not self.feature_importances:
+            raise ValueError("_fit_main has to be called first to compute the feature importance.")
+        else:
+            normalized_values = get_normalized_values(self.feature_importances.values())
+            norm_feature_importances = {
+                "_".join(feature.feature_id.feature_group): normalized_values[i]
+                for i, feature in enumerate(self.feature_importances.keys())
+            }
+            return norm_feature_importances
+
+    def get_feature_contributions(self, X: Union[pd.DataFrame, np.ndarray]) -> Dict[str, np.ndarray]:
+        """Returns the contributions of each feature for each individual
+        prediction on a given data set, offering individual explainability of
+        the model. That means the learned parameter, e.g., factor for
+        multiplicative modes, of the corresponding feature bin is accessed.
+        These contributions should be interpreted in respect to the neutral
+        element of the mode, i.e., 1 for multiplicative and 0 for additive
+        modes.
+
+        Parameters
+        ----------
+        X: np.ndarray
+            data set to be predicted, needs to include the features of the
+            model
+
+        Returns
+        -------
+        dict
+            contributions from each feature for each sample of X
+        """
+        contribution = {}
+        for feature in self.features:
+            ft = "" if feature.feature_type is None else "_{}".format(feature.feature_type)
+            fg = " ".join(feature.feature_group)
+            contribution[fg + ft] = self.unlink_func(self._pred_feature(X, feature, is_fit=False))
+        return contribution
+
+    @abc.abstractmethod
+    def calc_parameters(self, feature: Feature, y: np.ndarray, pred: CBLinkPredictionsFactors, prefit_data):
+        """Calculates factors and uncertainties of the bins of a feature group
+        in the original space (not the link space) and transforms them to the
+        link space afterwards
+
+        The factors and uncertainties cannot be determined in link space, not
+        least because target values like 0 diverge in link spaces like `log`
+        or `logit`.
+
+        The main loop will call the smoothers on the results returned by this
+        method. Smoothing is always done in link space.
+
+        This function must be implemented by the subclass according to its
+        statistical model.
+
+        Parameters
+        ----------
+        feature: :class:`~.Feature`
+            class containing all features
+        y: np.ndarray
+            target, truth
+        pred
+            (in-sample) predictions from all other features (excluding the one
+            at hand)
+        prefit_data
+            data returned by :meth:`~.precalc_parameters` during fit
+
+        Returns
+        -------
+        tuple
+            This method must return a tuple of ``factors`` and
+            ``uncertainties`` in the **link space**.
+        """
+        raise NotImplementedError("implement in subclass")
+
+    @abc.abstractmethod
+    def precalc_parameters(self, feature: Feature, y: np.ndarray, pred: CBLinkPredictionsFactors):
+        """Calculations that are not  dependent on intermediate predictions. If
+        these are not needed, return :obj:`None` in the subclass.
+
+        Results returned by this method will be served to
+        :meth:`factors_and_uncertainties` as the ``prefit_data`` argument.
+
+        Parameters
+        ----------
+        feature: :class:`~.Feature`
+            class containing all features
+        y: np.ndarray
+            target, truth
+        pred
+            (in-sample) predictions from all other features (excluding the one
+            at hand)
+        """
+        return None
+
+    def required_columns(self) -> Set:
+        required_columns = set()
+
+        if self.weight_column is not None:
+            required_columns.add(self.weight_column)
+
+        if self.prior_prediction_column is not None:
+            required_columns.add(self.prior_prediction_column)
+
+        for feature_id in self.features:
+            for col in feature_id.feature_group:
+                required_columns.add(col)
+
+        return required_columns
+
+    def calibrate_to_weighted_mean(self, feature: Feature) -> np.ndarray:
+        return feature.factors_link
+
+
+def _coefficient_for_gaussian_matching_by_quantiles(perc: float) -> float:
+    """The coefficient in the linear system of equations for the Gaussian
+    matching by quantiles
+
+    For details, see :func:`gaussian_matching_by_quantiles`.
+    """
+    return np.sqrt(2) * scipy.special.erfinv(2 * perc - 1)
+
+
+def gaussian_matching_by_quantiles(
+    dist, link_func, perc1: Union[float, np.ndarray], perc2: Union[float, np.ndarray]
+) -> Tuple[float, float]:
+    r"""Gaussian matching of the distribution transformed by the link function
+    by demanding the equality of two quantiles in link space
+
+    Since each quantile of a distribution is transformed just by the link
+    function itself (by contrast to the mean or variance of the distribution),
+    the Gaussian matching is quite easy and general::
+
+        link_func(dist.ppf(perc<i>)) = gaussian_quantile<i>
+
+    The connection between a Gaussian quantile and the distribution parameters
+    is:
+
+    .. math::
+        \text{gaussian\_quantile}_i = \mu + \sigma \sqrt{2} \text{erf}^{-1}(
+        2 \cdot \text{perc}_i - 1)
+
+    Applied to both ``perc<i>``, this leads to a system of two linear equations
+    that can be solved for ``mu`` and ``sigma``.
+
+    Parameters
+    ----------
+
+    dist: scipy.stats distribution object
+        the assumed distribution in the original space, e.g. a
+        ``scipy.stats.beta`` in the case of
+        :class:`~cyclic_boosting.CBClassifier`; it is assumed that this
+        distribution has been initialized with vectorized parameters with one
+        value for each cyclic boosting bin
+
+    link_func: callable
+        the transformation function to link space, e.g. the method
+        :meth:`~cyclic_boosting.link.LinkFunction.link_func` inherited in
+        the cyclic boosting class
+
+    perc1: float or ndarray of floats
+        percentage (a fixed value or an individual value for each of the bins)
+        of the first quantile to match
+
+    perc2: float or ndarray of floats
+        percentage (a fixed value or an individual value for each of the bins)
+        of the second quantile to match; it must be different from perc1.
+
+    Returns
+    -------
+
+    tuple
+        mu, sigma of the matched Gaussian, each being a ndarray with one value
+        for each bin
+
+    Example
+    -------
+
+    As example, consider the case of a beta distribution with link function
+    logit which is used in :mod:`cyclic_boosting.classification`. It compares
+    the old and new Gaussian matching for different alphas and betas.
+
+    Derivation of the transformation of the beta distribution to logit space:
+
+    .. math::
+        y = \text{logit}(x) = \log(x / (1 - x))
+
+        \Leftrightarrow x = \frac{1}{1 + e^{-x}}
+
+        \Rightarrow \frac{\mathrm{d} x}{\mathrm{d} y} =
+        \frac{e^{-y}}{\left(1 + e^{-y}\right)^2}
+
+        p_{\text{beta}'(\alpha, \beta)}(y)\,\mathrm{d} y
+        = p_{\text{beta}(\alpha, \beta)}(x)\,\mathrm{d} x
+        = p_{\text{beta}(\alpha, \beta)}(x(y))
+        \,\frac{\mathrm{d} x}{\mathrm{d} y}\,\mathrm{d} y
+
+        = p_{\text{beta}(\alpha, \beta)}\left(\left(1 + e^{-y}\right)^2\right)
+        \frac{e^{-y}}{\left(1 + e^{-y}\right)^2}\,\mathrm{d} y
+    """
+    quant1_link: float = link_func(dist.ppf(perc1))
+    quant2_link: float = link_func(dist.ppf(perc2))
+
+    a1 = _coefficient_for_gaussian_matching_by_quantiles(perc1)
+    a2 = _coefficient_for_gaussian_matching_by_quantiles(perc2)
+
+    sigma = (quant1_link - quant2_link) / (a1 - a2)
+    mu = quant1_link - sigma * a1
+
+    return mu, sigma
+
+
+def calc_factors_generic(
+    lex_binnumbers: np.ndarray,
+    w_x: np.ndarray,
+    w: np.ndarray,
+    w_x2: np.ndarray,
+    external_weights: np.ndarray,
+    minlength: int,
+    x0: float,
+    w0: float,
+) -> Tuple[float, float]:
+    r"""Generic calculation of factors and uncertainties
+
+    It is always possible to reparametrise :math:`\chi^2`
+    of the different cyclic boosting models to the following standard form
+
+    .. math::
+        \chi^2 =\sum_i w_i \cdot (x_i - \hat{x})^2
+
+    where the sum goes over the samples in one specific feature bin and
+    :math:`\hat{x}` is the parameter to be estimated.
+
+    **Multiplicative Ansatz:**
+
+    Here we have
+
+    .. math::
+        \chi^2=\sum_i v_i \cdot (y_i - \hat{x} \cdot p_i)^2 / \sigma^2_{y_i}
+        =\sum_i v_i p_i^2 \cdot (y_i/p_i - \hat{x})^2 / \sigma^2_{y_i}
+
+    where :math:`v_i` is the external weight, :math:`y_i` is the target,
+    :math:`p_i` is the prediction without the contribution of this feature
+    and :math:`\sigma^2_{y_i}` is the variance of the target.
+    By setting
+
+    .. math::
+        x_i = y_i / p_i
+    .. math::
+        w_i = v_i \cdot p_i^2 / \sigma^2_{y_i}
+
+    we get the standard form.
+
+    **Sum Ansatz:**
+
+    Here we have
+
+    .. math::
+        \chi^2=\sum_i v_i \cdot (y_i - (\hat{x} - p_i))^2 / \sigma^2_{y_i}
+        =\sum_i v_i \cdot ((y_i - p_i) - \hat{x})^2 / \sigma^2_{y_i}
+
+    By setting
+
+    .. math::
+        x_i = y_i - p_i
+    .. math::
+        w_i = v_i / \sigma^2_{y_i}
+
+    we get the standard form.
+
+    **Slope Ansatz:**
+
+    Here we have
+
+    .. math::
+        \chi^2=\sum_i v_i \cdot (y_i -
+        (\hat{x} \cdot u_i + p_i))^2 / \sigma^2_{y_i}
+        =\sum_i v_i u_i^2 \cdot ((y_i - p_i)/u_i - \hat{x})^2 / \sigma^2_{y_i}
+
+    where :math:`u_i` is the external column, e.g. a price ratio for dynamic
+    pricing models. By setting
+
+    .. math::
+        x_i = (y_i- p_i) / u_i
+    .. math::
+        w_i = v_i \cdot u_i^2 / \sigma^2_{y_i}
+
+    we get the standard form.
+
+    All models above fit in the **general linear ansatz:**
+
+    .. math::
+        \chi^2=\sum_i v_i \cdot (y_i -
+        (\hat{x} \cdot m_i + b_i))^2 / \sigma^2_{y_i}
+        =\sum_i v_i m_i^2 \cdot ((y_i - b_i)/m_i - \hat{x})^2 / \sigma^2_{y_i}
+
+    By setting
+
+    .. math::
+        x_i = (y_i - b_i) / m_i
+    .. math::
+        w_i = v_i \cdot m_i^2 / \sigma^2_{y_i}
+            = \frac{v_i}{\sigma^2_{y_i} \cdot (\frac{d x_i}{d y_i})^2}
+
+    we get the standard form.
+
+    **Solution for the general linear ansatz:**
+
+    If we solve for :math:`\hat{x}`, we get the formula for the weighted
+    mean:
+
+    .. math::
+        \hat{x} = \frac{\sum_i w_i \cdot x_i} {\sum_i w_i}
+
+    The variance of :math:`\hat{x}` is
+
+    .. math::
+        \sigma^2_{\hat{x}} =
+        \sum_i \left(\frac{d \hat{x}}{d x_i}\right)^2 \cdot \sigma^2_{x_i}
+        = \sum_i \left(\frac{w_i}{\sum_i w_i}\right)^2 \cdot \sigma^2_{x_i}
+
+    with
+
+    .. math::
+        w_i \cdot \sigma^2_{x_i} = \frac{v_i}{\sigma^2_{y_i}
+        \cdot (\frac{d x_i}{d y_i})^2} \cdot \sigma^2_{y_i}
+        \cdot \left(\frac{d x_i}{d y_i}\right)^2 = v_i
+
+    we can write the variance as
+
+    .. math::
+        \sigma_{\hat{x}} = \frac{\sum_i w_i \cdot v_i} {(\sum_i w_i)^2}
+
+    **Solution for the general linear ansatz with a prior on:** :math:`\hat{x}`
+
+    To handle bins with low statistics or empty bins we introduce
+    a gaussian prior with precision :math:`w_0` and mean :math:`x_0`
+
+    Our :math:`\chi^2` now has the following form:
+
+    .. math::
+        \chi^2 =\sum_i w_i \cdot (x_i - \hat{x})^2 + w_0 \cdot (\hat{x} - x_0)^2
+
+    Solving for :math:`\hat{x}` gives
+
+    .. math::
+        \hat{x} = \frac{x_0 \cdot w_0 + \sum_i w_i \cdot x_i} {w_0 + \sum_i w_i}
+
+    The variance of :math:`\hat{x}` is
+
+    .. math::
+        \sigma^2_{\hat{x}} =
+        \left(\frac{d \hat{x}}{d x_0}\right)^2 \cdot \sigma^2_{x_0} +
+        \sum_i \left(\frac{d \hat{x}}{d x_i}\right)^2 \cdot \sigma^2_{x_i}
+        = \frac{w_0 + \sum_i w_i \cdot v_i} {(w_0 + \sum_i w_i)^2}
+
+    Note
+    ----
+
+    The quadratic sum is split in summands because parts of it may not be
+    finite (e.g. in slope estimation).
+
+
+    Parameters
+    ----------
+
+    lex_binnumbers: :class:`numpy.ndarray`
+        1-dimensional numpy array containing the bin numbers.
+    w_x: :class:`numpy.ndarray`
+        :math:`w_i \cdot x_i` for each array element i
+    w: :class:`numpy.ndarray`
+        :math:`w_i` for each array element i
+    w_x2: :class:`numpy.ndarray`
+        :math:`w_i \cdot x_i^2` for each array element i
+    external_weights: :class:`numpy.ndarray`
+        :math:`v_i` for each array element i
+    minlength: int
+        number of bins for this feature including the `nan` bin
+    x0: float
+        mean of the prior on the mean
+    w0: float
+        prior precision of the prior on the mean
+
+    Returns
+    -------
+    tuple
+        A tuple of ``factors`` and ``uncertainties``
+        in the original space.
+    """
+
+    sum_w_x, sum_w, sum_vw, sum_w_x2 = (
+        np.bincount(lex_binnumbers, weights=w, minlength=minlength) for w in [w_x, w, external_weights * w, w_x2]
+    )
+
+    sum_w_x += w0 * x0
+    sum_w += w0
+    sum_w_x2 += w0 * x0**2
+    sum_vw += w0
+
+    weighted_mean = sum_w_x / sum_w
+    variance_weighted_mean = sum_vw / sum_w**2
+
+    return weighted_mean, np.sqrt(variance_weighted_mean)
+
+
+__all__ = [
+    "_factors_deviation",
+    "CyclicBoostingBase",
+    "gaussian_matching_by_quantiles",
+    "calc_factors_generic",
+]

--- a/skpro/libs/cyclic_boosting/base.py
+++ b/skpro/libs/cyclic_boosting/base.py
@@ -1,37 +1,41 @@
-
 import abc
 import logging
 import warnings
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import numexpr
 import numpy as np
 import pandas as pd
-from pandas.api.extensions import ExtensionArray
 import scipy.special
-
+from pandas.api.extensions import ExtensionArray
 from sklearn import base as sklearnb
 
 from skpro.libs.cyclic_boosting import common_smoothers, learning_rate, link
 from skpro.libs.cyclic_boosting.binning import get_feature_column_names_or_indices
 from skpro.libs.cyclic_boosting.common_smoothers import SmootherChoice
-from skpro.libs.cyclic_boosting.features import create_features, Feature, FeatureList, FeatureTypes, create_feature_id
+from skpro.libs.cyclic_boosting.features import (
+    Feature,
+    FeatureList,
+    FeatureTypes,
+    create_feature_id,
+    create_features,
+)
 from skpro.libs.cyclic_boosting.link import IdentityLinkMixin, LogLinkMixin
 from skpro.libs.cyclic_boosting.utils import (
-    slice_finite_semi_positive,
-    nans,
-    get_X_column,
     ConvergenceError,
     ConvergenceParameters,
+    get_normalized_values,
+    get_X_column,
+    nans,
+    slice_finite_semi_positive,
 )
-
-from skpro.libs.cyclic_boosting.utils import get_normalized_values
-
-from typing import Any, Dict, Optional, Union, Tuple, List, Set
 
 _logger = logging.getLogger(__name__)
 
 
-def get_influence_category(feature: Feature, influence_categories: dict) -> Union[None, str]:
+def get_influence_category(
+    feature: Feature, influence_categories: dict
+) -> Union[None, str]:
     influence_category = None
     if influence_categories is not None:
         influence_category = influence_categories.get(feature.feature_group, None)
@@ -42,12 +46,18 @@ def get_influence_category(feature: Feature, influence_categories: dict) -> Unio
                 fg = feature.feature_group[0]
                 influence_category = influence_categories.get(fg, None)
         if influence_category is None:
-            raise KeyError(f"Please add {feature.feature_group} to influence_categories")
+            raise KeyError(
+                f"Please add {feature.feature_group} to influence_categories"
+            )
     return influence_category
 
 
-class UpdateMixin(object):
-    def __init__(self, df: Optional[pd.DataFrame] = None, price_feature_seen: Optional[bool] = None):
+class UpdateMixin:
+    def __init__(
+        self,
+        df: Optional[pd.DataFrame] = None,
+        price_feature_seen: Optional[bool] = None,
+    ):
         self.df = df
         self.price_feature_seen = price_feature_seen
 
@@ -55,7 +65,9 @@ class UpdateMixin(object):
         self.df["exponents"] += pred
         self.price_feature_seen = True
 
-    def include_factor_contrib(self, pred: np.ndarray, influence_category: Union[None, str]) -> None:
+    def include_factor_contrib(
+        self, pred: np.ndarray, influence_category: Union[None, str]
+    ) -> None:
         self.df["factors"] += pred
         if influence_category is not None:
             if influence_category in self.df.columns:
@@ -66,7 +78,9 @@ class UpdateMixin(object):
     def remove_price_contrib(self, pred) -> None:
         self.df["exponents"] -= pred
 
-    def remove_factor_contrib(self, pred: np.ndarray, influence_category: Union[None, str]) -> None:
+    def remove_factor_contrib(
+        self, pred: np.ndarray, influence_category: Union[None, str]
+    ) -> None:
         self.df["factors"] -= pred
         if influence_category is not None:
             if influence_category in self.df.columns:
@@ -75,20 +89,30 @@ class UpdateMixin(object):
                 self.df[influence_category] = pred
 
     def update_predictions(
-        self, pred: np.ndarray, feature: Feature, influence_categories: Optional[dict] = None
+        self,
+        pred: np.ndarray,
+        feature: Feature,
+        influence_categories: Optional[dict] = None,
     ) -> None:
         if feature.feature_type == FeatureTypes.external:
             self.include_price_contrib(pred)
         else:
-            self.include_factor_contrib(pred, get_influence_category(feature, influence_categories))
+            self.include_factor_contrib(
+                pred, get_influence_category(feature, influence_categories)
+            )
 
     def remove_predictions(
-        self, pred: np.ndarray, feature: Feature, influence_categories: Optional[dict] = None
+        self,
+        pred: np.ndarray,
+        feature: Feature,
+        influence_categories: Optional[dict] = None,
     ) -> None:
         if feature.feature_type == FeatureTypes.external:
             self.remove_price_contrib(pred)
         else:
-            self.remove_factor_contrib(pred, get_influence_category(feature, influence_categories))
+            self.remove_factor_contrib(
+                pred, get_influence_category(feature, influence_categories)
+            )
 
 
 class CBLinkPredictionsFactors(UpdateMixin):
@@ -105,19 +129,25 @@ class CBLinkPredictionsFactors(UpdateMixin):
 
 
 class ZeroSmoother(sklearnb.BaseEstimator, sklearnb.RegressorMixin):
-    def fit(self, X_for_smoother: np.ndarray, y: np.ndarray) -> Union[sklearnb.BaseEstimator, sklearnb.RegressorMixin]:
+    def fit(
+        self, X_for_smoother: np.ndarray, y: np.ndarray
+    ) -> Union[sklearnb.BaseEstimator, sklearnb.RegressorMixin]:
         return self
 
     def predict(self, X: np.ndarray) -> np.ndarray:
         return np.repeat(0.0, len(X))
 
 
-def _predict_factors(feature: Feature, X_for_smoother: np.ndarray, neutral_factor: float) -> np.ndarray:
+def _predict_factors(
+    feature: Feature, X_for_smoother: np.ndarray, neutral_factor: float
+) -> np.ndarray:
     isfinite_all = slice_finite_semi_positive(X_for_smoother)
     prediction_smoother = nans(len(X_for_smoother))
 
     if isfinite_all.any() and (feature.smoother is not None):
-        prediction_smoother[isfinite_all] = feature.learn_rate * feature.smoother.predict(X_for_smoother[isfinite_all])
+        prediction_smoother[
+            isfinite_all
+        ] = feature.learn_rate * feature.smoother.predict(X_for_smoother[isfinite_all])
 
     prediction_smoother[~isfinite_all] = feature.factors_link[-1]
     prediction_smoother[~np.isfinite(prediction_smoother)] = neutral_factor
@@ -134,9 +164,11 @@ def _factors_deviation(features: FeatureList) -> float:
     features: :class:`~cyclic_boosting.base.FeatureList`
         Collection of all features.
     """
-    mean_factor_devs = [np.mean(np.abs(feature.factors_link - feature.factors_link_old)) for feature in features]
+    mean_factor_devs = [
+        np.mean(np.abs(feature.factors_link - feature.factors_link_old))
+        for feature in features
+    ]
     return np.mean(mean_factor_devs)
-
 
 
 class CyclicBoostingBase(
@@ -299,7 +331,9 @@ class CyclicBoostingBase(
             for fg in self.hierarchical_feature_groups:
                 hierarchical_feature = create_feature_id(fg)
                 self.hierarchical_features.append(hierarchical_feature.feature_group)
-        self.training_iterations_hierarchical_features = training_iterations_hierarchical_features
+        self.training_iterations_hierarchical_features = (
+            training_iterations_hierarchical_features
+        )
         self.feature_importances = {}
         self.aggregate = aggregate
 
@@ -330,11 +364,15 @@ class CyclicBoostingBase(
             self.learn_rate = learning_rate.constant_learn_rate_one
         self._init_features()
 
-    def loss(self, prediction: np.ndarray, y: np.ndarray, weights: np.ndarray) -> np.ndarray:
+    def loss(
+        self, prediction: np.ndarray, y: np.ndarray, weights: np.ndarray
+    ) -> np.ndarray:
         if not len(y) > 0:
             raise ValueError("Loss cannot be computed on empty data")
         else:
-            sum_weighted_error = numexpr.evaluate("sum((prediction - y) * (prediction - y) * weights)")
+            sum_weighted_error = numexpr.evaluate(
+                "sum((prediction - y) * (prediction - y) * weights)"
+            )
             sum_weights = numexpr.evaluate("sum(weights)")
             return sum_weighted_error / sum_weights
 
@@ -366,7 +404,9 @@ class CyclicBoostingBase(
         else:
             self.weights = get_X_column(X, self.weight_column)
 
-    def _init_external_column(self, X: Union[pd.DataFrame, np.ndarray], is_fit: bool) -> None:
+    def _init_external_column(
+        self, X: Union[pd.DataFrame, np.ndarray], is_fit: bool
+    ) -> None:
         """Init the external column.
 
         Parameters
@@ -390,9 +430,13 @@ class CyclicBoostingBase(
         if self.weight_column is not None:
             exclude_columns.append(self.weight_column)
 
-        self.feature_groups = get_feature_column_names_or_indices(X, exclude_columns=exclude_columns)
+        self.feature_groups = get_feature_column_names_or_indices(
+            X, exclude_columns=exclude_columns
+        )
 
-    def _init_global_scale(self, X: Union[pd.DataFrame, np.ndarray], y: np.ndarray) -> None:
+    def _init_global_scale(
+        self, X: Union[pd.DataFrame, np.ndarray], y: np.ndarray
+    ) -> None:
         """
         Initializes the ``global_scale_link_`` and the
         ``prior_pred_link_offset_``. The ``global_scale_link_`` is set to the
@@ -405,7 +449,9 @@ class CyclicBoostingBase(
             raise RuntimeError("The weights have to be initialized.")
 
         minimal_prediction = 0.001
-        self.global_scale_link_ = self.link_func(np.sum(y * self.weights) / np.sum(self.weights) + minimal_prediction)
+        self.global_scale_link_ = self.link_func(
+            np.sum(y * self.weights) / np.sum(self.weights) + minimal_prediction
+        )
 
         if self.prior_prediction_column is not None:
             prior_pred = get_X_column(X, self.prior_prediction_column)
@@ -418,12 +464,16 @@ class CyclicBoostingBase(
                     )
                 )
 
-            prior_pred_mean = np.sum(prior_pred[finite] * self.weights[finite]) / np.sum(self.weights[finite])
+            prior_pred_mean = np.sum(
+                prior_pred[finite] * self.weights[finite]
+            ) / np.sum(self.weights[finite])
 
             prior_pred_link_mean = self.link_func(prior_pred_mean)
 
             if np.isfinite(prior_pred_link_mean):
-                self.prior_pred_link_offset_ = self.global_scale_link_ - prior_pred_link_mean
+                self.prior_pred_link_offset_ = (
+                    self.global_scale_link_ - prior_pred_link_mean
+                )
             else:
                 warnings.warn(
                     "The mean prior prediction in link-space is not finite. "
@@ -441,20 +491,26 @@ class CyclicBoostingBase(
         Initializes the ``features`` and binds the data belonging to a feature
         to it.
         """
-        self.features = create_features(self.feature_groups, self.feature_properties, self.smoother_choice)
+        self.features = create_features(
+            self.feature_groups, self.feature_properties, self.smoother_choice
+        )
 
     def _get_prior_predictions(self, X: Union[pd.DataFrame, np.ndarray]) -> np.ndarray:
         if self.prior_prediction_column is None:
             prior_prediction_link = np.repeat(self.global_scale_link_, X.shape[0])
         else:
             prior_pred = get_X_column(X, self.prior_prediction_column)
-            prior_prediction_link = self.link_func(prior_pred) + self.prior_pred_link_offset_
+            prior_prediction_link = (
+                self.link_func(prior_pred) + self.prior_pred_link_offset_
+            )
             finite = np.isfinite(prior_prediction_link)
             prior_prediction_link[~finite] = self.global_scale_link_
 
         return prior_prediction_link
 
-    def _feature_contribution(self, feature: Feature, contribution: np.ndarray) -> np.ndarray:
+    def _feature_contribution(
+        self, feature: Feature, contribution: np.ndarray
+    ) -> np.ndarray:
         """The contribution of a feature group to the full model in link space.
 
         The link spaces have been chosen such that contributions in link space
@@ -484,10 +540,12 @@ class CyclicBoostingBase(
     def _check_convergence(self) -> None:
         msg = (
             "Your cyclic boosting training seems to be "
-            "diverging. In the {0}. iteration the "
-            "current loss: {1}, is greater "
+            "diverging. In the {}. iteration the "
+            "current loss: {}, is greater "
             "than the trivial loss with just mean "
-            "predictions: {2}.".format(self.iteration_ + 1, self.insample_loss_, self.initial_loss_)
+            "predictions: {}.".format(
+                self.iteration_ + 1, self.insample_loss_, self.initial_loss_
+            )
         )
 
         if self.is_diverged(self.insample_loss_):
@@ -514,7 +572,9 @@ class CyclicBoostingBase(
 
         return loss_change
 
-    def _log_iteration_info(self, convergence_parameters: ConvergenceParameters) -> None:
+    def _log_iteration_info(
+        self, convergence_parameters: ConvergenceParameters
+    ) -> None:
         if self.iteration_ == 0:
             _logger.info("Factor model iteration 1")
         else:
@@ -529,14 +589,23 @@ class CyclicBoostingBase(
             )
 
     def _call_observe_feature_iterations(
-        self, iteration: int, i: int, X: np.ndarray, y: np.ndarray, prediction: np.ndarray
+        self,
+        iteration: int,
+        i: int,
+        X: np.ndarray,
+        y: np.ndarray,
+        prediction: np.ndarray,
     ) -> None:
         for observer in self.observers:
-            observer.observe_feature_iterations(iteration, i, X, y, prediction, self.weights, self.get_state())
+            observer.observe_feature_iterations(
+                iteration, i, X, y, prediction, self.weights, self.get_state()
+            )
 
     def _call_observe_iterations(self, iteration, X, y, prediction, delta) -> None:
         for observer in self.observers:
-            observer.observe_iterations(iteration, X, y, prediction, self.weights, self.get_state(), delta)
+            observer.observe_iterations(
+                iteration, X, y, prediction, self.weights, self.get_state(), delta
+            )
 
     def get_state(self) -> Dict[str, Any]:
         est_state = {
@@ -550,7 +619,9 @@ class CyclicBoostingBase(
             and self.iteration_ < self.training_iterations_hierarchical_features
         ):
             est_state["features"] = [
-                feature for feature in self.features if feature.feature_group in self.hierarchical_features
+                feature
+                for feature in self.features
+                if feature.feature_group in self.hierarchical_features
             ]
         return est_state
 
@@ -587,13 +658,20 @@ class CyclicBoostingBase(
         return min_f, max_f
 
     def visit_factors(
-        self, feature: Feature, unfitted_factors, X: np.ndarray, y: np.ndarray, pred: CBLinkPredictionsFactors
+        self,
+        feature: Feature,
+        unfitted_factors,
+        X: np.ndarray,
+        y: np.ndarray,
+        pred: CBLinkPredictionsFactors,
     ) -> None:
         clip = isinstance(self, LogLinkMixin)
 
         if clip and self.aggregate:
             # Maximal/Minimal updates
-            feature.factors_link = np.clip(feature.factors_link, np.log(0.5), np.log(2), out=feature.factors_link)
+            feature.factors_link = np.clip(
+                feature.factors_link, np.log(0.5), np.log(2), out=feature.factors_link
+            )
 
             # Absolute size of factors/exponents per feature
             if feature.is_fitted:
@@ -628,7 +706,7 @@ class CyclicBoostingBase(
                         feature.factors_link = -feature.fitted_aggregated
                         feature.smoother = ZeroSmoother()
                 elif check_diverged():
-                    msg = "Feature factors for {} will be clipped due to diverging loss".format(feature.feature_group)
+                    msg = f"Feature factors for {feature.feature_group} will be clipped due to diverging loss"
                     warnings.warn(msg)
                     np.clip(
                         feature.factors_link,
@@ -647,13 +725,20 @@ class CyclicBoostingBase(
             feature.is_fitted = True
 
     def feature_iteration(
-        self, X: np.ndarray, y: np.ndarray, feature: Feature, pred: CBLinkPredictionsFactors, prefit_data
+        self,
+        X: np.ndarray,
+        y: np.ndarray,
+        feature: Feature,
+        pred: CBLinkPredictionsFactors,
+        prefit_data,
     ):
         if not self.aggregate:
             feature_predictions = self._pred_feature(X, feature, True)
             pred.remove_predictions(feature_predictions, feature)
 
-        factors_link, uncertainties_link = self.calc_parameters(feature, y, pred, prefit_data=prefit_data)
+        factors_link, uncertainties_link = self.calc_parameters(
+            feature, y, pred, prefit_data=prefit_data
+        )
 
         X_for_smoother = feature.update_factors(
             factors_link.copy(),
@@ -663,7 +748,9 @@ class CyclicBoostingBase(
         )
 
         feature.factors_link = _predict_factors(
-            feature=feature, X_for_smoother=X_for_smoother[:, : feature.dim], neutral_factor=self.neutral_factor_link
+            feature=feature,
+            X_for_smoother=X_for_smoother[:, : feature.dim],
+            neutral_factor=self.neutral_factor_link,
         )
 
         feature.factors_link = self.calibrate_to_weighted_mean(feature)
@@ -684,7 +771,9 @@ class CyclicBoostingBase(
                 weights = self.weights_external
             if self.iteration_ == 0:
                 feature.bind_data(X, weights)
-                feature.factors_link = np.ones(feature.n_bins) * self.neutral_factor_link
+                feature.factors_link = (
+                    np.ones(feature.n_bins) * self.neutral_factor_link
+                )
                 if prefit_data is not None:
                     prefit_data[i] = self.precalc_parameters(feature, y, pred)
             else:
@@ -710,11 +799,13 @@ class CyclicBoostingBase(
         self._init_features()
         self._init_global_scale(X, y)
 
-    def _fit_main(self, X: np.ndarray, y: np.ndarray, pred: CBLinkPredictionsFactors) -> np.ndarray:
+    def _fit_main(
+        self, X: np.ndarray, y: np.ndarray, pred: CBLinkPredictionsFactors
+    ) -> np.ndarray:
         self.diverging = 0
         self.is_diverging = False
 
-        _logger.info("Cyclic Boosting global scale {}".format(self.global_scale_))
+        _logger.info(f"Cyclic Boosting global scale {self.global_scale_}")
 
         prediction = self.unlink_func(pred.predict_link())
 
@@ -726,8 +817,12 @@ class CyclicBoostingBase(
 
         convergence_parameters = ConvergenceParameters()
 
-        while (not self._check_stop_criteria(self.iteration_, convergence_parameters)) or self.is_diverging:
-            self._call_observe_iterations(self.iteration_, X, y, prediction, convergence_parameters.delta)
+        while (
+            not self._check_stop_criteria(self.iteration_, convergence_parameters)
+        ) or self.is_diverging:
+            self._call_observe_iterations(
+                self.iteration_, X, y, prediction, convergence_parameters.delta
+            )
 
             self._log_iteration_info(convergence_parameters)
             for i, feature, pf_data in self.cb_features(X, y, pred, prefit_data):
@@ -739,7 +834,9 @@ class CyclicBoostingBase(
                     feature.factors_link_old = feature.factors_link.copy()
                     continue
                 pred = self.feature_iteration(X, y, feature, pred, pf_data)
-                self._call_observe_feature_iterations(self.iteration_, i, X, y, prediction)
+                self._call_observe_feature_iterations(
+                    self.iteration_, i, X, y, prediction
+                )
 
                 if feature.factor_sum is None:
                     feature.factor_sum = [np.sum(np.abs(feature.fitted_aggregated))]
@@ -749,7 +846,9 @@ class CyclicBoostingBase(
             prediction = self.unlink_func(pred.predict_link())
 
             updated_loss_change = self._update_loss(prediction, y)
-            convergence_parameters.set_loss_change(updated_loss_change=updated_loss_change)
+            convergence_parameters.set_loss_change(
+                updated_loss_change=updated_loss_change
+            )
 
             updated_delta = _factors_deviation(self.features)
             convergence_parameters.set_delta(updated_delta=updated_delta)
@@ -765,17 +864,21 @@ class CyclicBoostingBase(
         if len(self.observers) > 0:
             self.prepare_plots(X, y, prediction)
 
-        self._call_observe_iterations(-1, X, y, prediction, convergence_parameters.delta)
+        self._call_observe_iterations(
+            -1, X, y, prediction, convergence_parameters.delta
+        )
         self._check_convergence()
 
-        _logger.info("Cyclic Boosting, final global scale {}".format(self.global_scale_))
+        _logger.info(f"Cyclic Boosting, final global scale {self.global_scale_}")
 
         for feature in self.features:
             feature.clear_feature_reference(observers=self.observers)
 
         return prediction
 
-    def prepare_plots(self, X: np.ndarray, y: np.ndarray, prediction: np.ndarray) -> None:
+    def prepare_plots(
+        self, X: np.ndarray, y: np.ndarray, prediction: np.ndarray
+    ) -> None:
         for feature in self.features:
             if feature.feature_type is None:
                 weights = self.weights
@@ -785,7 +888,9 @@ class CyclicBoostingBase(
             feature.bind_data(X, weights)
 
             sum_w, sum_yw, sum_pw = (
-                np.bincount(feature.lex_binned_data, weights=w, minlength=feature.n_bins)
+                np.bincount(
+                    feature.lex_binned_data, weights=w, minlength=feature.n_bins
+                )
                 for w in [weights, weights * y, weights * prediction]
             )
 
@@ -805,16 +910,22 @@ class CyclicBoostingBase(
                 feature.y = mean_target_binned - mean_y_finite
                 feature.prediction = mean_prediction_binned - mean_prediction_finite
             else:
-                feature.mean_dev = np.log(mean_prediction_binned + 1e-12) - np.log(mean_target_binned + 1e-12)
+                feature.mean_dev = np.log(mean_prediction_binned + 1e-12) - np.log(
+                    mean_target_binned + 1e-12
+                )
                 feature.y = np.log(mean_target_binned / mean_y_finite + 1e-12)
-                feature.prediction = np.log(mean_prediction_binned / mean_prediction_finite + 1e-12)
+                feature.prediction = np.log(
+                    mean_prediction_binned / mean_prediction_finite + 1e-12
+                )
 
             feature.y_finite = mean_y_finite
             feature.prediction_finite = mean_prediction_finite
 
             feature.learn_rate = 1.0
 
-    def _fit_predict(self, X: Union[pd.DataFrame, np.ndarray], y: Optional[np.ndarray] = None) -> np.ndarray:
+    def _fit_predict(
+        self, X: Union[pd.DataFrame, np.ndarray], y: Optional[np.ndarray] = None
+    ) -> np.ndarray:
         """Fit the estimator to the training samples.
 
         Iterate to calculate the factors and the global scale.
@@ -828,20 +939,28 @@ class CyclicBoostingBase(
 
         return prediction
 
-    def _pred_feature(self, X: Union[pd.DataFrame, np.ndarray], feature: Feature, is_fit: bool):
+    def _pred_feature(
+        self, X: Union[pd.DataFrame, np.ndarray], feature: Feature, is_fit: bool
+    ):
         if is_fit:
             return feature.factors_link[feature.lex_binned_data]
         else:
-            X_for_predict = get_X_column(X, feature.feature_group, array_for_1_dim=False)
+            X_for_predict = get_X_column(
+                X, feature.feature_group, array_for_1_dim=False
+            )
             pred = _predict_factors(feature, X_for_predict, self.neutral_factor_link)
             return pred
 
-    def predict(self, X: Union[pd.DataFrame, np.ndarray], y: Optional[np.ndarray] = None) -> np.ndarray:
+    def predict(
+        self, X: Union[pd.DataFrame, np.ndarray], y: Optional[np.ndarray] = None
+    ) -> np.ndarray:
         pred = self.predict_extended(X, None)
         return self.unlink_func(pred.predict_link())
 
     def predict_extended(
-        self, X: Union[pd.DataFrame, np.ndarray], influence_categories: Optional[dict] = None
+        self,
+        X: Union[pd.DataFrame, np.ndarray],
+        influence_categories: Optional[dict] = None,
     ) -> CBLinkPredictionsFactors:
         self._check_fitted()
         self._init_external_column(X, False)
@@ -855,29 +974,43 @@ class CyclicBoostingBase(
 
         return pred
 
-    def fit_transform(self, X: pd.DataFrame, y: Optional[np.ndarray] = None) -> pd.DataFrame:
+    def fit_transform(
+        self, X: pd.DataFrame, y: Optional[np.ndarray] = None
+    ) -> pd.DataFrame:
         if not self.output_column:
             raise KeyError("output_column not defined")
         try:
             if self.output_column in X.columns:
-                raise KeyError("""output_column "{}" exists already""".format(self.output_column))
+                raise KeyError(
+                    f"""output_column "{self.output_column}" exists already"""
+                )
         except AttributeError:
-            raise TypeError("data needs to be a dataframe for the usage as a fit_transformer")
+            raise TypeError(
+                "data needs to be a dataframe for the usage as a fit_transformer"
+            )
         X[self.output_column] = self._fit_predict(X, y)
         return X
 
-    def transform(self, X: pd.DataFrame, y: Optional[np.ndarray] = None) -> pd.DataFrame:
+    def transform(
+        self, X: pd.DataFrame, y: Optional[np.ndarray] = None
+    ) -> pd.DataFrame:
         if not self.output_column:
             raise KeyError("output_column not defined")
         try:
             if self.output_column in X.columns:
-                raise KeyError("""output_column "{}" exists already""".format(self.output_column))
+                raise KeyError(
+                    f"""output_column "{self.output_column}" exists already"""
+                )
         except AttributeError:
-            raise TypeError("data needs to be a dataframe for the usage as a transformer")
+            raise TypeError(
+                "data needs to be a dataframe for the usage as a transformer"
+            )
         X[self.output_column] = self.predict(X=X, y=y)
         return X
 
-    def _check_stop_criteria(self, iterations: int, convergence_parameters: ConvergenceParameters) -> bool:
+    def _check_stop_criteria(
+        self, iterations: int, convergence_parameters: ConvergenceParameters
+    ) -> bool:
         """
         Checks the stop criteria and returns True if at least one is satisfied.
 
@@ -904,16 +1037,18 @@ class CyclicBoostingBase(
         if delta <= self.minimal_factor_change:
             _logger.info(
                 "Cyclic Boosting stopped because the change of "
-                "the factors {0} was lower than the "
-                "required minimum {1}.".format(delta, self.minimal_factor_change)
+                "the factors {} was lower than the "
+                "required minimum {}.".format(delta, self.minimal_factor_change)
             )
             stop_factor_change = True
 
         if abs(loss_change) <= self.minimal_loss_change:
             _logger.info(
                 "Cyclic Boosting stopped because the change of "
-                "the loss {0} was lower "
-                "than the required minimum {1}.".format(loss_change, self.minimal_loss_change)
+                "the loss {} was lower "
+                "than the required minimum {}.".format(
+                    loss_change, self.minimal_loss_change
+                )
             )
             stop_loss_change = True
 
@@ -932,7 +1067,9 @@ class CyclicBoostingBase(
             veto_hierarchical = True
 
         self.stop_criteria_ = (stop_iterations, stop_factor_change, stop_loss_change)
-        return (stop_iterations or stop_factor_change or stop_loss_change) and not veto_hierarchical
+        return (
+            stop_iterations or stop_factor_change or stop_loss_change
+        ) and not veto_hierarchical
 
     def _check_parameters(self) -> None:
         if self.feature_groups is not None and len(self.feature_groups) == 0:
@@ -943,7 +1080,9 @@ class CyclicBoostingBase(
         if self.features is None:
             raise ValueError("fit must be called first.")
 
-    def _check_len_data(self, X: Union[pd.DataFrame, np.ndarray], y: np.ndarray) -> None:
+    def _check_len_data(
+        self, X: Union[pd.DataFrame, np.ndarray], y: np.ndarray
+    ) -> None:
         """Check that input arrays are not empty"""
         if len(X) == 0 | len(y) == 0:
             raise ValueError("Estimator should be applied on non-empty data")
@@ -953,7 +1092,8 @@ class CyclicBoostingBase(
         implemented by the child class.
         """
         raise NotImplementedError(
-            "You have to implement the function _check_y" " to ensure your target has correct values."
+            "You have to implement the function _check_y"
+            " to ensure your target has correct values."
         )
 
     def get_subestimators_as_items(self, prototypes=True) -> List[Tuple]:
@@ -978,7 +1118,9 @@ class CyclicBoostingBase(
         Returns the relative importance of each input feature.
         """
         if not self.feature_importances:
-            raise ValueError("_fit_main has to be called first to compute the feature importance.")
+            raise ValueError(
+                "_fit_main has to be called first to compute the feature importance."
+            )
         else:
             normalized_values = get_normalized_values(self.feature_importances.values())
             norm_feature_importances = {
@@ -987,7 +1129,9 @@ class CyclicBoostingBase(
             }
             return norm_feature_importances
 
-    def get_feature_contributions(self, X: Union[pd.DataFrame, np.ndarray]) -> Dict[str, np.ndarray]:
+    def get_feature_contributions(
+        self, X: Union[pd.DataFrame, np.ndarray]
+    ) -> Dict[str, np.ndarray]:
         """Returns the contributions of each feature for each individual
         prediction on a given data set, offering individual explainability of
         the model. That means the learned parameter, e.g., factor for
@@ -1009,13 +1153,21 @@ class CyclicBoostingBase(
         """
         contribution = {}
         for feature in self.features:
-            ft = "" if feature.feature_type is None else "_{}".format(feature.feature_type)
+            ft = "" if feature.feature_type is None else f"_{feature.feature_type}"
             fg = " ".join(feature.feature_group)
-            contribution[fg + ft] = self.unlink_func(self._pred_feature(X, feature, is_fit=False))
+            contribution[fg + ft] = self.unlink_func(
+                self._pred_feature(X, feature, is_fit=False)
+            )
         return contribution
 
     @abc.abstractmethod
-    def calc_parameters(self, feature: Feature, y: np.ndarray, pred: CBLinkPredictionsFactors, prefit_data):
+    def calc_parameters(
+        self,
+        feature: Feature,
+        y: np.ndarray,
+        pred: CBLinkPredictionsFactors,
+        prefit_data,
+    ):
         """Calculates factors and uncertainties of the bins of a feature group
         in the original space (not the link space) and transforms them to the
         link space afterwards
@@ -1051,7 +1203,9 @@ class CyclicBoostingBase(
         raise NotImplementedError("implement in subclass")
 
     @abc.abstractmethod
-    def precalc_parameters(self, feature: Feature, y: np.ndarray, pred: CBLinkPredictionsFactors):
+    def precalc_parameters(
+        self, feature: Feature, y: np.ndarray, pred: CBLinkPredictionsFactors
+    ):
         """Calculations that are not  dependent on intermediate predictions. If
         these are not needed, return :obj:`None` in the subclass.
 
@@ -1366,7 +1520,8 @@ def calc_factors_generic(
     """
 
     sum_w_x, sum_w, sum_vw, sum_w_x2 = (
-        np.bincount(lex_binnumbers, weights=w, minlength=minlength) for w in [w_x, w, external_weights * w, w_x2]
+        np.bincount(lex_binnumbers, weights=w, minlength=minlength)
+        for w in [w_x, w, external_weights * w, w_x2]
     )
 
     sum_w_x += w0 * x0

--- a/skpro/libs/cyclic_boosting/binning/__init__.py
+++ b/skpro/libs/cyclic_boosting/binning/__init__.py
@@ -1,0 +1,27 @@
+
+from skpro.libs.cyclic_boosting.binning._utils import (
+    get_bin_bounds,
+    get_column_index,
+    minimal_difference,
+)
+from skpro.libs.cyclic_boosting.binning.bin_number_transformer import BinNumberTransformer
+from skpro.libs.cyclic_boosting.binning.ecdf_transformer import (
+    ECdfTransformer,
+    get_feature_column_names_or_indices,
+    get_weight_column,
+    reduce_cdf_and_boundaries_to_nbins,
+)
+
+MISSING_VALUE_AS_BINNO = -1
+
+
+__all__ = [
+    "ECdfTransformer",
+    "BinNumberTransformer",
+    "reduce_cdf_and_boundaries_to_nbins",
+    "get_weight_column",
+    "get_feature_column_names_or_indices",
+    "get_column_index",
+    "minimal_difference",
+    "get_bin_bounds",
+]

--- a/skpro/libs/cyclic_boosting/binning/__init__.py
+++ b/skpro/libs/cyclic_boosting/binning/__init__.py
@@ -1,10 +1,11 @@
-
 from skpro.libs.cyclic_boosting.binning._utils import (
     get_bin_bounds,
     get_column_index,
     minimal_difference,
 )
-from skpro.libs.cyclic_boosting.binning.bin_number_transformer import BinNumberTransformer
+from skpro.libs.cyclic_boosting.binning.bin_number_transformer import (
+    BinNumberTransformer,
+)
 from skpro.libs.cyclic_boosting.binning.ecdf_transformer import (
     ECdfTransformer,
     get_feature_column_names_or_indices,

--- a/skpro/libs/cyclic_boosting/binning/_binary_search.py
+++ b/skpro/libs/cyclic_boosting/binning/_binary_search.py
@@ -1,4 +1,3 @@
-
 import math
 
 import numpy as np

--- a/skpro/libs/cyclic_boosting/binning/_binary_search.py
+++ b/skpro/libs/cyclic_boosting/binning/_binary_search.py
@@ -1,0 +1,329 @@
+
+import math
+
+import numpy as np
+from numba import jit
+
+
+@jit(nopython=True)
+def le(z, z_searched, inclusive):
+    """
+    Binary search for the **last** element **less than or equal to**
+    a given value in a sorted float64 array
+
+    If there are issues with float64 precision, please **add** a suitable
+    ``epsilon`` to ``z_searched`` first.
+
+    :param z: sorted array to search in; consecutive repetitions of values are
+        allowed.
+    :type z: :class:`numpy.ndarray` `(float64, ndim=1)`
+
+    :param z_searched: value to look for
+    :type z_searched: float64
+
+    :param inclusive: whether to always return a valid index, see below
+    :type inclusive: bool
+
+    :return: the index of the last element **less than or equal to**
+        ``z_searched``; If ``z_searched`` is less than all elements in ``z``,
+        -1 or 0 is returned for ``inclusive=False, True``, respectively.
+    :rtype: int64_t
+    """
+    i_left = 0 if inclusive else -1
+    i_right = z.shape[0]
+    while i_left < i_right - 1:
+        i = (i_left + i_right) // 2
+        if z[i] <= z_searched:
+            i_left = i
+        else:
+            i_right = i
+    return i_left
+
+
+@jit(nopython=True)
+def ge(z, z_searched, inclusive):
+    """
+    Binary search for the **first** element **greater than or equal to**
+    a given value in a sorted float64 array
+
+    This function implements the same functionality as the C++ function
+    ``std::lower_bound``. C++'s ``std::equal_range`` corresponds to the tuple
+    :func:`ge_lim`, :func:`gt_lim`.
+
+    If there are issues with float64 precision, please **subtract** a suitable
+    ``epsilon`` from ``z_searched`` first.
+
+    :param z: sorted array to search in; consecutive repetitions of values are
+        allowed.
+    :type z: :class:`numpy.ndarray` `(float64, ndim=1)`
+
+    :param z_searched: value to look for
+    :type z_searched: float64
+
+    :param inclusive: whether to always return a valid index, see below
+    :type inclusive: bool
+
+    :return: the index of the first element **greater than or equal to**
+        ``z_searched``; If ``z_searched`` is greater than all elements in ``z``,
+        ``len(z)`` or ``len(z) - 1`` is returned for
+        ``inclusive=False, True``, respectively.
+    :rtype: int64_t
+    """
+    n = z.shape[0]
+    i_left = -1
+    i_right = n - 1 if inclusive else n
+    while i_left < i_right - 1:
+        i = (i_left + i_right) // 2
+        if z[i] >= z_searched:
+            i_right = i
+        else:
+            i_left = i
+    return i_right
+
+
+@jit(nopython=True)
+def eq_multi(z, z_searched, u, epsilon, result):
+    """
+    Search the values of `z_searched` in z and return u[i_found] if
+    equality of z_searched[i_searched] and z[i_found] is given. Otherwise
+    `numpy.nan` is returned.
+
+    :param z: sorted array to search in
+    :type z: :class:`numpy.ndarray` (float64, ndim=1)
+
+    :param z_searched: Values to search for.
+    :type z_searched: :class:`numpy.ndarray` (float64, ndim=1)
+
+    :param u: Array from which to take the result. It is in one-to-one
+        correspondence to z.
+    :type u: :class:`numpy.ndarray` `(float64, ndim=1)`
+
+    :param epsilon: In order to avoid issues with float64 precision, this
+        epsilon is used.
+    :type epsilon: float64
+
+    :param result: where to put the results; passing the same array as
+        ``z_searched`` is supported.
+    :type result: :class:`numpy.ndarray` (float64, ndim=1), same length as
+        ``z_searched``
+    """
+    n = z_searched.shape[0]
+
+    if result.shape[0] != n:
+        raise ValueError("Inconsistent lengths of z_searched and result.")
+    if z.shape[0] != u.shape[0]:
+        raise ValueError("Inconsistent lengths of z and u.")
+    for i in range(n):
+        ind = le(z, z_searched[i] + epsilon, 0)
+        if check_equal(z[ind], z_searched[i], epsilon, 0.0):
+            result[i] = u[ind]
+        else:
+            result[i] = np.nan
+
+
+@jit(nopython=True)
+def ge_multi(z, z_searched, inclusive, result):
+    """
+    Binary search for the **first** elements **greater than or equal to**
+    given values in a sorted float64 array
+
+    For each value in ``z_searched``, :func:`ge` is called.
+
+    If there are issues with float64 precision, please **subtract** a suitable
+    ``epsilon`` from ``z_searched`` first.
+
+    :param z: sorted array to search in; consecutive repetitions of values are
+        allowed.
+    :type z: :class:`numpy.ndarray` `(float64, ndim=1)`
+
+    :param z_searched: value to look for
+    :type z_searched: float64
+
+    :param inclusive: whether to always return a valid index, see :func:`ge`
+    :type inclusive: bool
+
+    :param result: where to put the results
+    :type result: :class:`numpy.ndarray` (float64, ndim=1), same length as
+        ``z_searched``
+    """
+    n = z_searched.shape[0]
+
+    if result.shape[0] != n:
+        raise ValueError("Inconsistent lengths of z_searched and result.")
+    for i in range(n):
+        result[i] = ge(z, z_searched[i], inclusive)
+
+
+@jit(nopython=True)
+def le_interp(z, z_searched, u, out_left, epsilon):
+    """
+    Interpolation of a value between the position found by :func:`le` (i.e. the
+    **last** element **less than or equal to** a given value in a sorted float64
+    array) and the next position
+
+    :param z: sorted array to search in
+    :type z: :class:`numpy.ndarray` (float64, ndim=1)
+
+    :param z_searched: Value to search for.
+    :type z_searched: float64
+
+    :param u: Array from which to take the result. It is in one-to-one
+        correspondence to z.
+    :type u: :class:`numpy.ndarray` `(float64, ndim=1)`
+
+    :param out_left: value to return for ``z_searched < z[0]``.
+    :type out_left: float64
+
+    :param epsilon: In order to avoid issues with float64 precision, this
+        epsilon is added to ``z_searched`` for the binary search, but not in
+        the interpolation.
+    :type epsilon: float64
+
+    :return: If ``z_searched`` is found in z, the corresponding value ``u[i]``.
+        Otherwise a value between ``u[i]`` and ``u[i + 1]`` interpolated in
+        accord with the corresponding z values.
+
+        If ``z_searched`` is not a finite value or ``z`` is empty, ``np.nan``
+        is returned.
+    :rtype: float64
+    """
+    n = z.shape[0]
+
+    if not math.isfinite(z_searched) or n == 0:
+        return np.nan
+
+    i = le(z, z_searched + epsilon, 0)
+    z_found = z[i]
+    u0 = u[i]
+
+    if i < 0:
+        return out_left
+
+    if i < n - 1 and z_found < z_searched:
+        u0 += (z_searched - z_found) / (z[i + 1] - z_found) * (u[i + 1] - u0)
+
+    return u0
+
+
+@jit(nopython=True)
+def le_interp_multi(z, z_searched, u, out_left, epsilon, result):
+    """
+    Interpolation of values between the position found by :func:`le` (i.e. the
+    **last** element **less than or equal to** a given value in a sorted float64
+    array) and the next position
+
+    For each element in ``z_searched``, :func:`le_interp`
+    is called and the result is put in the corresponding slot in ``result``.
+
+    :param z: sorted array to search in
+    :type z: :class:`numpy.ndarray` (float64, ndim=1)
+
+    :param z_searched: Values to search for.
+    :type z_searched: :class:`numpy.ndarray` (float64, ndim=1)
+
+    :param u: Array from which to take the result. It is in one-to-one
+        correspondence to z.
+    :type u: :class:`numpy.ndarray` `(float64, ndim=1)`
+
+    :param out_left: value to return for ``z_searched < z[0]``.
+    :type out_left: float64
+
+    :param epsilon: In order to avoid issues with float64 precision, this
+        epsilon is added to ``z_searched`` for the binary search, but not in
+        the interpolation.
+    :type epsilon: float64
+
+    :param result: where to put the results; passing the same array as
+        ``z_searched`` is supported.
+    :type result: :class:`numpy.ndarray` (float64, ndim=1), same length as
+        ``z_searched``
+    """
+    n = z_searched.shape[0]
+    if result.shape[0] != n:
+        raise ValueError("Inconsistent lengths of z_searched and result.")
+    for i in range(n):
+        result[i] = le_interp(z, z_searched[i], u, out_left, epsilon)
+
+
+@jit(nopython=True)
+def ge_lim(z, z_searched, inclusive, i_left, i_right):
+    """
+    Binary search for the **first** element **greater than or equal to**
+    a given value in a sorted float64 array
+
+    This function implements the same functionality as the C++ function
+    ``std::lower_bound``. C++'s ``std::equal_range`` corresponds to the tuple
+    :func:`ge_lim`, :func:`gt_lim`.
+
+    If there are issues with float64 precision, please **subtract** a suitable
+    ``epsilon`` from ``z_searched`` first.
+
+    :param z: sorted array to search in; consecutive repetitions of values are
+        allowed.
+    :type z: :class:`numpy.ndarray` `(float64, ndim=1)`
+
+    :param z_searched: value to look for
+    :type z_searched: float64
+
+    :param inclusive: whether to always return a valid index, see below
+    :type inclusive: bool
+
+    :param i_left: The range of array indices considered is
+        ``[i_left, i_right)``.
+    :type i_left: int64_t
+
+    :param i_right: see ``i_left``.
+    :type i_right: int64_t
+
+    :return: the index of the first element **greater than or equal to**
+        ``z_searched``; If ``z_searched`` is greater than all elements in ``z``,
+        ``i_right`` or ``i_right - 1`` is returned for
+        ``inclusive=False, True``, respectively.
+    :rtype: int64_t
+    """
+    if inclusive:
+        i_right -= 1
+    i_left -= 1
+
+    while i_left < i_right - 1:
+        i = (i_left + i_right) // 2
+        if z[i] >= z_searched:
+            i_right = i
+        else:
+            i_left = i
+    return i_right
+
+
+@jit(nopython=True)
+def check_equal(z_1, z_2, atol, rtol):
+    r"""
+    Check if two doubles are equal within the specified relative and absolute
+    precision. This function is similar to :func:`numpy.allclose` with the
+    difference that it is symmetric in `z1` and `z2` regarding relative
+    comparisons.
+
+    By default NaN's are considered unequal.
+
+    .. math::
+
+        | z_1 - z_2 | \le a_{tol} + r_{tol} \cdot (|z_1| + |z_2|)
+
+    :param z_1: first input double
+    :type z_1: double
+
+    :param z_2: second input double
+    :type z_2: double
+
+    :param atol: absolute tolerance for comparisons:
+        :math:`| z_1 - z_2 | \le a_{tol}`
+    :type atol: double
+
+    :param rtol: relative tolerance for comparisons:
+        :math:`| z_1 - z_2 | \le r_{tol} \cdot (|z_1| + |z_2|)`
+    :type rtol: double
+
+    :rtype: bool
+    """
+    sum_abs = math.fabs(z_1) + math.fabs(z_2)
+    abs_diff = math.fabs(z_1 - z_2)
+    return abs_diff <= atol + (rtol * sum_abs)

--- a/skpro/libs/cyclic_boosting/binning/_utils.py
+++ b/skpro/libs/cyclic_boosting/binning/_utils.py
@@ -1,0 +1,111 @@
+
+import logging
+
+import numpy as np
+import pandas as pd
+
+from skpro.libs.cyclic_boosting import flags
+
+_logger = logging.getLogger(__name__)
+
+
+def _read_feature_property(col, feature_properties=None):
+    """
+    Get the feature property for a specific column
+
+    Parameters
+    ----------
+    col: int or str
+        column index specifier, integer for :class:`numpy.ndarray` or
+        :class:`str` for :class:`pandas.DataFrame`
+
+    feature_properties: dict
+        Dictionary listing the names of all features as keys and their
+        preprocessing flags as values. When using a numpy feature matrix X with
+        no column names the keys of the feature properties are the column
+        indices.
+
+    Returns
+    -------
+    int
+        feature property
+    """
+    if feature_properties is None:
+        return flags.IS_CONTINUOUS
+    else:
+        try:
+            fprop = feature_properties[col]
+            flags.check_flags_consistency(fprop)
+        except KeyError:
+            _logger.warning("Column '%s' not found in " "feature_properties dict." % col)
+            fprop = None
+        return fprop
+
+
+def minimal_difference(values):
+    """Minimal difference of consecutive array values
+    excluding zero differences.
+
+    :param values: Array values
+    :type values: :class:`numpy.ndarray` with dim=1.
+    """
+    bin_widths = values[1:] - values[:-1]
+    bin_widths = bin_widths[bin_widths > 0]
+
+    if len(bin_widths) > 0:
+        return np.min(bin_widths)
+    else:
+        return 1
+
+
+def get_column_index(X, column_name_or_index):
+    """Integer column index of pandas.Dataframe or numpy.ndarray.
+
+    :param X: input matrix
+    :type X: numpy.ndarray(dim=2) or pandas.DataFrame
+
+    :param column_name_or_index: column name or index
+    :type column_name_or_index: string or int
+
+    :rtype: int
+    """
+    if isinstance(X, pd.DataFrame):
+        return list(X.columns).index(column_name_or_index)
+    else:
+        return column_name_or_index
+
+
+def get_bin_bounds(binners, feat_group):
+    """
+    Gets the bin boundaries for each feature group.
+
+    Parameters
+    ----------
+    binners: list
+        List of binners.
+    feat_group: str or tuple of str
+        A feature property for which the bin boundaries should be extracted
+        from the binners.
+    """
+    if binners is None:
+        return None
+    bin_bounds = {}
+    for binner in binners:
+        bin_bounds.update(binner.get_feature_bin_boundaries())
+    if feat_group in bin_bounds and bin_bounds[feat_group] is not None:
+        return bin_bounds[feat_group][:, 0]
+    else:
+        return None
+
+
+def check_frame_empty(X):
+    """Check if a :class:`pd.DataFrame` or a :class:`numpy.ndarray`
+    is empty.
+
+    :param X: input matrix
+    :type X: :class:`pd.DataFrame` or a :class:`numpy.ndarray`
+    """
+    if isinstance(X, pd.DataFrame):
+        return X.empty
+    else:
+        return X.size == 0

--- a/skpro/libs/cyclic_boosting/binning/_utils.py
+++ b/skpro/libs/cyclic_boosting/binning/_utils.py
@@ -1,4 +1,3 @@
-
 import logging
 
 import numpy as np
@@ -37,7 +36,9 @@ def _read_feature_property(col, feature_properties=None):
             fprop = feature_properties[col]
             flags.check_flags_consistency(fprop)
         except KeyError:
-            _logger.warning("Column '%s' not found in " "feature_properties dict." % col)
+            _logger.warning(
+                "Column '%s' not found in " "feature_properties dict." % col
+            )
             fprop = None
         return fprop
 

--- a/skpro/libs/cyclic_boosting/binning/bin_number_transformer.py
+++ b/skpro/libs/cyclic_boosting/binning/bin_number_transformer.py
@@ -1,0 +1,245 @@
+
+import logging
+
+import numpy as np
+import pandas as pd
+
+from skpro.libs.cyclic_boosting import flags
+
+from ._binary_search import eq_multi, ge_multi
+from ._utils import _read_feature_property, check_frame_empty
+from .ecdf_transformer import ECdfTransformer
+
+from typing import Union, Optional
+
+MISSING_VALUE_AS_BINNO = -1
+
+_logger = logging.getLogger(__name__)
+
+
+class BinNumberTransformer(ECdfTransformer):
+    r"""This transformer bins feature-variables in ``X`` into integral bins,
+    depending on each feature's *feature property*. Features
+    with discrete preprocessing (not continuous, but ordered or unordered) are
+    enumerated by their unique values, ascending from the lowest (Thus, a
+    column with ``10, 11, 12`` would be binned as ``0, 1, 2``).
+
+    If no ``feature_properties`` are passed, all columns in ``X`` are treated
+    as :obj:`cyclic_boosting.flags.IS_CONTINUOUS`. If a ``feature_properties``
+    dictionary is supplied, it must contain feature properties for each feature
+    in ``X``.
+
+    Not-a-number values in the input feature matrix are mapped to
+    :obj:`cyclic_boosting.binning.MISSING_VALUE_AS_BINNO` in the transform
+    step. This value can then be treated as a missing value by Cyclic Boosting.
+
+    The feature property :obj:`cyclic_boosting.flags.HAS_MAGIC_INT_MISSING`
+    enables missing-value treatment for values of -999 and -9 in integer-typed
+    feature columns (for both continuous and non-continuous features).
+
+    Binning is performed for each feature-column individually. For example, two
+    columns with the same value range can end up with totally different bin
+    numbers. Also, the ``n_bins`` argument which is typically an integer, can
+    be indivualized by passing a dict that provides column-names and the
+    respective number of bins, that should be used for continuous
+    preprocessing.
+
+    During the fit, all features are treated in the same way as in
+    :class:`ECdfTransformer`. During the transform step, each feature value is
+    transformed to the number of its feature bin.  The range of bin numbers
+    is::
+
+      [0, trans.bins_and_cdfs_[feature_no][1].shape[0] - 1)
+
+    For the **estimated parameters** see :class:`ECdfTransformer`.
+
+    Parameters
+    ----------
+    n_bins: int
+        Maximum number of bins used to estimate the empirical CDF. ``n_bins`` is
+        ignored for features with discrete preprocessing.
+        If a dict is passed, the feature names/indices should be the keys and the
+        n_bins are the values. Example : ``{'feature a': 150, 'feature b': 20}``
+
+    feature_properties: dict
+        Dictionary listing the names of all features as keys and their
+        preprocessing flags as values. When using a numpy feature matrix X with
+        no column names the keys of the feature properties are the column
+        indices.
+
+    weight_column: str or int
+        Optional column label or column index for the weight column. If not set
+        all samples receive the same weight 1.
+
+    epsilon: float
+        Used thresholds for the comparison of float values:
+
+         * ``epsilon * 1.0`` for the comparison of CDF values
+         * ``epsilon * minimal_bin_width`` for the comparison with bin
+           boundaries of a given feature
+
+        Default value for epsilon: 1e-9
+
+    tolerance: double
+        Relative tolerance of the minimum bin weight. (E.g.
+        if you specify 100 bins and a tolerance of 0.05 the bins are
+        required to have only 0.95% of the total bin weights instead of
+        1.0%)
+
+    Examples
+    --------
+
+    >>> feature_1 = np.asarray([2.1, 2.2, 2.5, 3.1, 3.3, 3.7, 4.1, 4.4])
+    >>> X = np.c_[feature_1]
+
+    >>> from skpro.libs.cyclic_boosting.binning import BinNumberTransformer
+    >>> trans = BinNumberTransformer(n_bins=4, epsilon=1e-8)
+    >>> trans = trans.fit(X)
+
+    >>> # only one input column
+    >>> column, epsilon, bins_cdfs = trans.bins_and_cdfs_[0]
+    >>> assert column == 0, np.allclose(epsilon, 1e-8 * 0.1)
+    >>> bins_cdfs
+    array([[ 2.1 ,  0.  ],
+           [ 2.2 ,  0.25],
+           [ 3.1 ,  0.5 ],
+           [ 3.7 ,  0.75],
+           [ 4.4 ,  1.  ]])
+
+    >>> X_test = np.c_[[1.9, 2.15, 2.4, 2.2, 3.6, 3.5, 4.3, 5.1]]
+    >>> trans.transform(X_test)
+    array([[0],
+           [0],
+           [1],
+           [0],
+           [2],
+           [2],
+           [3],
+           [3]], dtype=int8)
+    """
+
+    def __init__(
+        self,
+        n_bins=100,
+        feature_properties=None,
+        weight_column=None,
+        epsilon=1e-9,
+        tolerance=0.1,
+        inplace=False,
+    ):
+        self.n_bins = n_bins
+        self.feature_properties = feature_properties
+        self.weight_column = weight_column
+        self.epsilon = epsilon
+        self.tolerance = tolerance
+        self.nan_representation = MISSING_VALUE_AS_BINNO
+        self.inplace = inplace
+        ECdfTransformer.__init__(
+            self,
+            n_bins=self.n_bins,
+            feature_properties=self.feature_properties,
+            weight_column=self.weight_column,
+            epsilon=self.epsilon,
+            tolerance=self.tolerance,
+        )
+
+    def _transform_one_feature(self, X, feature_prop, col, epsilon, bins_and_cdfs):
+        xt = column_selector(X, col).astype(np.float64)
+
+        def is_finite(x):
+            if flags.has_magic_missing_set(feature_prop):
+                return (x != -9) & (x != -999) & np.isfinite(xt)
+            else:
+                return np.isfinite(xt)
+
+        if bins_and_cdfs is not None:
+            finite_mask = is_finite(xt)
+            xt_f = xt[finite_mask]
+
+            if flags.is_continuous_set(feature_prop):
+                ge_multi(bins_and_cdfs[1:, 0], xt_f - epsilon, 1, xt_f)
+            else:
+                eq_multi(
+                    bins_and_cdfs[1:, 0],
+                    xt_f,
+                    np.arange(len(bins_and_cdfs[1:, 0]), dtype=np.float64),
+                    epsilon,
+                    xt_f,
+                )
+
+            xt[finite_mask] = xt_f
+            # re_check for nans, which may have been brought in by the
+            # binary search (values out of bounds)
+            xt[~is_finite(xt)] = MISSING_VALUE_AS_BINNO
+        else:
+            xt = MISSING_VALUE_AS_BINNO
+        return xt
+
+    def transform(
+        self, X_orig: Union[pd.DataFrame, np.ndarray], y: Optional[np.ndarray] = None
+    ) -> Union[pd.DataFrame, np.ndarray]:
+        self._check_input_for_transform(X_orig)
+
+        if not self.inplace:
+            X = X_orig.copy()
+        else:
+            X = X_orig
+
+        if check_frame_empty(X):
+            if isinstance(X, pd.DataFrame):
+                X = X.astype({col: np.int8 for col, _, _ in self.bins_and_cdfs_})
+            else:
+                return _as_int_array_of_minimum_dtype(X)
+
+            return X
+
+        n_transformed_features = len(self.bins_and_cdfs_)
+
+        for col, epsilon, bins_and_cdfs in self.bins_and_cdfs_:
+            feature_prop = _read_feature_property(col, self.feature_properties)
+
+            if feature_prop is None:
+                pass
+            else:
+                xt = self._transform_one_feature(X, feature_prop, col, epsilon, bins_and_cdfs)
+                column_setter(X, col, xt)
+
+        if not isinstance(X, pd.DataFrame) and n_transformed_features == X.shape[1]:
+            X = _as_int_array_of_minimum_dtype(X)
+        return X
+
+    def get_feature_bin_boundaries(self):
+        return {feature: probas for feature, epsilon, probas in self.bins_and_cdfs_}
+
+
+def column_selector(X, column):
+    """Dispatches to column selection via pandas or numpy, depending on the type of X"""
+    if isinstance(X, pd.DataFrame):
+        return X[column].values
+    else:
+        return X[:, int(column)]
+
+
+def _as_int_array_of_minimum_dtype(arr):
+    if isinstance(arr, int):
+        maximum = abs(arr)
+    elif len(arr) == 0:
+        maximum = 0
+    else:
+        maximum = max(arr.max(), abs(arr.min()))
+    if maximum <= np.iinfo(np.int8).max:
+        return np.asarray(arr, dtype=np.int8)
+    elif maximum <= np.iinfo(np.int16).max:
+        return np.asarray(arr, dtype=np.int16)
+    elif maximum <= np.iinfo(np.int32).max:
+        return np.asarray(arr, dtype=np.int32)
+    else:
+        return np.asarray(arr, dtype=np.int64)
+
+
+def column_setter(X, column, rhs):
+    """Dispatches to column selection via pandas or numpy, depending on the type of X"""
+    if isinstance(X, pd.DataFrame):
+        X[column] = _as_int_array_of_minimum_dtype(rhs)
+    else:
+        X[:, int(column)] = rhs

--- a/skpro/libs/cyclic_boosting/binning/bin_number_transformer.py
+++ b/skpro/libs/cyclic_boosting/binning/bin_number_transformer.py
@@ -1,5 +1,5 @@
-
 import logging
+from typing import Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -9,8 +9,6 @@ from skpro.libs.cyclic_boosting import flags
 from ._binary_search import eq_multi, ge_multi
 from ._utils import _read_feature_property, check_frame_empty
 from .ecdf_transformer import ECdfTransformer
-
-from typing import Union, Optional
 
 MISSING_VALUE_AS_BINNO = -1
 
@@ -201,7 +199,9 @@ class BinNumberTransformer(ECdfTransformer):
             if feature_prop is None:
                 pass
             else:
-                xt = self._transform_one_feature(X, feature_prop, col, epsilon, bins_and_cdfs)
+                xt = self._transform_one_feature(
+                    X, feature_prop, col, epsilon, bins_and_cdfs
+                )
                 column_setter(X, col, xt)
 
         if not isinstance(X, pd.DataFrame) and n_transformed_features == X.shape[1]:

--- a/skpro/libs/cyclic_boosting/binning/ecdf_transformer.py
+++ b/skpro/libs/cyclic_boosting/binning/ecdf_transformer.py
@@ -1,0 +1,570 @@
+
+import logging
+from collections import defaultdict
+from typing import Union, Optional, List
+
+import numpy as np
+import pandas as pd
+import sklearn.base as sklearnb
+
+from skpro.libs.cyclic_boosting import flags
+
+from ._binary_search import eq_multi, ge_lim, le_interp_multi
+from ._utils import (
+    _read_feature_property,
+    check_frame_empty,
+    get_column_index,
+    minimal_difference,
+)
+
+_logger = logging.getLogger(__name__)
+
+
+class ConstFunction(object):
+    def __init__(self, val):
+        self.val = val
+
+    def __call__(self):
+        return self.val
+
+
+class ECdfTransformer(sklearnb.BaseEstimator, sklearnb.TransformerMixin):
+    r"""Transform features to the empirical CDF scale of the training data.
+
+    CDF = :math:`P\left(X \leq x\right)` = cumulative distribution function.
+    See `CDF on wikipedia
+    <http://en.wikipedia.org/wiki/Cumulative_distribution_function>`_
+
+    Each feature found in ``feature_properties`` is considered in separation.
+
+    In :meth:`fit`, (up to) ``n_bins`` bin boundaries with approximately equal
+    number of data points are determined.  For discrete values, the complete CDF
+    is stored and ``n_bins`` is ignored.
+
+    In :meth:`transform`, each feature value is associated with the
+    corresponding bin by binary search. For features with
+    :obj:`cyclic_boosting.flags.IS_CONTINUOUS` set the empirical CDF is then
+    interpolated between the left and the right bin boundary.  For out-of-range
+    features, the bin boundaries are taken.  For features with
+    :obj:`cyclic_boosting.flags.IS_ORDERED` or
+    :obj:`cyclic_boosting.flags.IS_UNORDERED` only values that have been seen
+    in the fit are transformed to the corresponding empirical CDF values. For
+    all values, not within epsilon of the values seen in the fit, `numpy.nan`
+    is returned. Missing values(:obj:`numpy.nan`) stay missing values and are
+    not transformed regardless of the ``feature_properties`` set and feature
+    values seen in :meth:`fit`. For all features the feature property
+    :obj:`cyclic_boosting.flags.HAS_MISSING` is assumed.
+
+    Parameters
+    ----------
+
+    n_bins: int, dict
+        Maximum number of bins used to estimate the empirical CDF.  ``n_bins``
+        is ignored for features with discrete preprocessing.
+        If a dict is passed, the feature names/indices should be the keys and the
+        n_bins are the values. Example : ``{'feature a': 150, 'feature b': 20}``
+
+    feature_properties: dict
+        Dictionary listing the names of all features as keys and their
+        preprocessing flags as values. When using a numpy feature matrix X with
+        no column names the keys of the feature properties are the column
+        indices.  If no ``feature_properties`` are passed, all columns in ``X``
+        are treated as `cyclic_boosting.flags.IS_CONTINUOUS`.  For more
+        information about feature properties:
+
+        .. seealso::
+            :mod:`cyclic_boosting.flags`
+
+    weight_column
+        Optional column label or column index for the weight column.  If not set
+        all samples receive the same weight 1.
+
+    epsilon: float
+        Used thresholds for the comparison of float values:
+
+         * ``epsilon * 1.0`` for the comparison of CDF values
+         * ``epsilon * minimal_bin_width`` for the comparison with bin
+           boundaries of a given feature
+
+        Default value for epsilon: 1e-9
+
+    tolerance: double
+        Relative tolerance of the minimum bin weight. (E.g.
+        if you specify 100 bins and a tolerance of 0.05 the bins are
+        required to have only 0.95% of the total bin weights instead of
+        1.0%)
+
+
+    **Guarantees for continuous features**
+    (cyclic_boosting.flags.IS_CONTINUOUS set for feature)
+
+    * The estimated number of bins :math:`n_\text{bins\_estimated}` is always
+      smaller equal than the number of bins
+      requested by the user :math:`n_\text{bins}`.
+
+      .. math::
+          n_\text{bins\_estimated} \leq n_\text{bins}
+
+    * The bin boundaries are chosen such that each bin contains at least
+      a fraction of :math:`\frac{1}{n_\text{bins}}` of all values.
+
+    **Guarantees for discrete features**
+    (flags.UNORDERED or flags.ORDERED set for feature)
+
+    * The estimated number of bins :math:`n_\text{bins\_estimated}` is equal
+      to the number of unique values :math:`n_\text{unique\_values}` found.
+
+      .. math::
+           n_\text{bins\_estimated} \Leftrightarrow n_\text{unique\_values}
+
+    **Estimated parameters**
+
+    Attributes
+    ----------
+    bins_and_cdfs_
+        For each feature, a tuple containing
+
+         * the column name or index
+         * the epsilon used for comparisons to bin boundaries; it is the
+           constructor parameter ``epsilon`` multiplied by the smallest bin
+           width
+
+         * and the :class:`numpy.ndarray` of shape ``(at most n_bins + 1, 2)``
+
+           This is a matrix containing the **bin boundaries** (column 0) and
+           the **corresponding cumulative probabilities** (column 1) is
+           learned in the fit. The matrix looks for one feature ``x`` like this:
+
+           .. math::
+              \begin{pmatrix}
+              x_\text{min} & P\left(X < x_\text{min}\right) = 0 \\
+              x_\text{boundary1} & P\left(X \leq x_\text{boundary1}\right) \\
+              x_\text{boundary2} & P\left(X \leq x_\text{boundary2}\right) \\
+              \ldots & \ldots \\
+              x_\text{max} & P\left(X \leq x_\text{max}\right) = 1 \\
+              \end{pmatrix}
+
+           For mixed discrete and continuous features, there might be fewer than
+           ``n_bins`` bins. For discrete features ``n_bins`` is ignored and
+           the ``cdf`` is calculated for each unique value.
+           type of `bins_and_cdfs_`: item :obj:`list` of :obj:`tuple`
+
+    Examples
+    --------
+
+    >>> feature_1 = np.asarray([2.1, 2.2, 2.5, 3.1, 3.3, 3.7, 4.1, 4.4])
+    >>> X = np.c_[feature_1]
+    >>> eps = 1e-8
+
+    >>> from skpro.libs.cyclic_boosting.binning import ECdfTransformer
+    >>> trans = ECdfTransformer(n_bins=4, epsilon=eps)
+    >>> trans = trans.fit(X)
+
+    >>> # only one input column
+    >>> column, epsilon, bins_cdfs = trans.bins_and_cdfs_[0]
+    >>> assert column == 0 and np.allclose(epsilon, eps * 0.1)
+    >>> bins_cdfs
+    array([[ 2.1 ,  0.  ],
+           [ 2.2 ,  0.25],
+           [ 3.1 ,  0.5 ],
+           [ 3.7 ,  0.75],
+           [ 4.4 ,  1.  ]])
+
+    >>> X_test = np.c_[[1.9, 2.4, 2.2, 3.6, 3.5, 4.3, 5.1]]
+    >>> trans.transform(X_test)
+    array([[ 0.        ],
+           [ 0.30555556],
+           [ 0.25      ],
+           [ 0.70833333],
+           [ 0.66666667],
+           [ 0.96428571],
+           [ 1.        ]])
+    """
+
+    def __init__(
+        self,
+        n_bins=100,
+        feature_properties=None,
+        weight_column=None,
+        epsilon=1e-9,
+        tolerance=0.1,
+    ):
+        self.n_bins = n_bins
+        self.feature_properties = feature_properties
+        self.weight_column = weight_column
+        self.epsilon = epsilon
+        self.tolerance = tolerance
+        self.bins_and_cdfs_ = None
+
+    @staticmethod
+    def _normalize_bins(n_bins):
+        if isinstance(n_bins, int):
+            return defaultdict(ConstFunction(n_bins))
+        else:
+            return n_bins
+
+    def fit(self, X, y=None):
+        self._nbins_per_feature = self._normalize_bins(self.n_bins)
+        self.bins_and_cdfs_ = []
+
+        if check_frame_empty(X):
+            raise ValueError("Your input matrix for the binning is empty.")
+
+        feature_columns = get_feature_column_names_or_indices(X, exclude_columns=[self.weight_column])
+        weights = get_weight_column(X, self.weight_column)
+
+        for col in feature_columns:
+            _logger.info("{0} column: {1}".format(self.__class__.__name__, col))
+            x_col = get_X_column(X, col)
+
+            feature_prop = _read_feature_property(col, self.feature_properties)
+
+            if feature_prop is None:
+                continue
+
+            bins_x, cdf_x, _wsum, _n_nan = calculate_cdf_from_weighted_data(x_col.astype(float), weights)
+
+            if len(bins_x) == 0 or len(cdf_x) == 0:
+                self.bins_and_cdfs_.append((col, self.epsilon, None))
+                continue
+
+            if flags.is_ordered_set(feature_prop) or flags.is_unordered_set(feature_prop):
+                bin_boundaries = np.r_[bins_x[0], bins_x]
+                cdf = np.r_[0.0, cdf_x]
+            else:
+                bin_boundaries, cdf = reduce_cdf_and_boundaries_to_nbins(
+                    bins_x,
+                    cdf_x,
+                    self._nbins_per_feature[col],
+                    self.epsilon,
+                    self.tolerance,
+                )
+
+            n = len(cdf)
+            bins_and_cdfs = np.empty((n, 2))
+            bins_and_cdfs[:, 0] = bin_boundaries
+            bins_and_cdfs[:, 1] = cdf
+
+            epsilon = self.epsilon * minimal_difference(bin_boundaries)
+
+            self.bins_and_cdfs_.append((col, epsilon, bins_and_cdfs))
+        return self
+
+    def _check_input_for_transform(self, X):
+        if self.bins_and_cdfs_ is None:
+            raise RuntimeError("Fit was not called before.")
+
+        columns = get_feature_column_names_or_indices(X, exclude_columns=[self.weight_column])
+        if self.feature_properties is not None:
+            columns = [col for col in columns if col in self.feature_properties]
+        n_cols = len(columns)
+        if n_cols != len(self.bins_and_cdfs_):
+            raise ValueError(
+                "Input Matrix X has not the same number"
+                " of feature columns (%s) as "
+                "the matrix in the fit (%s)." % (n_cols, len(self.bins_and_cdfs_))
+            )
+
+    def transform(self, X, y=None):
+        self._check_input_for_transform(X)
+
+        if check_frame_empty(X):
+            return X
+
+        Xnp = np.asarray(X, dtype=float)
+        Xt = Xnp
+
+        for col, epsilon, bins_and_cdfs in self.bins_and_cdfs_:
+            j = get_column_index(X, col)
+            feature_property = _read_feature_property(col, self.feature_properties)
+
+            if feature_property is None:
+                continue
+
+            if bins_and_cdfs is not None:
+                if flags.is_continuous_set(feature_property):
+                    le_interp_multi(
+                        bins_and_cdfs[:, 0],
+                        Xnp[:, j],
+                        bins_and_cdfs[:, 1],
+                        0.0,
+                        epsilon,
+                        Xt[:, j],
+                    )
+                else:
+                    eq_multi(
+                        bins_and_cdfs[:, 0],
+                        Xnp[:, j],
+                        bins_and_cdfs[:, 1],
+                        epsilon,
+                        Xt[:, j],
+                    )
+
+            elif bins_and_cdfs is None:
+                Xnp[:, j] = np.nan
+
+        if isinstance(X, pd.DataFrame):
+            return pd.DataFrame(Xt, columns=X.columns)
+        else:
+            return Xt
+
+
+def get_feature_column_names_or_indices(
+    X: Union[pd.DataFrame, np.ndarray], exclude_columns: Optional[Union[List[str], List[int]]] = None
+) -> Union[List[str], List[int]]:
+    """
+    Extract the column names from `X`. If `X` is a numpy matrix
+    each column is labeled with an integer starting from zero.
+
+    :param X: input matrix
+    :type X: numpy.ndarray(dim=2) or pandas.DataFrame
+
+    :param exclude_columns: column names or indices to omit.
+    :type exclude_columns: list of int or str
+
+    :rtype: list
+
+    >>> X = np.c_[[0, 1], [1,0], [3, 5]]
+    >>> from skpro.libs.cyclic_boosting.binning import get_feature_column_names_or_indices
+    >>> get_feature_column_names_or_indices(X)
+    [0, 1, 2]
+
+    >>> get_feature_column_names_or_indices(X, exclude_columns=[1])
+    [0, 2]
+
+    >>> get_feature_column_names_or_indices(X, exclude_columns=[1, 1])
+    [0, 2]
+
+    >>> get_feature_column_names_or_indices(X, exclude_columns=[0, 1, 2])
+    []
+
+    >>> X = pd.DataFrame(X, columns = ['b', 'c', 'a'])
+    >>> get_feature_column_names_or_indices(X, exclude_columns=['a'])
+    ['b', 'c']
+
+    >>> get_feature_column_names_or_indices(X, exclude_columns=['d'])
+    ['b', 'c', 'a']
+    """
+    if isinstance(X, pd.DataFrame):
+        columns = list(X.columns)
+    elif isinstance(X, np.ndarray):
+        assert X.ndim == 2, "X must be a 2D matrix"
+        columns = list(range(0, X.shape[1]))
+    else:
+        raise ValueError("X must be a pandas.DataFrame or a numpy.ndarray")
+
+    if exclude_columns is not None:
+        exclude_columns = set(exclude_columns)
+        return [x for x in columns if x not in exclude_columns]
+    else:
+        return columns
+
+
+def get_weight_column(X, weight_column=None):
+    """
+    Check if a weight column is present and return it if
+    possible. If no weight columns is present in `X` a
+    weight column with only ``ones`` of same length than
+    `X` is created and returned.
+
+    :param X: Samples feature matrix.
+    :type X: numpy.ndarray(dim=2) or pandas.DataFrame
+
+    :param weight_column: Name or index of the weight column or None.
+    :type weight_column: int or string or ``NoneType``
+
+    :rtype: numpy.ndarray
+
+    >>> X = np.c_[[0., 1], [1,0], [3, 5]]
+    >>> from skpro.libs.cyclic_boosting.binning import get_weight_column
+    >>> get_weight_column(X)
+    array([ 1.,  1.])
+    >>> get_weight_column(X, 0)
+    array([ 0.,  1.])
+    >>> get_weight_column(X, 2)
+    array([ 3.,  5.])
+
+    >>> X = pd.DataFrame(X, columns = ['b', 'c', 'a'])
+    >>> get_weight_column(X)
+    array([ 1.,  1.])
+
+    >>> get_weight_column(X, 'c')
+    array([ 1.,  0.])
+    """
+    if weight_column is not None:
+        if isinstance(X, pd.DataFrame):
+            try:
+                return np.asarray(X[weight_column])
+            except:
+                raise ValueError("Weight column {} not found in X.".format(str(weight_column)))
+        else:
+            try:
+                return X[:, weight_column]
+            except:
+                raise ValueError("Index {} defining weight column not found in X.".format(str(weight_column)))
+    else:
+        return np.ones(X.shape[0], dtype=np.float64)
+
+
+def reduce_cdf_and_boundaries_to_nbins(bins_x, cdf_x, n_bins, epsilon, tolerance):
+    """
+    Section the cdf spectrum into `n_bin` parts of equal statistics, and find
+    all events beloning into these bins by filtering all suitable events in
+    the event-wise `cdf_x` array.
+
+    Often, events cannot be distributed exactly with equal statistics over all
+    bins, therefore the ``tolerance`` argument allows for bins to be of a weight
+    below  1.0 / n_bins.
+
+    A minimum weight of 1.0 / n_bins - tolerance per bin is guaranteed.
+
+    This function is used internally in the method
+    :meth:`cyclic_boosting.binning.ECdfTransformer`.
+
+    Parameters
+    ----------
+    bins_x: np.ndarray
+        strictly increasing array containing all bin boundaries, length is the
+        number of evenets.
+
+    cdf_x: np.ndarray
+        Strictly increasing array containing the cdf values corresponding to the
+        bin boundaries in `bin_x`.  Contains one value for each event.
+
+    n_bins: int
+        Maximum number of bins that ought to be returned. This also determines
+        the minimum weight per bin, which is 1 / n_bins.
+
+    epsilon: double
+        Threshold for the comparison of CDFs
+
+    tolerance: double
+        Relative tolerance of the minimum bin weight. (E.g.
+        if you specify 100 bins and a tolerance of 0.05 the bins are
+        required to have only 0.95% of the total bin weights instead of
+        1.0%)
+
+    Returns
+    -------
+    The ``reduced`` input arrays `bins_x` and `cdf_x`, now with **maximum**
+    length n_bins, tuple of numpy.ndarrays(dim=1)
+    """
+    if n_bins < 2:
+        raise ValueError("N_bins = %s has to greater than 1!", n_bins)
+
+    n_cdf = n_bins + 1
+
+    bin_boundaries = np.zeros(n_cdf, dtype=np.float64)
+    cdf = np.zeros(n_cdf, dtype=np.float64)
+
+    bin_boundaries[0] = bins_x[0]
+
+    n = cdf_x.shape[0]
+    index = 0
+    cdf_share = 1.0 / n_bins
+    previous_cdf = 0.0
+
+    for i in range(1, n_bins + 1):
+        cdf_rest = previous_cdf % cdf_share
+        cdf_searched = previous_cdf + cdf_share
+
+        if cdf_rest <= tolerance * cdf_share:
+            cdf_searched -= cdf_rest
+
+        if cdf_searched <= 1.0 + tolerance * cdf_share:
+            index = ge_lim(cdf_x, cdf_searched - epsilon, 1, index, n)
+
+            previous_cdf = cdf_x[index]
+            cdf[i] = cdf_x[index]
+            bin_boundaries[i] = bins_x[index]
+        else:
+            cdf[i - 1] = 1.0
+            bin_boundaries[i - 1] = bins_x[n - 1]
+            n_cdf = i
+            break
+    return np.array(bin_boundaries[:n_cdf]), np.array(cdf[:n_cdf])
+
+
+def get_X_column(X, column, array_for_1_dim=True):
+    """
+    Picks columns from :class:`pandas.DataFrame` or :class:`numpy.ndarray`.
+
+    Parameters
+    ----------
+    X: :class:`pandas.DataFrame` or :class:`numpy.ndarray`
+        Data Source from which columns are picked.
+    column:
+        The format depends on the type of X. For :class:`pandas.DataFrame` you
+        can give a string or a list/tuple of strings naming the columns. For
+        :class:`numpy.ndarray` an integer or a list/tuple of integers indexing
+        the columns.
+    array_for_1_dim: bool
+        In default mode (set to True) the return type for a one dimensional
+        access is a np.ndarray with shape (n, ). If set to False it is a
+        np.ndarray with shape (1, n).
+    """
+    if isinstance(column, tuple):
+        column = list(column)
+    if not array_for_1_dim:
+        if not isinstance(column, list):
+            column = [column]
+    else:
+        if isinstance(column, list) and len(column) == 1:
+            column = column[0]
+    if isinstance(X, pd.DataFrame):
+        return X[column].values
+    else:
+        return X[:, column]
+
+
+def calculate_cdf_from_weighted_data(z, w):
+    """
+    Calculate the cdf value for each unique value in `z` weighted with the
+    sample weights in `w`. All values not finite values in `z`
+    and unique values of z with weight zero are ignored.
+
+    Parameters
+    ----------
+    z: numpy.ndarray of float64
+        input array
+
+    w: numpy.ndarray
+        sample weights
+
+
+    Returns
+    -------
+    tuple of two :class:`numpy.ndarray`, a double and an int
+        Tuple consisting of an array containing the valid unique `z`
+        values, an array containing the cdf values for the valid `z` values,
+        the total weight sum and the number of non finite values in `z`.
+
+    Examples
+    --------
+    >>> z = np.array([1., 2., 3., 4., 5., 6., np.nan, 6.])
+    >>> w = np.array([4., 2., 2., 1., 0., 1., 1.,     0.])
+    >>> z_unique, cdfs, wsum, n_nan = calculate_cdf_from_weighted_data(z, w)
+    >>> wsum
+    10.0
+    >>> n_nan
+    1
+    >>> z_unique  # array of unique values of z
+    array([ 1.,  2.,  3.,  4.,  6.])
+    >>> cdfs  # corresponding cdf values to z_unique
+    array([ 0.4,  0.6,  0.8,  0.9,  1. ])
+    """
+    if z.shape[0] != w.shape[0]:
+        raise ValueError("input vectors must be of same shape")
+
+    n_nan = np.count_nonzero(np.isnan(z))
+    z_unique = np.unique(z[~np.isnan(z)])
+
+    wsum = np.nansum(w[~np.isnan(z)])
+
+    # Accumulate the weights for the unique values.
+    uniques = pd.DataFrame({"z": z, "w": w}).groupby(["z"]).agg({"w": "sum"}).reset_index()
+    uniques = uniques.loc[uniques["w"] != 0]
+
+    cdf = np.nancumsum(uniques["w"]) / wsum
+
+    return z_unique, cdf, wsum, n_nan

--- a/skpro/libs/cyclic_boosting/binning/ecdf_transformer.py
+++ b/skpro/libs/cyclic_boosting/binning/ecdf_transformer.py
@@ -1,7 +1,6 @@
-
 import logging
 from collections import defaultdict
-from typing import Union, Optional, List
+from typing import List, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -20,7 +19,7 @@ from ._utils import (
 _logger = logging.getLogger(__name__)
 
 
-class ConstFunction(object):
+class ConstFunction:
     def __init__(self, val):
         self.val = val
 
@@ -210,11 +209,13 @@ class ECdfTransformer(sklearnb.BaseEstimator, sklearnb.TransformerMixin):
         if check_frame_empty(X):
             raise ValueError("Your input matrix for the binning is empty.")
 
-        feature_columns = get_feature_column_names_or_indices(X, exclude_columns=[self.weight_column])
+        feature_columns = get_feature_column_names_or_indices(
+            X, exclude_columns=[self.weight_column]
+        )
         weights = get_weight_column(X, self.weight_column)
 
         for col in feature_columns:
-            _logger.info("{0} column: {1}".format(self.__class__.__name__, col))
+            _logger.info(f"{self.__class__.__name__} column: {col}")
             x_col = get_X_column(X, col)
 
             feature_prop = _read_feature_property(col, self.feature_properties)
@@ -222,13 +223,17 @@ class ECdfTransformer(sklearnb.BaseEstimator, sklearnb.TransformerMixin):
             if feature_prop is None:
                 continue
 
-            bins_x, cdf_x, _wsum, _n_nan = calculate_cdf_from_weighted_data(x_col.astype(float), weights)
+            bins_x, cdf_x, _wsum, _n_nan = calculate_cdf_from_weighted_data(
+                x_col.astype(float), weights
+            )
 
             if len(bins_x) == 0 or len(cdf_x) == 0:
                 self.bins_and_cdfs_.append((col, self.epsilon, None))
                 continue
 
-            if flags.is_ordered_set(feature_prop) or flags.is_unordered_set(feature_prop):
+            if flags.is_ordered_set(feature_prop) or flags.is_unordered_set(
+                feature_prop
+            ):
                 bin_boundaries = np.r_[bins_x[0], bins_x]
                 cdf = np.r_[0.0, cdf_x]
             else:
@@ -254,7 +259,9 @@ class ECdfTransformer(sklearnb.BaseEstimator, sklearnb.TransformerMixin):
         if self.bins_and_cdfs_ is None:
             raise RuntimeError("Fit was not called before.")
 
-        columns = get_feature_column_names_or_indices(X, exclude_columns=[self.weight_column])
+        columns = get_feature_column_names_or_indices(
+            X, exclude_columns=[self.weight_column]
+        )
         if self.feature_properties is not None:
             columns = [col for col in columns if col in self.feature_properties]
         n_cols = len(columns)
@@ -310,7 +317,8 @@ class ECdfTransformer(sklearnb.BaseEstimator, sklearnb.TransformerMixin):
 
 
 def get_feature_column_names_or_indices(
-    X: Union[pd.DataFrame, np.ndarray], exclude_columns: Optional[Union[List[str], List[int]]] = None
+    X: Union[pd.DataFrame, np.ndarray],
+    exclude_columns: Optional[Union[List[str], List[int]]] = None,
 ) -> Union[List[str], List[int]]:
     """
     Extract the column names from `X`. If `X` is a numpy matrix
@@ -396,12 +404,14 @@ def get_weight_column(X, weight_column=None):
             try:
                 return np.asarray(X[weight_column])
             except:
-                raise ValueError("Weight column {} not found in X.".format(str(weight_column)))
+                raise ValueError(f"Weight column {str(weight_column)} not found in X.")
         else:
             try:
                 return X[:, weight_column]
             except:
-                raise ValueError("Index {} defining weight column not found in X.".format(str(weight_column)))
+                raise ValueError(
+                    f"Index {str(weight_column)} defining weight column not found in X."
+                )
     else:
         return np.ones(X.shape[0], dtype=np.float64)
 
@@ -562,7 +572,9 @@ def calculate_cdf_from_weighted_data(z, w):
     wsum = np.nansum(w[~np.isnan(z)])
 
     # Accumulate the weights for the unique values.
-    uniques = pd.DataFrame({"z": z, "w": w}).groupby(["z"]).agg({"w": "sum"}).reset_index()
+    uniques = (
+        pd.DataFrame({"z": z, "w": w}).groupby(["z"]).agg({"w": "sum"}).reset_index()
+    )
     uniques = uniques.loc[uniques["w"] != 0]
 
     cdf = np.nancumsum(uniques["w"]) / wsum

--- a/skpro/libs/cyclic_boosting/classification.py
+++ b/skpro/libs/cyclic_boosting/classification.py
@@ -1,0 +1,148 @@
+"""
+Cyclic Boosting Classifier
+"""
+
+
+import logging
+
+import numpy as np
+import pandas as pd
+import scipy.stats
+import sklearn.base
+
+from skpro.libs.cyclic_boosting import base as cyclic_boosting_base
+from skpro.libs.cyclic_boosting.base import CyclicBoostingBase
+from skpro.libs.cyclic_boosting.link import LogitLinkMixin
+from typing import Tuple, Optional, Union
+from skpro.libs.cyclic_boosting.features import Feature
+
+_logger = logging.getLogger(__name__)
+
+
+def get_beta_priors() -> Tuple[float, float]:
+    r"""Prior values for beta distribution. The prior distribution was chosen
+    to be Beta(1.001, 1.001), which is almost a uniform distribution but has a
+    probability density function that goes to 0 for math:`x=0` and :math:`x=1`.
+
+    Returns
+    -------
+    float
+        :math:`alpha=1.001` and :math:`beta=1.001`
+    """
+    alpha_prior = 1.001
+    beta_prior = 1.001
+    return alpha_prior, beta_prior
+
+
+def boost_weights(y: np.ndarray, prediction: np.ndarray) -> np.ndarray:
+    r"""Returns weights for bincount operations on the CBClassifier.
+
+    The weights are assigned so that they are suitable for boosting, i.e.
+    weights for well-estimated samples are low, weights for bad estimations are
+    high.
+
+    .. math::
+
+       w_i = \begin{cases} (1 - \left\langle y
+                      \right\rangle_i) & y_{\text{truth}} = 1 \\
+            \left\langle y \right\rangle_i &
+            \text{otherwise} \end{cases}
+
+    """
+    epsilon = 1e-12
+    prediction = np.where(prediction == 0.0, epsilon, prediction)
+    prediction = np.where(prediction == 1.0, 1 - epsilon, prediction)
+    return np.where(y, 1 - prediction, prediction)
+
+
+class CBClassifier(sklearn.base.ClassifierMixin, CyclicBoostingBase, LogitLinkMixin):
+    """This regressor is the cyclic boosting core algorithm for classifications
+
+    Its interface, methods and arguments are described in
+    :class:`~CyclicBoostingBase`.
+    """
+
+    def _check_y(self, y: np.ndarray) -> None:
+        """Check that y has only values 0. or 1."""
+        if not ((y == 0.0) | (y == 1.0)).all():
+            raise ValueError(
+                "The target y must be either 0 or 1 "
+                "and not NAN. y[(y != 0) & (y != 1)] = {0}".format(y[(y != 0) & (y != 1)])
+            )
+
+    def precalc_parameters(self, feature: Feature, y: np.ndarray, pred):
+        return None
+
+    def _get_posterior_dist_from_prior_dist(
+        self, alpha: np.ndarray, beta: np.ndarray
+    ) -> Tuple[scipy.stats.beta, np.ndarray, np.ndarray]:
+        """
+        Beta(1,1) is the uniform distribution, Beta(1.001, 1.001) has pdf
+        zero at 0 and 1. It is thus chosen as the prior.
+        """
+        alpha_prior, beta_prior = get_beta_priors()
+        alpha_posterior = alpha + alpha_prior
+        beta_posterior = beta + beta_prior
+        posterior = scipy.stats.beta(alpha_posterior, beta_posterior)
+        return posterior, alpha_posterior, beta_posterior
+
+    def _get_percentiles_from_distribution_parameters(
+        self, alpha_posterior: np.ndarray, beta_posterior: np.ndarray
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        Choose perc1 and perc2 for gaussian_matching_by_quantiles such that
+        for an asymmetric beta distribution, the quantiles are rather far
+        from the unsafe boundaries 0 and 1.
+
+        TODO: Why are we choosing the 0.75 and 0.25 percentiles? What is the formula for the shift?
+        """
+        shift = 0.4 * (alpha_posterior / (alpha_posterior + beta_posterior) - 0.5)
+        perc1 = 0.75 - shift
+        perc2 = 0.25 - shift
+        return perc1, perc2
+
+    def calc_parameters(self, feature: Feature, y: np.ndarray, pred, prefit_data: np.ndarray) -> Tuple[float, float]:
+        prediction = self.unlink_func(pred.predict_link())
+        boosting_weights = boost_weights(y, prediction)
+        event_weights = self.weights
+        weights = event_weights * boosting_weights
+
+        wsum, w2sum, alpha, beta = (
+            np.bincount(feature.lex_binned_data, weights=w, minlength=feature.n_bins)
+            for w in [weights, weights * boosting_weights, weights * y, weights * (1 - y)]
+        )
+
+        weight_factor = np.ones_like(wsum)
+
+        alpha *= weight_factor
+        alpha = np.where(alpha < 0, 0, alpha)
+
+        beta *= weight_factor
+        beta = np.where(beta < 0, 0, beta)
+
+        posterior, alpha_posterior, beta_posterior = self._get_posterior_dist_from_prior_dist(alpha=alpha, beta=beta)
+
+        perc1, perc2 = self._get_percentiles_from_distribution_parameters(
+            alpha_posterior=alpha_posterior, beta_posterior=beta_posterior
+        )
+
+        # actual Gaussian matching
+        (
+            factors_link,
+            uncertainties_l,
+        ) = cyclic_boosting_base.gaussian_matching_by_quantiles(
+            dist=posterior, link_func=self.link_func, perc1=perc1, perc2=perc2
+        )
+
+        return factors_link, uncertainties_l
+
+    def predict_proba(self, X: Union[pd.DataFrame, np.ndarray], y: Optional[np.ndarray] = None) -> np.ndarray:
+        probability_signal = super(CBClassifier, self).predict(X, y=y)
+        return np.c_[1 - probability_signal, probability_signal]
+
+    def predict(self, X: Union[pd.DataFrame, np.ndarray], y: Optional[np.ndarray] = None) -> np.ndarray:
+        probability_signal = super(CBClassifier, self).predict(X, y=y)
+        return np.asarray(probability_signal > 0.5, dtype=np.float64)
+
+
+__all__ = ["CBClassifier", "boost_weights", "get_beta_priors"]

--- a/skpro/libs/cyclic_boosting/classification.py
+++ b/skpro/libs/cyclic_boosting/classification.py
@@ -4,6 +4,7 @@ Cyclic Boosting Classifier
 
 
 import logging
+from typing import Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -12,9 +13,8 @@ import sklearn.base
 
 from skpro.libs.cyclic_boosting import base as cyclic_boosting_base
 from skpro.libs.cyclic_boosting.base import CyclicBoostingBase
-from skpro.libs.cyclic_boosting.link import LogitLinkMixin
-from typing import Tuple, Optional, Union
 from skpro.libs.cyclic_boosting.features import Feature
+from skpro.libs.cyclic_boosting.link import LogitLinkMixin
 
 _logger = logging.getLogger(__name__)
 
@@ -67,7 +67,9 @@ class CBClassifier(sklearn.base.ClassifierMixin, CyclicBoostingBase, LogitLinkMi
         if not ((y == 0.0) | (y == 1.0)).all():
             raise ValueError(
                 "The target y must be either 0 or 1 "
-                "and not NAN. y[(y != 0) & (y != 1)] = {0}".format(y[(y != 0) & (y != 1)])
+                "and not NAN. y[(y != 0) & (y != 1)] = {}".format(
+                    y[(y != 0) & (y != 1)]
+                )
             )
 
     def precalc_parameters(self, feature: Feature, y: np.ndarray, pred):
@@ -101,7 +103,9 @@ class CBClassifier(sklearn.base.ClassifierMixin, CyclicBoostingBase, LogitLinkMi
         perc2 = 0.25 - shift
         return perc1, perc2
 
-    def calc_parameters(self, feature: Feature, y: np.ndarray, pred, prefit_data: np.ndarray) -> Tuple[float, float]:
+    def calc_parameters(
+        self, feature: Feature, y: np.ndarray, pred, prefit_data: np.ndarray
+    ) -> Tuple[float, float]:
         prediction = self.unlink_func(pred.predict_link())
         boosting_weights = boost_weights(y, prediction)
         event_weights = self.weights
@@ -109,7 +113,12 @@ class CBClassifier(sklearn.base.ClassifierMixin, CyclicBoostingBase, LogitLinkMi
 
         wsum, w2sum, alpha, beta = (
             np.bincount(feature.lex_binned_data, weights=w, minlength=feature.n_bins)
-            for w in [weights, weights * boosting_weights, weights * y, weights * (1 - y)]
+            for w in [
+                weights,
+                weights * boosting_weights,
+                weights * y,
+                weights * (1 - y),
+            ]
         )
 
         weight_factor = np.ones_like(wsum)
@@ -120,7 +129,11 @@ class CBClassifier(sklearn.base.ClassifierMixin, CyclicBoostingBase, LogitLinkMi
         beta *= weight_factor
         beta = np.where(beta < 0, 0, beta)
 
-        posterior, alpha_posterior, beta_posterior = self._get_posterior_dist_from_prior_dist(alpha=alpha, beta=beta)
+        (
+            posterior,
+            alpha_posterior,
+            beta_posterior,
+        ) = self._get_posterior_dist_from_prior_dist(alpha=alpha, beta=beta)
 
         perc1, perc2 = self._get_percentiles_from_distribution_parameters(
             alpha_posterior=alpha_posterior, beta_posterior=beta_posterior
@@ -136,12 +149,16 @@ class CBClassifier(sklearn.base.ClassifierMixin, CyclicBoostingBase, LogitLinkMi
 
         return factors_link, uncertainties_l
 
-    def predict_proba(self, X: Union[pd.DataFrame, np.ndarray], y: Optional[np.ndarray] = None) -> np.ndarray:
-        probability_signal = super(CBClassifier, self).predict(X, y=y)
+    def predict_proba(
+        self, X: Union[pd.DataFrame, np.ndarray], y: Optional[np.ndarray] = None
+    ) -> np.ndarray:
+        probability_signal = super().predict(X, y=y)
         return np.c_[1 - probability_signal, probability_signal]
 
-    def predict(self, X: Union[pd.DataFrame, np.ndarray], y: Optional[np.ndarray] = None) -> np.ndarray:
-        probability_signal = super(CBClassifier, self).predict(X, y=y)
+    def predict(
+        self, X: Union[pd.DataFrame, np.ndarray], y: Optional[np.ndarray] = None
+    ) -> np.ndarray:
+        probability_signal = super().predict(X, y=y)
         return np.asarray(probability_signal > 0.5, dtype=np.float64)
 
 

--- a/skpro/libs/cyclic_boosting/common_smoothers.py
+++ b/skpro/libs/cyclic_boosting/common_smoothers.py
@@ -1,0 +1,356 @@
+"""Convenient smoother mappings from feature property values (and tuples) to
+typical smoothers used for the Cyclic Boosting regressor"""
+
+import logging
+
+
+
+from skpro.libs.cyclic_boosting import flags, smoothing
+from skpro.libs.cyclic_boosting.smoothing.base import AbstractBinSmoother
+from skpro.libs.cyclic_boosting.smoothing.meta_smoother import (
+    NormalizationRegressionTypeSmoother,
+    NormalizationSmoother,
+    RegressionType,
+    RegressionTypeSmoother,
+)
+
+from typing import Optional
+
+_logger = logging.getLogger(__name__)
+
+
+def _simplify_flags(feature_property: int, feature_group: Optional[str] = None):
+    """
+    Simplifies a general flag to a basic set to select a smoother later on.
+
+    Parameters
+    ----------
+    feature_property:
+        A single feature property.
+
+    feature_group:
+        Optional argument for the name of the feature/feature_group
+        corresponding to the feature_property used for logging.
+    """
+    if flags.is_linear_set(feature_property):
+        return flags.IS_LINEAR
+    elif flags.is_seasonal_set(feature_property):
+        return flags.IS_SEASONAL
+    elif flags.is_monotonic_set(feature_property):
+        if flags.increasing_set(feature_property):
+            return flags.IS_MONOTONIC | flags.INCREASING
+        elif flags.decreasing_set(feature_property):
+            return flags.IS_MONOTONIC | flags.DECREASING
+        else:
+            return flags.IS_MONOTONIC
+    elif flags.is_continuous_set(feature_property):
+        return flags.IS_CONTINUOUS
+    elif flags.is_ordered_set(feature_property):
+        return flags.IS_ORDERED
+    elif flags.is_unordered_set(feature_property):
+        return flags.IS_UNORDERED
+    else:
+        features = ""
+        if feature_group is not None:
+            features = "for feature {}".format(feature_group)
+        if flags.has_missing_set(feature_property):
+            _logger.info("No feature property set. Thus it is set to default IS_UNORDERED!")
+        else:
+            _logger.warning(
+                "Feature property {0} is not known {1}."
+                " Thus it is converted to IS_UNORDERED!".format(flags.flags_to_string(feature_property), features)
+            )
+        return flags.IS_UNORDERED
+
+
+def _default_smoother_types(neutral_factor_link=0, use_normalization=True):
+    smoother_types = {
+        flags.IS_UNORDERED: smoothing.onedim.WeightedMeanSmoother(prior_prediction=neutral_factor_link),
+        flags.IS_ORDERED: smoothing.onedim.WeightedMeanSmootherNeighbors(),
+        flags.IS_CONTINUOUS: smoothing.onedim.OrthogonalPolynomialSmoother(),
+        flags.IS_LINEAR: smoothing.extrapolate.LinearExtrapolator(),
+        flags.IS_SEASONAL:
+        # the seasonal smoother does not work with offset_tozero
+        # when the normalization is done within the smoother
+        smoothing.onedim.SeasonalSmoother(offset_tozero=not use_normalization),
+        flags.IS_MONOTONIC: smoothing.onedim.IsotonicRegressor(increasing="auto"),
+        flags.IS_MONOTONIC | flags.INCREASING: smoothing.onedim.IsotonicRegressor(increasing=True),
+        flags.IS_MONOTONIC | flags.DECREASING: smoothing.onedim.IsotonicRegressor(increasing=False),
+    }
+    return smoother_types
+
+
+def determine_reg_type(feature_group, feature_property, feature_type):
+    """Function to determine the RegressionType of a feature.
+
+    Parameters
+    ----------
+
+    feature_group: tuple
+        Name of the feature_group
+
+    feature_property: tuple
+        Tuple of feature properties.
+
+    feature_type:
+        Type of the feature.
+    """
+    if not isinstance(feature_property, tuple):
+        if flags.is_linear_set(feature_property):
+            return RegressionType.extrapolating
+        elif flags.is_seasonal_set(feature_property) or flags.is_continuous_set(feature_property):
+            return RegressionType.interpolating
+        else:
+            return RegressionType.discontinuous
+    else:
+        reg_types = [determine_reg_type(fg, fp, feature_type) for fg, fp in zip(feature_group, feature_property)]
+        if RegressionType.discontinuous in reg_types:
+            return RegressionType.discontinuous
+        elif RegressionType.interpolating in reg_types:
+            return RegressionType.interpolating
+        else:
+            return RegressionType.extrapolating
+
+
+def determine_meta_smoother(smoother, use_normalization, reg_type=None):
+    """Wrapper function that chooses the correct meta_estimators
+    for the smoothers in the SmootherChoice class.
+
+    Parameters
+    ----------
+
+    smoother: :class:`AbstractBinSmoother`
+        smoother that should be wrapped.
+
+    use_normalization: bool
+        Flag to decide if normalization should be used for the smoothers.
+
+    reg_type: :class:`RegressionType`
+        If a ``RegressionType`` is set the RegressionTypeSmoother is used.
+    """
+
+    if not use_normalization and reg_type is None:
+        return smoother
+    if use_normalization and reg_type is None:
+        return NormalizationSmoother(smoother)
+    if not use_normalization and reg_type is not None:
+        return RegressionTypeSmoother(smoother, reg_type)
+    if use_normalization and reg_type is not None:
+        return NormalizationRegressionTypeSmoother(smoother, reg_type)
+
+
+class SmootherChoice(object):
+    r"""Base class for selecting smoothers for cyclic boosting.
+
+    Maps feature property tuples to smoothers in 1D/2D/3D.
+
+    Parameters
+    ----------
+
+    use_regression_type: bool
+        Flag to decide if ``RegressionType`` regularization should be used
+        for the smoothers.
+        (default = True)
+
+    use_normalization: bool
+        Flag to decide if normalization should be used for the smoothers.
+        (default = True)
+
+    explicit_smoothers: dict
+        A dictionary with custom 1-d smoothers that override the default
+        one-dimensional smoothers chosen by the feautre property.
+        Needs to be of the format {feature_group : smoother},
+        where feature_group is a tuple of strings and smoother is
+        and instance of AbstractBinSmoother.
+        (default = None)
+
+    """
+    neutral_factor_link = 0
+
+    def __init__(self, use_regression_type=True, use_normalization=True, explicit_smoothers=None):
+        self.use_regression_type = use_regression_type
+        self.use_normalization = use_normalization
+        self.explicit_smoothers = self._validate_explicit_smoothers(explicit_smoothers)
+        self.onedim_smoothers = _default_smoother_types(self.neutral_factor_link, use_normalization)
+
+    @staticmethod
+    def _validate_explicit_smoothers(explicit_smoothers):
+        if explicit_smoothers is None:
+            return {}
+
+        def is_tuple_of_strings(x):
+            return isinstance(x, tuple) and all(isinstance(s, str) for s in x)
+
+        if not all(is_tuple_of_strings(feature_group) for feature_group in explicit_smoothers.keys()):
+            raise ValueError(
+                "All explicit smoothers passed to the SmootherChoice"
+                " need to have a tuple of strings as a feature group key."
+            )
+
+        if not all(isinstance(sm, AbstractBinSmoother) for sm in explicit_smoothers.values()):
+            raise ValueError(
+                "All explicit smoothers passed to the SmootherChoice" " need to be instances of AbstractBinSmoother."
+            )
+
+        return explicit_smoothers
+
+    def choice_fct(self, feature_group, feature_property, feature_type=None):
+        """
+        Returns the smoother specified by the `get_raw_smoother` method
+        If an explicit smoother is defined for the feature group,
+        the explicit smoother is used instead.
+
+        The result is wrapped with a meta_smoother using the `wrap_smoother` method.
+
+        Parameters
+        ----------
+
+        feature_group: tuple
+            Name of the feature_group
+
+        feature_property: tuple
+            Tuple of feature properties.
+
+        feature_type:
+            Type of the feature.
+        """
+
+        explicit_smoother = self.explicit_smoothers.get(feature_group)
+
+        if explicit_smoother is not None:
+            smoother = explicit_smoother
+        else:
+            smoother = self.get_raw_smoother(feature_group, feature_property, feature_type)
+
+        return self.wrap_smoother(smoother, feature_group, feature_property, feature_type)
+
+    def get_onedim_smoother(self, feature_property, feature_name=None):
+        """
+        Returns the standard one-dimensional smoother to be used for a
+        specific feature.
+        If an explicit 1D-smoother for the feature is defined, it is returned,
+        otherwise the default smoother for the feature property is chosen.
+
+        Parameters
+        ----------
+
+        feature_property: int
+            Feature property defined as flag.
+
+        feature_name: str
+            Name of the feature
+
+        """
+        feature_group = (feature_name,)
+        explicit_smoother = self.explicit_smoothers.get(feature_group)
+
+        if explicit_smoother is not None:
+            return explicit_smoother
+        else:
+            return self.onedim_smoothers[_simplify_flags(feature_property)]
+
+    def get_raw_smoother(self, feature_group, feature_property, feature_type=None):
+        """Method returning the raw smoother for the `feature_group`,
+        `feature_property` and `feature_type` specified.
+
+        This is smoother is not yet wrapped with a `meta_smoother` from the
+        `wrap_smoother` method.
+
+        Parameters
+        ----------
+
+        feature_group: tuple
+            Name of the feature_group
+
+        feature_property: tuple
+            Tuple of feature properties.
+
+        feature_type:
+            Type of the feature.
+        """
+        raise NotImplementedError("Please implement this method.")
+
+    def wrap_smoother(self, smoother, feature_group, feature_property, feature_type):
+        """Wrapper method that chooses the correct meta_estimators
+        for the smoothers in the SmootherChoice class.
+
+        Parameters
+        ----------
+
+        smoother: :class:`AbstractBinSmoother`
+            smoother that should be wrapped.
+
+        feature_group: tuple
+            Name of the feature_group
+
+        feature_property: tuple
+            Tuple of feature properties.
+
+        feature_type:
+            Type of the feature.
+        """
+        reg_type = None
+        if self.use_regression_type:
+            reg_type = determine_reg_type(feature_group, feature_property, feature_type)
+        return determine_meta_smoother(smoother, self.use_normalization, reg_type)
+
+
+class SmootherChoiceWeightedMean(SmootherChoice):
+    r"""Weighted mean smoothing for multi-dimensional feature groups.
+
+    This defines a set of common smoothers where
+    choose_smoothers_for_factor_model selects from.
+    """
+
+    def get_raw_smoother(self, feature_group, feature_prop, feature_type=None):
+        if len(feature_group) > 1:
+            smoother = smoothing.multidim.WeightedMeanSmoother(prior_prediction=self.neutral_factor_link)
+        else:
+            smoother = self.get_onedim_smoother(feature_prop[0], feature_group[0])
+        return smoother
+
+
+class SmootherChoiceGroupBy(SmootherChoice):
+    """
+    Groupby smoothing for multi-dimensional feature groups.
+    """
+
+    def wrap_smoother(self, smoother, feature_group, feature_property, feature_type=None):
+        # only the properties of the innermost feature should
+        # determine the regression type of the groupby smoother:
+        if not isinstance(smoother, smoothing.multidim.GroupBySmootherCB):
+            return super(self.__class__, self).wrap_smoother(
+                smoother, feature_group, feature_property[-1], feature_type
+            )
+        else:
+            return smoother
+
+    def get_raw_smoother(self, feature_group, feature_prop, feature_type=None):
+        innermost_smoother = self.get_onedim_smoother(feature_prop[-1], feature_group[-1])
+        if len(feature_group) > 1:
+            return smoothing.multidim.GroupBySmootherCB(
+                self.wrap_smoother(innermost_smoother, feature_group, feature_prop),
+                n_dim=len(feature_group),
+            )
+        else:
+            return innermost_smoother
+
+
+class NoSmootherChoice(SmootherChoice):
+    """This SmootherChoice class only use BinValueSmoother for all features
+    that do no smoothing. It is thought for experimental use only.
+    """
+
+    def choice_fct(self, feature_group, feature_prop, feature_type=None):
+        if len(feature_group) == 1:
+            smoother = smoothing.onedim.BinValuesSmoother()
+        else:
+            smoother = smoothing.multidim.BinValuesSmoother()
+        return self.wrap_smoother(smoother, feature_group, feature_prop, feature_type)
+
+
+__all__ = [
+    "SmootherChoice",
+    "SmootherChoiceWeightedMean",
+    "SmootherChoiceGroupBy",
+]

--- a/skpro/libs/cyclic_boosting/common_smoothers.py
+++ b/skpro/libs/cyclic_boosting/common_smoothers.py
@@ -2,8 +2,7 @@
 typical smoothers used for the Cyclic Boosting regressor"""
 
 import logging
-
-
+from typing import Optional
 
 from skpro.libs.cyclic_boosting import flags, smoothing
 from skpro.libs.cyclic_boosting.smoothing.base import AbstractBinSmoother
@@ -13,8 +12,6 @@ from skpro.libs.cyclic_boosting.smoothing.meta_smoother import (
     RegressionType,
     RegressionTypeSmoother,
 )
-
-from typing import Optional
 
 _logger = logging.getLogger(__name__)
 
@@ -52,20 +49,26 @@ def _simplify_flags(feature_property: int, feature_group: Optional[str] = None):
     else:
         features = ""
         if feature_group is not None:
-            features = "for feature {}".format(feature_group)
+            features = f"for feature {feature_group}"
         if flags.has_missing_set(feature_property):
-            _logger.info("No feature property set. Thus it is set to default IS_UNORDERED!")
+            _logger.info(
+                "No feature property set. Thus it is set to default IS_UNORDERED!"
+            )
         else:
             _logger.warning(
-                "Feature property {0} is not known {1}."
-                " Thus it is converted to IS_UNORDERED!".format(flags.flags_to_string(feature_property), features)
+                "Feature property {} is not known {}."
+                " Thus it is converted to IS_UNORDERED!".format(
+                    flags.flags_to_string(feature_property), features
+                )
             )
         return flags.IS_UNORDERED
 
 
 def _default_smoother_types(neutral_factor_link=0, use_normalization=True):
     smoother_types = {
-        flags.IS_UNORDERED: smoothing.onedim.WeightedMeanSmoother(prior_prediction=neutral_factor_link),
+        flags.IS_UNORDERED: smoothing.onedim.WeightedMeanSmoother(
+            prior_prediction=neutral_factor_link
+        ),
         flags.IS_ORDERED: smoothing.onedim.WeightedMeanSmootherNeighbors(),
         flags.IS_CONTINUOUS: smoothing.onedim.OrthogonalPolynomialSmoother(),
         flags.IS_LINEAR: smoothing.extrapolate.LinearExtrapolator(),
@@ -74,8 +77,10 @@ def _default_smoother_types(neutral_factor_link=0, use_normalization=True):
         # when the normalization is done within the smoother
         smoothing.onedim.SeasonalSmoother(offset_tozero=not use_normalization),
         flags.IS_MONOTONIC: smoothing.onedim.IsotonicRegressor(increasing="auto"),
-        flags.IS_MONOTONIC | flags.INCREASING: smoothing.onedim.IsotonicRegressor(increasing=True),
-        flags.IS_MONOTONIC | flags.DECREASING: smoothing.onedim.IsotonicRegressor(increasing=False),
+        flags.IS_MONOTONIC
+        | flags.INCREASING: smoothing.onedim.IsotonicRegressor(increasing=True),
+        flags.IS_MONOTONIC
+        | flags.DECREASING: smoothing.onedim.IsotonicRegressor(increasing=False),
     }
     return smoother_types
 
@@ -98,12 +103,17 @@ def determine_reg_type(feature_group, feature_property, feature_type):
     if not isinstance(feature_property, tuple):
         if flags.is_linear_set(feature_property):
             return RegressionType.extrapolating
-        elif flags.is_seasonal_set(feature_property) or flags.is_continuous_set(feature_property):
+        elif flags.is_seasonal_set(feature_property) or flags.is_continuous_set(
+            feature_property
+        ):
             return RegressionType.interpolating
         else:
             return RegressionType.discontinuous
     else:
-        reg_types = [determine_reg_type(fg, fp, feature_type) for fg, fp in zip(feature_group, feature_property)]
+        reg_types = [
+            determine_reg_type(fg, fp, feature_type)
+            for fg, fp in zip(feature_group, feature_property)
+        ]
         if RegressionType.discontinuous in reg_types:
             return RegressionType.discontinuous
         elif RegressionType.interpolating in reg_types:
@@ -139,7 +149,7 @@ def determine_meta_smoother(smoother, use_normalization, reg_type=None):
         return NormalizationRegressionTypeSmoother(smoother, reg_type)
 
 
-class SmootherChoice(object):
+class SmootherChoice:
     r"""Base class for selecting smoothers for cyclic boosting.
 
     Maps feature property tuples to smoothers in 1D/2D/3D.
@@ -167,11 +177,15 @@ class SmootherChoice(object):
     """
     neutral_factor_link = 0
 
-    def __init__(self, use_regression_type=True, use_normalization=True, explicit_smoothers=None):
+    def __init__(
+        self, use_regression_type=True, use_normalization=True, explicit_smoothers=None
+    ):
         self.use_regression_type = use_regression_type
         self.use_normalization = use_normalization
         self.explicit_smoothers = self._validate_explicit_smoothers(explicit_smoothers)
-        self.onedim_smoothers = _default_smoother_types(self.neutral_factor_link, use_normalization)
+        self.onedim_smoothers = _default_smoother_types(
+            self.neutral_factor_link, use_normalization
+        )
 
     @staticmethod
     def _validate_explicit_smoothers(explicit_smoothers):
@@ -181,15 +195,21 @@ class SmootherChoice(object):
         def is_tuple_of_strings(x):
             return isinstance(x, tuple) and all(isinstance(s, str) for s in x)
 
-        if not all(is_tuple_of_strings(feature_group) for feature_group in explicit_smoothers.keys()):
+        if not all(
+            is_tuple_of_strings(feature_group)
+            for feature_group in explicit_smoothers.keys()
+        ):
             raise ValueError(
                 "All explicit smoothers passed to the SmootherChoice"
                 " need to have a tuple of strings as a feature group key."
             )
 
-        if not all(isinstance(sm, AbstractBinSmoother) for sm in explicit_smoothers.values()):
+        if not all(
+            isinstance(sm, AbstractBinSmoother) for sm in explicit_smoothers.values()
+        ):
             raise ValueError(
-                "All explicit smoothers passed to the SmootherChoice" " need to be instances of AbstractBinSmoother."
+                "All explicit smoothers passed to the SmootherChoice"
+                " need to be instances of AbstractBinSmoother."
             )
 
         return explicit_smoothers
@@ -220,9 +240,13 @@ class SmootherChoice(object):
         if explicit_smoother is not None:
             smoother = explicit_smoother
         else:
-            smoother = self.get_raw_smoother(feature_group, feature_property, feature_type)
+            smoother = self.get_raw_smoother(
+                feature_group, feature_property, feature_type
+            )
 
-        return self.wrap_smoother(smoother, feature_group, feature_property, feature_type)
+        return self.wrap_smoother(
+            smoother, feature_group, feature_property, feature_type
+        )
 
     def get_onedim_smoother(self, feature_property, feature_name=None):
         """
@@ -304,7 +328,9 @@ class SmootherChoiceWeightedMean(SmootherChoice):
 
     def get_raw_smoother(self, feature_group, feature_prop, feature_type=None):
         if len(feature_group) > 1:
-            smoother = smoothing.multidim.WeightedMeanSmoother(prior_prediction=self.neutral_factor_link)
+            smoother = smoothing.multidim.WeightedMeanSmoother(
+                prior_prediction=self.neutral_factor_link
+            )
         else:
             smoother = self.get_onedim_smoother(feature_prop[0], feature_group[0])
         return smoother
@@ -315,7 +341,9 @@ class SmootherChoiceGroupBy(SmootherChoice):
     Groupby smoothing for multi-dimensional feature groups.
     """
 
-    def wrap_smoother(self, smoother, feature_group, feature_property, feature_type=None):
+    def wrap_smoother(
+        self, smoother, feature_group, feature_property, feature_type=None
+    ):
         # only the properties of the innermost feature should
         # determine the regression type of the groupby smoother:
         if not isinstance(smoother, smoothing.multidim.GroupBySmootherCB):
@@ -326,7 +354,9 @@ class SmootherChoiceGroupBy(SmootherChoice):
             return smoother
 
     def get_raw_smoother(self, feature_group, feature_prop, feature_type=None):
-        innermost_smoother = self.get_onedim_smoother(feature_prop[-1], feature_group[-1])
+        innermost_smoother = self.get_onedim_smoother(
+            feature_prop[-1], feature_group[-1]
+        )
         if len(feature_group) > 1:
             return smoothing.multidim.GroupBySmootherCB(
                 self.wrap_smoother(innermost_smoother, feature_group, feature_prop),

--- a/skpro/libs/cyclic_boosting/features.py
+++ b/skpro/libs/cyclic_boosting/features.py
@@ -1,0 +1,413 @@
+from collections import namedtuple
+
+import numpy as np
+import pandas as pd
+
+from skpro.libs.cyclic_boosting import flags
+from skpro.libs.cyclic_boosting.common_smoothers import SmootherChoice
+from skpro.libs.cyclic_boosting.smoothing import multidim, onedim
+from skpro.libs.cyclic_boosting.smoothing.base import AbstractBinSmoother
+from skpro.libs.cyclic_boosting.utils import (
+    arange_multi,
+    clone,
+    get_X_column,
+    multidim_binnos_to_lexicographic_binnos,
+)
+
+from typing import Any, List, Optional, Union
+
+FeatureID = namedtuple("FeatureID", ["feature_group", "feature_type"])
+
+
+class FeatureTypes(object):
+    standard = None
+    external = "external"
+
+
+class Feature(object):
+    """Wrapper for information regarding a single feature group in the cyclic
+    boosting algorithm
+
+    Parameters
+    ----------
+
+    feature_id: :class:`FeatureID`
+        feature ID is a named tuple consisting of the name of a feature or
+        tuple of such names in the multidimensional case and the feature type.
+
+    feature_property: int
+        feature property, see :mod:`flags`
+
+    smoother: subclass of :class:`cyclic_boosting.smoothing.base.AbstractBinSmoother`
+        smoother for the bins of the feature group
+
+    minimal_factor_change: float
+        minimum change of the results in the feature group's bins that are
+        considered progress in a cyclic boosting iteration
+
+    Note
+    ----
+
+    The suffix ``_link`` in attributes refers to values valid in link space.
+    """
+
+    def __init__(
+        self,
+        feature_id: FeatureID,
+        feature_property: Union[tuple, int],
+        smoother: AbstractBinSmoother,
+        minimal_factor_change: Optional[float] = 1e-4,
+    ):
+        self.feature_id = feature_id
+        self.feature_group = feature_id.feature_group
+
+        if len(self.feature_group) < 2:
+            self.smootherb = onedim.BinValuesSmoother()
+        else:
+            self.smootherb = multidim.BinValuesSmoother()
+
+        self.is_fitted = False
+        self.feature_property = feature_property
+        self.smoother = smoother
+        self.learn_rate = 0.0
+
+        self.unfitted_factors_link = None
+        self.factors_link = None
+        self.factors_link_old = None
+        self.unfitted_uncertainties_link = None
+        self.uncertainties_link = None
+        self.fitted_aggregated = None
+
+        # set by bind_data method
+        self.lex_binned_data = None
+        self.n_multi_bins_finite = None
+        self.bin_weightsums = None
+
+        self.minimal_factor_change = minimal_factor_change
+        self.stop_iterations = False
+
+        self.feature_type = feature_id.feature_type
+        self.factor_sum = None
+
+        # required by prepare_plots
+        self.mean_dev = None
+        self.y = None
+        self.y_finite = None
+        self.prediction = None
+        self.prediction_finite = None
+
+        # set by set_feature_bin_deviations_from_neutral
+        self.bin_weighted_average = None
+
+    @property
+    def dim(self) -> int:
+        """Dimension of the feature group, i.e. the number of its features"""
+        return len(self.feature_group)
+
+    @property
+    def is_1dim(self) -> bool:
+        """
+        True if feature is 1-dimensional, False otherwise
+        """
+        return self.dim == 1
+
+    @property
+    def missing_not_learned(self) -> bool:
+        """
+        True if ``flags.MISSING_NOT_LEARNED`` can be found in feature property.
+        """
+        return any(flags.missing_not_learned_set(feature_prop) for feature_prop in self.feature_property)
+
+    @property
+    def n_bins(self) -> int:
+        """Number of bins, including the extra bin for missing and infinite
+        values
+        """
+        return self.n_bins_finite + 1
+
+    @property
+    def n_bins_finite(self) -> int:
+        """Number of bins, excluding the extra bin for missing and infinite
+        values
+        """
+        return int(np.prod(self.n_multi_bins_finite))
+
+    @property
+    def bin_centers(self) -> np.ndarray:
+        if self.n_bins_finite == 0:
+            return np.ndarray(shape=(0, len(self.n_multi_bins_finite)))
+        else:
+            return arange_multi(self.n_multi_bins_finite)
+
+    @property
+    def finite_bin_weightsums(self) -> np.ndarray:
+        """Array of finite bin weightsums"""
+        return self.bin_weightsums[:-1]
+
+    @property
+    def nan_bin_weightsum(self) -> np.ndarray:
+        return self.bin_weightsums[-1]
+
+    def bind_data(self, X: Union[pd.DataFrame, np.ndarray], weights: np.ndarray) -> None:
+        """
+        Binds data from X belonging to the feature and calculates the
+        following features:
+
+        * lex_binned_data: The binned data transformed to a 1-dimensional array
+            containing lexical binned data.
+        * n_multi_bins_finite: Number of bins for each column in feature
+            (needed for plotting).
+        * finite_bin_weightsums: Array containing the sum of weights for
+             each bin.
+        * nan_bin_weightsum: The sum of weights for the nan-bin.
+        * bin_centers: Array containing the center of each bin.
+        """
+        binnumbers = get_X_column(X, self.feature_group, array_for_1_dim=False)
+        (
+            self.lex_binned_data,
+            self.n_multi_bins_finite,
+        ) = multidim_binnos_to_lexicographic_binnos(binnumbers, self.n_multi_bins_finite)
+
+        self.bin_weightsums = np.bincount(self.lex_binned_data, weights=weights, minlength=self.n_bins)
+
+    @property
+    def unfitted_factor_link_nan_bin(self) -> np.ndarray:
+        return self.unfitted_factors_link[-1]
+
+    @property
+    def factor_link_nan_bin(self) -> np.ndarray:
+        return self.factors_link[-1]
+
+    def unbind_data(self) -> None:
+        """Clear some of the references set in :meth:`bind_data`."""
+        self.lex_binned_data = None
+
+    def unbind_factor_data(self) -> None:
+        self.unfitted_factors_link = None
+        self.factors_link_old = None
+        self.fitted_aggregated = None
+        self.unfitted_uncertainties_link = None
+        self.uncertainties_link = None
+        self.factors_link = [self.factors_link[-1]]
+
+    def _get_data_for_smoother(self, uncertainties_link) -> np.ndarray:
+        """Prepare ``X_for_smoother`` as needed by the smoother's ``fit`` method.
+
+        bin_centers, bin_weightsums and the uncertainties in link space
+        must already have been calculated.
+        """
+        n_bins = self.n_bins_finite
+        n_bin_dims = self.dim
+        X_for_smoother = np.empty((n_bins + 1, n_bin_dims + 2))
+
+        X_for_smoother[:n_bins, :n_bin_dims] = self.bin_centers
+        X_for_smoother[n_bins, :n_bin_dims] = np.nan
+        X_for_smoother[:, n_bin_dims] = self.bin_weightsums
+        X_for_smoother[:, -1] = uncertainties_link
+        return X_for_smoother
+
+    def update_factors(
+        self,
+        unfitted_factors: np.ndarray,
+        unfitted_uncertainties: np.ndarray,
+        neutral_factor_link: float,
+        learn_rate: float,
+    ) -> np.ndarray:
+        """Call the smoother on the bin results if necessary.
+
+        Parameters
+        ----------
+
+        unfitted_factors: ndarray
+            bin means in link space as returned by the method
+            :meth:`cyclic_boosting.base.CyclicBoostingBase.calc_parameters`
+
+        unfitted_uncertainties: ndarray
+            bin uncertainties in link space as returned by the method
+            :meth:`cyclic_boosting.base.CyclicBoostingBase.calc_parameters`
+
+        neutral_factor_link: float
+            neutral value in link space, currently always 0
+
+        learn_rate: float
+            learning rate used
+        """
+        self.learn_rate = learn_rate
+        self.factors_link_old = self.factors_link.copy()
+        self.unfitted_factors_link = unfitted_factors
+        self.unfitted_uncertainties_link = unfitted_uncertainties
+
+        if self.missing_not_learned:
+            # do not learn missing features by regularizing the factor
+            # for the nan bin to the neutral factor
+            unfitted_factors[-1] = neutral_factor_link
+            self.factors_link[-1] = neutral_factor_link
+        else:
+            self.factors_link[-1] = unfitted_factors[-1] * learn_rate
+
+        X_for_smoother = self._get_data_for_smoother(unfitted_uncertainties)
+
+        if self.n_bins_finite > 0:
+            self.smoother.fit(X_for_smoother[:-1], unfitted_factors[:-1].copy())
+            if not self.is_fitted:
+                self.smootherb.fit(X_for_smoother[:-1], unfitted_factors[:-1].copy())
+                self.smootherb.smoothed_y_ = None
+        else:
+            self.smoother = None
+            self.smootherb = None
+        return X_for_smoother
+
+    def prepare_feature(self) -> None:
+        self.factors_link = self.fitted_aggregated
+        self.learn_rate = 1.0
+        self.smoother = self.smootherb
+
+        del self.smootherb
+
+        if self.smoother is not None:
+            self.smoother.smoothed_y_ = self.factors_link[:-1].copy()
+
+    def clear_feature_reference(self, observers: List) -> None:
+        if len(observers) == 0:
+            self.bin_weightsums = None
+        self.unbind_data()
+        self.unbind_factor_data()
+
+    def set_feature_bin_deviations_from_neutral(self, neutral_factor_link: float) -> None:
+        weights = np.bincount(self.lex_binned_data, minlength=self.n_bins)
+        weighted_average = np.sum(weights * np.abs(self.factors_link - neutral_factor_link) / np.sum(weights))
+        self.bin_weighted_average = weighted_average
+
+
+def create_feature_id(feature_group_or_id: Union[FeatureID, Any], default_type: Optional[str] = None) -> FeatureID:
+    """Convenience function to convert feature_groups
+    into :class:`FeatureID`s
+    """
+    if isinstance(feature_group_or_id, FeatureID):
+        return feature_group_or_id
+    elif isinstance(feature_group_or_id, tuple):
+        return FeatureID(feature_group=feature_group_or_id, feature_type=default_type)
+    else:
+        return FeatureID(feature_group=(feature_group_or_id,), feature_type=default_type)
+
+
+class FeatureList(object):
+    """Iterable providing the information about a list of features in the
+    form of :class:`Feature` objects
+
+    Parameters
+    ----------
+
+    features: list of :class:`Feature`
+        List of :class:`Feature` that is normally created by
+        :func:`create_features`.
+    """
+
+    def __init__(self, features: List[Feature]):
+        self.features = features
+
+    @property
+    def feature_groups(self) -> List[Union[tuple, str, int]]:
+        """
+        Obtain the feature_groups for all features.
+        """
+        return [feature.feature_group for feature in self.features]
+
+    @property
+    def feature_ids(self) -> List[FeatureID]:
+        """
+        Obtain the feature_groups for all features.
+        """
+        return [feature.feature_id for feature in self.features]
+
+    def iter_fitting(self):
+        """Generator yielding only the features with attribute
+        ``stop_iterations == False``
+        """
+        for feature in self.features:
+            if not feature.stop_iterations:
+                yield feature
+
+    def __iter__(self):
+        for feature in self.features:
+            yield feature
+
+    def __len__(self) -> int:
+        return len(self.features)
+
+    def __getitem__(self, feature_group_or_id: Union[str, int, tuple, FeatureID]) -> Feature:
+        """Selects feature specified by ``feature_id``
+
+        Parameters
+        ----------
+
+        feature_group_or_id: `string`, `int` or `tuple` of `string` or :class:`FeatureID`
+           feature identifier
+
+        Returns
+        -------
+
+        class:`cyclic_boosting.base.Feature`
+           Feature instance
+        """
+        feature_id = create_feature_id(feature_group_or_id)
+
+        for feature in self.features:
+            if feature.feature_id == feature_id:
+                return feature
+        raise KeyError("Feature {0} is not known in {1}".format(feature_id, self.feature_ids))
+
+    def get_feature(self, feature_group: Union[str, int, tuple], feature_type: Optional[str] = None) -> Feature:
+        """Selects feature specified by ``feature_group`` and ``feature_type``
+
+        Parameters
+        ----------
+
+        feature_group: `string`, `int` or `tuple` of `string` or `int`
+           name or index of feature group
+
+        feature_type: `None` or `string`
+           type of feature
+
+        Returns
+        -------
+
+        class:`cyclic_boosting.base.Feature`
+           Feature instance
+        """
+        feature_id = create_feature_id(feature_group, feature_type)
+        return self[feature_id]
+
+
+def create_features(
+    feature_groups_or_ids: List[Union[str, int, tuple, FeatureID]],
+    feature_properties: dict,
+    smoother_choice: SmootherChoice,
+) -> FeatureList:
+    """
+    Parameters
+    ----------
+
+    feature_groups_or_ids: List of `string`, `int` or `tuple` of `string` or :class:`FeatureID`
+           feature identifier
+
+    feature_properties: dict of feature properties
+
+    smoother_choice: subclass of :class:`cyclic_boosting.SmootherChoice`
+        Selects smoothers
+    """
+    if feature_groups_or_ids is None:
+        feature_groups_or_ids = []
+
+    def make_feature_for_group_or_id(feature_group_or_id):
+        feature_id = create_feature_id(feature_group_or_id)
+
+        feature_property = flags.read_feature_property(
+            feature_properties, feature_id.feature_group, default=flags.HAS_MISSING
+        )
+        smoother = smoother_choice.choice_fct(feature_id.feature_group, feature_property, feature_id.feature_type)
+        return Feature(feature_id, feature_property, clone(smoother))
+
+    features = [make_feature_for_group_or_id(feature_group_or_id) for feature_group_or_id in feature_groups_or_ids]
+
+    return FeatureList(features)

--- a/skpro/libs/cyclic_boosting/features.py
+++ b/skpro/libs/cyclic_boosting/features.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from typing import Any, List, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -14,17 +15,15 @@ from skpro.libs.cyclic_boosting.utils import (
     multidim_binnos_to_lexicographic_binnos,
 )
 
-from typing import Any, List, Optional, Union
-
 FeatureID = namedtuple("FeatureID", ["feature_group", "feature_type"])
 
 
-class FeatureTypes(object):
+class FeatureTypes:
     standard = None
     external = "external"
 
 
-class Feature(object):
+class Feature:
     """Wrapper for information regarding a single feature group in the cyclic
     boosting algorithm
 
@@ -116,7 +115,10 @@ class Feature(object):
         """
         True if ``flags.MISSING_NOT_LEARNED`` can be found in feature property.
         """
-        return any(flags.missing_not_learned_set(feature_prop) for feature_prop in self.feature_property)
+        return any(
+            flags.missing_not_learned_set(feature_prop)
+            for feature_prop in self.feature_property
+        )
 
     @property
     def n_bins(self) -> int:
@@ -148,7 +150,9 @@ class Feature(object):
     def nan_bin_weightsum(self) -> np.ndarray:
         return self.bin_weightsums[-1]
 
-    def bind_data(self, X: Union[pd.DataFrame, np.ndarray], weights: np.ndarray) -> None:
+    def bind_data(
+        self, X: Union[pd.DataFrame, np.ndarray], weights: np.ndarray
+    ) -> None:
         """
         Binds data from X belonging to the feature and calculates the
         following features:
@@ -166,9 +170,13 @@ class Feature(object):
         (
             self.lex_binned_data,
             self.n_multi_bins_finite,
-        ) = multidim_binnos_to_lexicographic_binnos(binnumbers, self.n_multi_bins_finite)
+        ) = multidim_binnos_to_lexicographic_binnos(
+            binnumbers, self.n_multi_bins_finite
+        )
 
-        self.bin_weightsums = np.bincount(self.lex_binned_data, weights=weights, minlength=self.n_bins)
+        self.bin_weightsums = np.bincount(
+            self.lex_binned_data, weights=weights, minlength=self.n_bins
+        )
 
     @property
     def unfitted_factor_link_nan_bin(self) -> np.ndarray:
@@ -273,13 +281,19 @@ class Feature(object):
         self.unbind_data()
         self.unbind_factor_data()
 
-    def set_feature_bin_deviations_from_neutral(self, neutral_factor_link: float) -> None:
+    def set_feature_bin_deviations_from_neutral(
+        self, neutral_factor_link: float
+    ) -> None:
         weights = np.bincount(self.lex_binned_data, minlength=self.n_bins)
-        weighted_average = np.sum(weights * np.abs(self.factors_link - neutral_factor_link) / np.sum(weights))
+        weighted_average = np.sum(
+            weights * np.abs(self.factors_link - neutral_factor_link) / np.sum(weights)
+        )
         self.bin_weighted_average = weighted_average
 
 
-def create_feature_id(feature_group_or_id: Union[FeatureID, Any], default_type: Optional[str] = None) -> FeatureID:
+def create_feature_id(
+    feature_group_or_id: Union[FeatureID, Any], default_type: Optional[str] = None
+) -> FeatureID:
     """Convenience function to convert feature_groups
     into :class:`FeatureID`s
     """
@@ -288,10 +302,12 @@ def create_feature_id(feature_group_or_id: Union[FeatureID, Any], default_type: 
     elif isinstance(feature_group_or_id, tuple):
         return FeatureID(feature_group=feature_group_or_id, feature_type=default_type)
     else:
-        return FeatureID(feature_group=(feature_group_or_id,), feature_type=default_type)
+        return FeatureID(
+            feature_group=(feature_group_or_id,), feature_type=default_type
+        )
 
 
-class FeatureList(object):
+class FeatureList:
     """Iterable providing the information about a list of features in the
     form of :class:`Feature` objects
 
@@ -329,13 +345,14 @@ class FeatureList(object):
                 yield feature
 
     def __iter__(self):
-        for feature in self.features:
-            yield feature
+        yield from self.features
 
     def __len__(self) -> int:
         return len(self.features)
 
-    def __getitem__(self, feature_group_or_id: Union[str, int, tuple, FeatureID]) -> Feature:
+    def __getitem__(
+        self, feature_group_or_id: Union[str, int, tuple, FeatureID]
+    ) -> Feature:
         """Selects feature specified by ``feature_id``
 
         Parameters
@@ -355,9 +372,11 @@ class FeatureList(object):
         for feature in self.features:
             if feature.feature_id == feature_id:
                 return feature
-        raise KeyError("Feature {0} is not known in {1}".format(feature_id, self.feature_ids))
+        raise KeyError(f"Feature {feature_id} is not known in {self.feature_ids}")
 
-    def get_feature(self, feature_group: Union[str, int, tuple], feature_type: Optional[str] = None) -> Feature:
+    def get_feature(
+        self, feature_group: Union[str, int, tuple], feature_type: Optional[str] = None
+    ) -> Feature:
         """Selects feature specified by ``feature_group`` and ``feature_type``
 
         Parameters
@@ -405,9 +424,14 @@ def create_features(
         feature_property = flags.read_feature_property(
             feature_properties, feature_id.feature_group, default=flags.HAS_MISSING
         )
-        smoother = smoother_choice.choice_fct(feature_id.feature_group, feature_property, feature_id.feature_type)
+        smoother = smoother_choice.choice_fct(
+            feature_id.feature_group, feature_property, feature_id.feature_type
+        )
         return Feature(feature_id, feature_property, clone(smoother))
 
-    features = [make_feature_for_group_or_id(feature_group_or_id) for feature_group_or_id in feature_groups_or_ids]
+    features = [
+        make_feature_for_group_or_id(feature_group_or_id)
+        for feature_group_or_id in feature_groups_or_ids
+    ]
 
     return FeatureList(features)

--- a/skpro/libs/cyclic_boosting/flags.py
+++ b/skpro/libs/cyclic_boosting/flags.py
@@ -1,0 +1,453 @@
+
+from enum import Enum
+from typing import Optional, Union
+
+
+class _FeatureProbBit(Enum):
+    """Each bit may only be used once in the feature-property flag mask"""
+
+    continuous = 0
+    ordered = 1
+    unordered = 2
+    monotonic = 3
+    missing = 4
+    missing_not_learned = 5
+    use_original = 6
+    corr_to_width = 7
+    is_linear = 8
+    is_seasonal = 9
+    magic_int_missing = 10
+    increasing = 11
+    decreasing = 12
+
+
+IS_CONTINUOUS = 1 << _FeatureProbBit.continuous.value
+IS_ORDERED = 1 << _FeatureProbBit.ordered.value
+IS_UNORDERED = 1 << _FeatureProbBit.unordered.value
+IS_MONOTONIC = IS_CONTINUOUS | (1 << _FeatureProbBit.monotonic.value)
+HAS_MISSING = 1 << _FeatureProbBit.missing.value
+MISSING_NOT_LEARNED = HAS_MISSING | (1 << _FeatureProbBit.missing_not_learned.value)
+USE_ORIGINAL = 1 << _FeatureProbBit.use_original.value
+CORR_TO_WIDTH = 1 << _FeatureProbBit.corr_to_width.value
+IS_LINEAR = 1 << _FeatureProbBit.is_linear.value
+IS_SEASONAL = 1 << _FeatureProbBit.is_seasonal.value
+HAS_MAGIC_INT_MISSING = HAS_MISSING | (1 << _FeatureProbBit.magic_int_missing.value)
+INCREASING = 1 << _FeatureProbBit.increasing.value
+DECREASING = 1 << _FeatureProbBit.decreasing.value
+
+_FLAG_LIST = [
+    "IS_CONTINUOUS",
+    "IS_ORDERED",
+    "IS_UNORDERED",
+    "IS_MONOTONIC",
+    "HAS_MISSING",
+    "MISSING_NOT_LEARNED",
+    "USE_ORIGINAL",
+    "CORR_TO_WIDTH",
+    "IS_LINEAR",
+    "IS_SEASONAL",
+]
+
+
+def is_continuous_set(feature_prop: int) -> bool:
+    """Is IS_CONTINUOUS included in the feature properties?
+
+    :param feature_prop: feature properties for one feature
+    :type feature_prop: int
+
+    :rtype: bool
+
+    >>> from skpro.libs.cyclic_boosting.flags import is_continuous_set
+    >>> from skpro.libs.cyclic_boosting import flags
+    >>> is_continuous_set(flags.IS_CONTINUOUS)
+    True
+    >>> is_continuous_set(flags.IS_CONTINUOUS | flags.HAS_MISSING)
+    True
+    >>> is_continuous_set(flags.IS_ORDERED)
+    False
+
+    IS_MONOTONIC implies IS_CONTINUOUS:
+
+    >>> is_continuous_set(flags.IS_MONOTONIC)
+    True
+    """
+    return feature_prop & IS_CONTINUOUS == IS_CONTINUOUS
+
+
+def is_ordered_set(feature_prop: int) -> bool:
+    """Is IS_ORDERED included in the feature properties?
+
+    :param feature_prop: feature properties for one feature
+    :type feature_prop: int
+
+    :rtype: bool
+
+    >>> from skpro.libs.cyclic_boosting.flags import is_ordered_set
+    >>> from skpro.libs.cyclic_boosting import flags
+    >>> is_ordered_set(flags.IS_ORDERED)
+    True
+    >>> is_ordered_set(flags.IS_ORDERED | flags.HAS_MISSING)
+    True
+    >>> is_ordered_set(flags.IS_CONTINUOUS)
+    False
+    """
+    return feature_prop & IS_ORDERED == IS_ORDERED
+
+
+def is_unordered_set(feature_prop: int) -> bool:
+    """Is IS_UNORDERED included in the feature properties?
+
+    :param feature_prop: feature properties for one feature
+    :type feature_prop: int
+
+    :rtype: bool
+
+    >>> from skpro.libs.cyclic_boosting.flags import is_unordered_set
+    >>> from skpro.libs.cyclic_boosting import flags
+    >>> is_unordered_set(flags.IS_UNORDERED)
+    True
+    >>> is_unordered_set(flags.IS_UNORDERED | flags.HAS_MISSING)
+    True
+    >>> is_unordered_set(flags.IS_ORDERED)
+    False
+    >>> is_unordered_set(flags.IS_CONTINUOUS)
+    False
+    """
+    return feature_prop & IS_UNORDERED == IS_UNORDERED
+
+
+def is_monotonic_set(feature_prop: int) -> bool:
+    """Is IS_MONOTONIC included in the feature properties?
+
+    :param feature_prop: feature properties for one feature
+    :type feature_prop: int
+
+    :rtype: bool
+
+    >>> from skpro.libs.cyclic_boosting.flags import is_monotonic_set
+    >>> from skpro.libs.cyclic_boosting import flags
+    >>> is_monotonic_set(flags.IS_MONOTONIC)
+    True
+    >>> is_monotonic_set(flags.IS_MONOTONIC | flags.HAS_MISSING)
+    True
+    >>> is_monotonic_set(flags.IS_CONTINUOUS)
+    False
+    >>> is_monotonic_set(flags.IS_CONTINUOUS | flags.IS_MONOTONIC)
+    True
+    >>> is_monotonic_set(flags.IS_ORDERED)
+    False
+    >>> is_monotonic_set(flags.IS_MONOTONIC_INCREASING)
+    True
+    """
+    return feature_prop & IS_MONOTONIC == IS_MONOTONIC
+
+
+def increasing_set(feature_prop: int) -> bool:
+    """Is INCREASING included in the feature properties?
+
+    :param feature_prop: feature properties for one feature
+    :type feature_prop: int
+
+    :rtype: bool
+
+    >>> from skpro.libs.cyclic_boosting.flags import _set
+    >>> from skpro.libs.cyclic_boosting import flags
+    >>> _increasing_set(flags.INCREASING)
+    True
+    >>> increasing_set(flags.INCREASING | flags.HAS_MISSING)
+    True
+    >>> increasing_set(flags.IS_MONOTONIC)
+    False
+    """
+    return feature_prop & INCREASING == INCREASING
+
+
+def decreasing_set(feature_prop: int) -> bool:
+    """Is DECREASING included in the feature properties?
+
+    :param feature_prop: feature properties for one feature
+    :type feature_prop: int
+
+    :rtype: bool
+
+    >>> from skpro.libs.cyclic_boosting.flags import _set
+    >>> from skpro.libs.cyclic_boosting import flags
+    >>> decreasing_set(flags.DECREASING)
+    True
+    >>> decreasing_set(flags.DECREASING | flags.HAS_MISSING)
+    True
+    >>> decreasing_set(flags.IS_MONOTONIC)
+    False
+    """
+    return feature_prop & DECREASING == DECREASING
+
+
+def has_magic_missing_set(feature_prop: int) -> bool:
+    return feature_prop & HAS_MAGIC_INT_MISSING == HAS_MAGIC_INT_MISSING
+
+
+def has_missing_set(feature_prop: int) -> bool:
+    """Is HAS_MISSING included in the feature properties?
+
+    :param feature_prop: feature properties for one feature
+    :type feature_prop: int
+
+    :rtype: bool
+
+    >>> from skpro.libs.cyclic_boosting.flags import has_missing_set
+    >>> from skpro.libs.cyclic_boosting import flags
+    >>> has_missing_set(flags.HAS_MISSING)
+    True
+    >>> has_missing_set(flags.IS_CONTINUOUS | flags.HAS_MISSING)
+    True
+    >>> has_missing_set(flags.IS_CONTINUOUS)
+    False
+
+    MISSING_NOT_LEARNED implies HAS_MISSING:
+
+    >>> has_missing_set(flags.MISSING_NOT_LEARNED)
+    True
+    """
+    return feature_prop & HAS_MISSING == HAS_MISSING
+
+
+def missing_not_learned_set(feature_prop: int) -> bool:
+    """Is MISSING_NOT_LEARNED included in the feature properties?
+
+    :param feature_prop: feature properties for one feature
+    :type feature_prop: int
+
+    :rtype: bool
+
+    >>> from skpro.libs.cyclic_boosting.flags import missing_not_learned_set
+    >>> from skpro.libs.cyclic_boosting import flags
+    >>> missing_not_learned_set(flags.MISSING_NOT_LEARNED)
+    True
+    >>> missing_not_learned_set(flags.IS_CONTINUOUS | flags.MISSING_NOT_LEARNED)
+    True
+    >>> missing_not_learned_set(flags.HAS_MISSING)
+    False
+    >>> missing_not_learned_set(flags.IS_CONTINUOUS)
+    False
+    """
+    return feature_prop & MISSING_NOT_LEARNED == MISSING_NOT_LEARNED
+
+
+def is_linear_set(feature_prop: int) -> bool:
+    return feature_prop & IS_LINEAR == IS_LINEAR
+
+
+def is_seasonal_set(feature_prop: int) -> bool:
+    return feature_prop & IS_SEASONAL == IS_SEASONAL
+
+
+def check_flags_consistency(feature_prop: int) -> None:
+    """Check that exactly one of ``IS_CONTINUOUS, IS_ORDERED, IS_UNORDERED``
+    has been set.
+
+    Parameters
+    ----------
+    feature_prop: int
+        value to check for consistency
+
+    Examples
+    --------
+
+    >>> from skpro.libs.cyclic_boosting.flags import check_flags_consistency
+    >>> from skpro.libs.cyclic_boosting import flags
+
+    The following flags will just work:
+
+    >>> check_flags_consistency(flags.IS_CONTINUOUS)
+    >>> check_flags_consistency(flags.IS_ORDERED)
+    >>> check_flags_consistency(flags.IS_UNORDERED)
+
+    Flags that fail:
+
+    >>> check_flags_consistency(flags.HAS_MISSING)
+    Traceback (most recent call last):
+    ValueError: Exactly one of IS_CONTINUOUS, IS_ORDERED, IS_UNORDERED ...
+
+    >>> check_flags_consistency(flags.IS_CONTINUOUS | flags.IS_UNORDERED)
+    Traceback (most recent call last):
+    ValueError: Exactly one of IS_CONTINUOUS, IS_ORDERED, IS_UNORDERED ...
+
+    >>> check_flags_consistency(flags.IS_CONTINUOUS | flags.IS_ORDERED)
+    Traceback (most recent call last):
+    ValueError: Exactly one of IS_CONTINUOUS, IS_ORDERED, IS_UNORDERED ...
+
+    >>> check_flags_consistency(flags.IS_ORDERED | flags.IS_UNORDERED)
+    Traceback (most recent call last):
+    ValueError: Exactly one of IS_CONTINUOUS, IS_ORDERED, IS_UNORDERED ...
+
+    >>> check_flags_consistency(flags.DECREASING | flags.INCREASING)
+    Traceback (most recent call last):
+    ValueError: One feature can either be ...
+    """
+    if (
+        int(is_continuous_set(feature_prop)) + int(is_ordered_set(feature_prop)) + int(is_unordered_set(feature_prop))
+        != 1
+    ):
+        raise ValueError(
+            "Exactly one of IS_CONTINUOUS, IS_ORDERED, "
+            "IS_UNORDERED must be set in a "
+            "flags value for the feature properties."
+        )
+    if int(increasing_set(feature_prop)) + int(decreasing_set(feature_prop)) == 2:
+        raise ValueError("One feature can either be INCREASING" " or DECREASING")
+
+
+def flags_to_string(flags_value: Union[int, tuple]) -> Union[tuple, str]:
+    """
+    This function converts the numeric flags to the corresponding strings
+    that are defined in the flag list.
+
+    Parameters
+    ----------
+
+    flags_value: int/tuple
+        preprocessing flag (see :mod:`cyclic_boosting.flags`)
+
+    Returns
+    -------
+    str
+        Flag value
+
+    Examples
+    --------
+
+    >>> from skpro.libs.cyclic_boosting.flags import flags_to_string
+    >>> from skpro.libs.cyclic_boosting import flags
+    >>> flags_to_string(flags.IS_CONTINUOUS)
+    'IS_CONTINUOUS'
+
+    >>> flags_to_string(flags.IS_UNORDERED)
+    'IS_UNORDERED'
+
+    >>> flags_to_string(flags.IS_ORDERED)
+    'IS_ORDERED'
+
+    >>> flags_to_string(flags.IS_MONOTONIC)
+    'IS_CONTINUOUS | IS_MONOTONIC'
+
+    >>> flags_to_string(flags.HAS_MISSING | flags.IS_CONTINUOUS)
+    'IS_CONTINUOUS | HAS_MISSING'
+
+    >>> flags_to_string(flags.IS_UNORDERED | flags.HAS_MISSING
+    ... | flags.MISSING_NOT_LEARNED)
+    'IS_UNORDERED | HAS_MISSING | MISSING_NOT_LEARNED'
+
+    >>> flags_to_string((flags.IS_ORDERED, flags.HAS_MISSING
+    ... | flags.IS_CONTINUOUS))
+    ('IS_ORDERED', 'IS_CONTINUOUS | HAS_MISSING')
+
+    >>> flags_to_string(flags.IS_CONTINUOUS | flags.IS_UNORDERED)
+    'IS_CONTINUOUS | IS_UNORDERED'
+    """
+    if isinstance(flags_value, tuple):
+        return tuple(_convert_flags_to_string(flags_val) for flags_val in flags_value)
+    else:
+        return _convert_flags_to_string(flags_value)
+
+
+def _convert_flags_to_string(
+    flags_value: int, alternative_flag_list: Optional[int] = None, alternative_flags: Optional[dict] = None
+) -> str:
+    """
+    This function converts the numeric flags to the corresponding strings
+    that are defined in the flag list.
+
+    Parameters
+    ----------
+
+    flags_value: int
+        preprocessing flag (see :mod:`cyclic_boosting.flags`)
+
+    alternative_flag_list: int
+        alternative list of possible flags
+
+    alternative_flags: dict
+        alternative flags
+
+    Returns
+    -------
+    str
+        string representation of flag
+    """
+    if alternative_flag_list is None:
+        alternative_flag_list = _FLAG_LIST
+
+    lst = []
+    flags1 = flags_value
+    glob_vars = globals()
+
+    if alternative_flags is not None:
+        glob_vars.update(alternative_flags)
+
+    for flag_name in alternative_flag_list:
+        flag = glob_vars[flag_name]
+        if flag & flags_value == flag:
+            lst.append(flag_name)
+            flags1 &= ~flag
+    if flags1 != 0:
+        raise ValueError("Unknown flags %d found" % flags1)
+    return " | ".join(lst)
+
+
+def read_feature_property(
+    feature_properties: dict, feature_group: Union[tuple, str], default: int
+) -> Union[tuple, int]:
+    """Read a feature property out of the ``feature_properties`` dict which may
+    be None. If no value is found, return ``default`` as the default value.
+
+    :param feature_properties: the `feature_properties` dict
+    :type feature_properties: dict
+
+    :param feature_group: feature group name
+    :type feature_group: str or tuple of str
+
+    :param default: the default value to return if ``feature_properties`` is
+        `None` or doesn't contain ``feature_group`` as a key.
+    :type default: int
+
+    >>> from skpro.libs.cyclic_boosting.flags import read_feature_property, flags_to_string
+    >>> from skpro.libs.cyclic_boosting import flags
+    >>> feature_properties = {'a': flags.IS_ORDERED, 'b': flags.IS_UNORDERED}
+    >>> flags_to_string(read_feature_property(feature_properties, 'b', flags.HAS_MISSING))
+    'IS_UNORDERED'
+    >>> flags_to_string(read_feature_property(feature_properties, 'c', flags.HAS_MISSING))
+    'HAS_MISSING'
+    """
+    if isinstance(feature_group, tuple):
+        return tuple(read_feature_property(feature_properties, col, default=default) for col in feature_group)
+    else:
+        feature_prop = None
+        if feature_properties is not None:
+            feature_prop = feature_properties.get(feature_group)
+        if feature_prop is None:
+            feature_prop = default
+        return feature_prop
+
+
+__all__ = [
+    "IS_CONTINUOUS",
+    "IS_LINEAR",
+    "IS_ORDERED",
+    "IS_UNORDERED",
+    "IS_MONOTONIC",
+    "HAS_MISSING",
+    "HAS_MAGIC_INT_MISSING",
+    "MISSING_NOT_LEARNED",
+    "is_continuous_set",
+    "is_unordered_set",
+    "is_ordered_set",
+    "is_monotonic_set",
+    "has_missing_set",
+    "missing_not_learned_set",
+    "increasing_set",
+    "decreasing_set",
+    "check_flags_consistency",
+    "flags_to_string",
+    "read_feature_property",
+    "has_magic_missing_set",
+]

--- a/skpro/libs/cyclic_boosting/flags.py
+++ b/skpro/libs/cyclic_boosting/flags.py
@@ -1,4 +1,3 @@
-
 from enum import Enum
 from typing import Optional, Union
 
@@ -285,7 +284,9 @@ def check_flags_consistency(feature_prop: int) -> None:
     ValueError: One feature can either be ...
     """
     if (
-        int(is_continuous_set(feature_prop)) + int(is_ordered_set(feature_prop)) + int(is_unordered_set(feature_prop))
+        int(is_continuous_set(feature_prop))
+        + int(is_ordered_set(feature_prop))
+        + int(is_unordered_set(feature_prop))
         != 1
     ):
         raise ValueError(
@@ -351,7 +352,9 @@ def flags_to_string(flags_value: Union[int, tuple]) -> Union[tuple, str]:
 
 
 def _convert_flags_to_string(
-    flags_value: int, alternative_flag_list: Optional[int] = None, alternative_flags: Optional[dict] = None
+    flags_value: int,
+    alternative_flag_list: Optional[int] = None,
+    alternative_flags: Optional[dict] = None,
 ) -> str:
     """
     This function converts the numeric flags to the corresponding strings
@@ -419,7 +422,10 @@ def read_feature_property(
     'HAS_MISSING'
     """
     if isinstance(feature_group, tuple):
-        return tuple(read_feature_property(feature_properties, col, default=default) for col in feature_group)
+        return tuple(
+            read_feature_property(feature_properties, col, default=default)
+            for col in feature_group
+        )
     else:
         feature_prop = None
         if feature_properties is not None:

--- a/skpro/libs/cyclic_boosting/generic_loss.py
+++ b/skpro/libs/cyclic_boosting/generic_loss.py
@@ -1,0 +1,811 @@
+
+import abc
+import logging
+import warnings
+
+import numpy as np
+import pandas as pd
+
+import sklearn.base
+from scipy.optimize import minimize
+from scipy.stats import beta
+
+from skpro.libs.cyclic_boosting.base import CyclicBoostingBase, gaussian_matching_by_quantiles, Feature, CBLinkPredictionsFactors
+from skpro.libs.cyclic_boosting.link import LogLinkMixin, IdentityLinkMixin, LogitLinkMixin
+from skpro.libs.cyclic_boosting.utils import continuous_quantile_from_discrete_pdf, get_X_column
+from skpro.libs.cyclic_boosting.classification import get_beta_priors
+
+from typing import Tuple, Union
+
+_logger = logging.getLogger(__name__)
+
+
+
+class CBGenericLoss(CyclicBoostingBase, metaclass=abc.ABCMeta):
+    """
+    A generic loss, to be defined in the respective subclass, is minimized in
+    each bin of each feature. While binning, feature cycles, smoothing, and
+    iterations work in the same way as usual in Cyclic Boosting, the
+    minimization itself is performed via ``scipy.optimize.minimize`` (instead
+    of an analytical solution like, e.g., in ``CBPoissonRegressor``,
+    ``CBNBinomRegressor``, or ``CBLocationRegressor``).
+    """
+
+    def precalc_parameters(self, feature: Feature, y: np.ndarray, pred: CBLinkPredictionsFactors) -> None:
+        pass
+
+    def calc_parameters(
+        self, feature: Feature, y: np.ndarray, pred: CBLinkPredictionsFactors, prefit_data
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        Calling of the optimization (loss minimization) for the different bins
+        of the feature at hand. In contrast to the analytical solution in most
+        other Cyclic Boosting modes (e.g., ``CBPoissonRegressor``), working
+        simply via bin statistics (`bincount`), the generic, numerical
+        optimization here requires a dedicated loss funtion to be called for
+        each observation.
+
+        Parameters
+        ----------
+        feature : :class:`Feature`
+            feature for which the parameters of each bin are estimated
+        y : np.ndarray
+            target variable, containing data with `float` type (potentially
+            discrete)
+        pred
+            (in-sample) predictions from all other features (excluding the one
+            at hand)
+        prefit_data
+            data returned by :meth:`~.precalc_parameters` during fit, not used
+            here
+
+        Returns
+        -------
+        float, float
+            estimated parameters and its uncertainties
+        """
+        sorting = feature.lex_binned_data.argsort()
+        sorted_bins = feature.lex_binned_data[sorting]
+        bins, split_indices = np.unique(sorted_bins, return_index=True)
+        split_indices = split_indices[1:]
+
+        y_pred = np.hstack((y[..., np.newaxis], self.unlink_func(pred.predict_link())[..., np.newaxis]))
+        y_pred = np.hstack((y_pred, self.weights[..., np.newaxis]))
+        y_pred_bins = np.split(y_pred[sorting], split_indices)
+
+        # keep potential empty bins in multi-dimensional features
+        all_bins = range(feature.n_bins)
+        empty_bins = list(set(bins) ^ set(all_bins))
+        for i in empty_bins:
+            y_pred_bins.insert(i, np.zeros((0, 3)))
+
+        n_bins = len(y_pred_bins)
+        parameters = np.zeros(n_bins)
+        uncertainties = np.zeros(n_bins)
+
+        for bin in range(n_bins):
+            parameters[bin], uncertainties[bin] = self.optimization(
+                y_pred_bins[bin][:, 0], y_pred_bins[bin][:, 1], y_pred_bins[bin][:, 2]
+            )
+
+        neutral_factor = self.unlink_func(np.array(self.neutral_factor_link))
+        if neutral_factor != 0:
+            epsilon = 1e-5
+            parameters = np.where(np.abs(parameters) < epsilon, epsilon, parameters)
+            parameters = np.log(parameters)
+
+        return parameters, uncertainties
+
+    def optimization(self, y: np.ndarray, yhat_others: np.ndarray, weights: np.ndarray) -> Tuple[float, float]:
+        """
+        Minimization of the costs (potentially including sample weights) for
+        individual feature bins. The initial value for the parameters is set to
+        the neutral value for the respective mode.
+
+        Parameters
+        ----------
+        param : float
+            Parameter to be estimated for the feature bin at hand.
+        yhat_others : np.ndarray
+            (in-sample) predictions from all other features (excluding the one
+            at hand) for the bin at hand, containing data with `float` type
+        y : np.ndarray
+            target variable, containing data with `float` type (potentially discrete).
+        weights : np.ndarray
+            optional (otherwise set to 1) sample weights, containing data with `float` type
+
+        Returns
+        -------
+        float, float
+            estimated parameter and its uncertainty
+        """
+        neutral_factor = self.unlink_func(np.array(self.neutral_factor_link))
+        res = minimize(self.objective_function, neutral_factor, args=(yhat_others, y, weights))
+        return float(res.x[0]), self.uncertainty(y, weights)
+
+    def objective_function(self, param: float, yhat_others: np.ndarray, y: np.ndarray, weights: np.ndarray) -> float:
+        """
+        Calculation of the in-sample costs (potentially including sample
+        weights) for individual feature bins according to a given loss
+        function, to be minimized subsequently.
+
+        Parameters
+        ----------
+        param : float
+            Parameter to be estimated for the feature bin at hand.
+        yhat_others : np.ndarray
+            (in-sample) predictions of all other features (excluding the one at
+            hand) for the bin at hand, containing data with `float` type
+        y : np.ndarray
+            target variable, containing data with `float` type (potentially discrete)
+        weights : np.ndarray
+            optional (otherwise set to 1) sample weights, containing data with `float` type
+
+        Returns
+        -------
+        float
+            calcualted costs
+        """
+        model = self.model(param, yhat_others)
+        return self.costs(model, y, weights)
+
+    @abc.abstractmethod
+    def costs(self, prediction: np.ndarray, y: np.ndarray, weights: np.ndarray) -> float:
+        raise NotImplementedError("implement in subclass")
+
+    @abc.abstractmethod
+    def model(self, param: float, yhat_others: np.ndarray) -> np.ndarray:
+        raise NotImplementedError("implement in subclass")
+
+    @abc.abstractmethod
+    def uncertainty(self, y: np.ndarray, weights: np.ndarray) -> float:
+        """
+        Estimation of parameter uncertainty for a given feature bin.
+
+        Parameters
+        ----------
+        y : np.ndarray
+            target variable, containing data with `float` type (potentially discrete)
+        weights : np.ndarray
+            optional (otherwise set to 1) sample weights, containing data with `float` type
+
+        Returns
+        -------
+        float
+            estimated parameter uncertainty
+        """
+        raise NotImplementedError("implement in subclass")
+
+
+
+class CBQuantileRegressor(CBGenericLoss, sklearn.base.RegressorMixin, metaclass=abc.ABCMeta):
+    """
+    Cyclic Boosting generic quantile regressor. A quantile loss,
+    according to the desired quantile to be predicted, is minimized in each bin
+    of each feature. While its general structure allows arbitrary/empirical
+    target ranges/distributions, the multiplicative model of this mode requires
+    non-negative target values.
+
+    Parameters
+    ----------
+    quantile : float
+        quantile to be estimated
+    See: class:`cyclic_boosting.base` for all other parameters.
+    """
+
+    def __init__(
+        self,
+        feature_groups=None,
+        hierarchical_feature_groups=None,
+        feature_properties=None,
+        weight_column=None,
+        prior_prediction_column=None,
+        minimal_loss_change=1e-10,
+        minimal_factor_change=1e-10,
+        maximal_iterations=10,
+        observers=None,
+        smoother_choice=None,
+        output_column=None,
+        learn_rate=None,
+        quantile=None,
+        aggregate=True,
+    ):
+        CyclicBoostingBase.__init__(
+            self,
+            feature_groups=feature_groups,
+            hierarchical_feature_groups=hierarchical_feature_groups,
+            feature_properties=feature_properties,
+            weight_column=weight_column,
+            prior_prediction_column=prior_prediction_column,
+            minimal_loss_change=minimal_loss_change,
+            minimal_factor_change=minimal_factor_change,
+            maximal_iterations=maximal_iterations,
+            observers=observers,
+            smoother_choice=smoother_choice,
+            output_column=output_column,
+            learn_rate=learn_rate,
+            aggregate=aggregate,
+        )
+
+        self.quantile = quantile
+
+    def loss(self, prediction: np.ndarray, y: np.ndarray, weights: np.ndarray) -> float:
+        """
+        Calculation of the in-sample quantile loss, or to be exact costs,
+        (potentially including sample weights) after full feature cycles, i.e.,
+        iterations, to be used as stopping criteria.
+
+        Parameters
+        ----------
+        prediction : np.ndarray
+            (in-sample) predictions for desired quantile, containing data with `float` type
+        y : np.ndarray
+            target variable, containing data with `float` type (potentially discrete)
+        weights : np.ndarray
+            optional (otherwise set to 1) sample weights, containing data with `float` type
+
+        Returns
+        -------
+        float
+            calculated quantile costs
+        """
+        return self.quantile_costs(prediction, y, weights, self.quantile)
+
+    def _init_global_scale(self, X: Union[pd.DataFrame, np.ndarray], y: np.ndarray) -> None:
+        self.global_scale_link_, self.prior_pred_link_offset_ = self.quantile_global_scale(
+            X, y, self.quantile, self.weights, self.prior_prediction_column, self.link_func
+        )
+
+    def costs(self, prediction: np.ndarray, y: np.ndarray, weights: np.ndarray) -> float:
+        return self.quantile_costs(prediction, y, weights, self.quantile)
+
+    def prepare_plots(self, X: np.ndarray, y: np.ndarray, prediction: np.ndarray) -> None:
+        for feature in self.features:
+            if feature.feature_type is None:
+                weights = self.weights
+            else:
+                weights = self.weights_external
+
+            feature.bind_data(X, weights)
+
+            sum_w, _, sum_pw = (
+                np.bincount(feature.lex_binned_data, weights=w) for w in [weights, weights * y, weights * prediction]
+            )
+
+            df = pd.DataFrame({"y": y, "weights": weights, "binnumbers": feature.lex_binned_data})
+
+            def df_continuous_quantile_from_discrete_pdf(df, quantile):
+                return continuous_quantile_from_discrete_pdf(df["y"], quantile, df["weights"])
+
+            mean_target_binned = np.asarray(
+                df.groupby("binnumbers")[["y", "weights"]].apply(
+                    df_continuous_quantile_from_discrete_pdf, quantile=self.quantile
+                )
+            )
+
+            mean_prediction_binned = sum_pw / sum_w
+            mean_prediction_binned = np.where(np.isfinite(mean_prediction_binned), mean_prediction_binned, 1.0)
+
+            # keep potential empty bins in multi-dimensional features
+            all_bins = range(max(feature.lex_binned_data) + 1)
+            empty_bins = list(set(np.unique(feature.lex_binned_data)) ^ set(all_bins))
+            for i in empty_bins:
+                mean_target_binned = np.insert(mean_target_binned, i, 1.0)
+
+            mean_y_finite = continuous_quantile_from_discrete_pdf(y, self.quantile, weights)
+            mean_prediction_finite = np.sum(sum_pw) / np.sum(sum_w)
+
+            if len(mean_target_binned) + 1 == feature.n_bins:
+                mean_target_binned = np.append(mean_target_binned, 1.0)
+            if len(mean_prediction_binned) + 1 == feature.n_bins:
+                mean_prediction_binned = np.append(mean_prediction_binned, 1.0)
+
+            if isinstance(self, IdentityLinkMixin):
+                feature.mean_dev = mean_prediction_binned - mean_target_binned
+                feature.y = mean_target_binned - mean_y_finite
+                feature.prediction = mean_prediction_binned - mean_prediction_finite
+            else:
+                feature.mean_dev = np.log(mean_prediction_binned + 1e-12) - np.log(mean_target_binned + 1e-12)
+                feature.y = np.log(mean_target_binned / mean_y_finite + 1e-12)
+                feature.prediction = np.log(mean_prediction_binned / mean_prediction_finite + 1e-12)
+
+            feature.y_finite = mean_y_finite
+            feature.prediction_finite = mean_prediction_finite
+
+            feature.learn_rate = 1.0
+
+    def _call_observe_iterations(self, iteration, X, y, prediction, delta) -> None:
+        for observer in self.observers:
+            observer.observe_iterations(
+                iteration, X, y, prediction, self.weights, self.get_state(), delta, self.quantile
+            )
+
+    @staticmethod
+    def quantile_costs(prediction: np.ndarray, y: np.ndarray, weights: np.ndarray, quantile: float) -> float:
+        """
+        Calculation of the in-sample quantile costs (potentially including sample
+        weights).
+
+        Parameters
+        ----------
+        prediction : np.ndarray
+            (in-sample) predictions for desired quantile, containing data with `float` type
+        y : np.ndarray
+            target variable, containing data with `float` type (potentially discrete)
+        weights : np.ndarray
+            optional (otherwise set to 1) sample weights, containing data with `float` type
+        quantile : float
+            quantile to be estimated
+
+        Returns
+        -------
+        float
+            calculated quantile costs
+        """
+        if len(y) > 0:
+            sum_weighted_error = np.nansum(
+                ((y < prediction) * (1 - quantile) * (prediction - y) + (y >= prediction) * quantile * (y - prediction))
+                * weights
+            )
+            quantile_costs = sum_weighted_error / np.nansum(weights)
+            return quantile_costs
+        else:
+            return 0.0
+
+    @staticmethod
+    def quantile_global_scale(
+        X: Union[pd.DataFrame, np.ndarray],
+        y: np.ndarray,
+        quantile: float,
+        weights: np.ndarray,
+        prior_prediction_column: Union[str, int, None],
+        link_func,
+    ) -> Tuple:
+        """
+        Calculation of the global scale for quantile regression, corresponding
+        to the (continuous approximation of the) respective quantile of the
+        target values used in the training.
+
+        The exact value of the global scale is not critical for the model
+        accuracy (as the model has enough parameters to compensate).
+        However, a value which is not representative of a good overall average leads to factors with
+        averages unequal to 1 for each feature (making interpretation more
+        difficult).
+        """
+        if weights is None:
+            raise RuntimeError("The weights have to be initialized.")
+
+        global_scale_link_ = link_func(continuous_quantile_from_discrete_pdf(y, quantile, weights))
+
+        prior_pred_link_offset_ = None
+        if prior_prediction_column is not None:
+            prior_pred = get_X_column(X, prior_prediction_column)
+            finite = np.isfinite(prior_pred)
+            if not np.all(finite):
+                _logger.warning(
+                    "Found a total number of {} non-finite values in the prior prediction column".format(
+                        np.sum(~finite)
+                    )
+                )
+
+            prior_pred_mean = np.sum(prior_pred[finite] * weights[finite]) / np.sum(weights[finite])
+
+            prior_pred_link_mean = link_func(prior_pred_mean)
+
+            if np.isfinite(prior_pred_link_mean):
+                prior_pred_link_offset_ = global_scale_link_ - prior_pred_link_mean
+            else:
+                warnings.warn(
+                    "The mean prior prediction in link-space is not finite. "
+                    "Therefore no individualization is done "
+                    "and no prior mean subtraction is necessary."
+                )
+                prior_pred_link_offset_ = float(global_scale_link_)
+
+        return global_scale_link_, prior_pred_link_offset_
+
+
+class CBMultiplicativeQuantileRegressor(CBQuantileRegressor, LogLinkMixin):
+    """
+    Cyclic Boosting multiplicative quantile-regression mode. A quantile loss,
+    according to the desired quantile to be predicted, is minimized in each bin
+    of each feature. While its general structure allows arbitrary/empirical
+    target ranges/distributions, the multiplicative model of this mode requires
+    non-negative target values.
+
+    This should be used for non-negative target ranges, i.e., 0 to infinity.
+
+    Parameters
+    ----------
+    quantile : float
+        quantile to be estimated
+    See :class:`cyclic_boosting.base` for all other parameters.
+    """
+
+    def __init__(
+        self,
+        feature_groups=None,
+        hierarchical_feature_groups=None,
+        feature_properties=None,
+        weight_column=None,
+        prior_prediction_column=None,
+        minimal_loss_change=1e-10,
+        minimal_factor_change=1e-10,
+        maximal_iterations=10,
+        observers=None,
+        smoother_choice=None,
+        output_column=None,
+        learn_rate=None,
+        quantile=None,
+        aggregate=True,
+    ):
+        CBQuantileRegressor.__init__(
+            self,
+            feature_groups=feature_groups,
+            hierarchical_feature_groups=hierarchical_feature_groups,
+            feature_properties=feature_properties,
+            weight_column=weight_column,
+            prior_prediction_column=prior_prediction_column,
+            minimal_loss_change=minimal_loss_change,
+            minimal_factor_change=minimal_factor_change,
+            maximal_iterations=maximal_iterations,
+            observers=observers,
+            smoother_choice=smoother_choice,
+            output_column=output_column,
+            learn_rate=learn_rate,
+            quantile=quantile,
+            aggregate=aggregate,
+        )
+
+    def _check_y(self, y: np.ndarray) -> None:
+        check_y_multiplicative(y)
+
+    def model(self, param: float, yhat_others: np.ndarray) -> np.ndarray:
+        return model_multiplicative(param, yhat_others)
+
+    def uncertainty(self, y: np.ndarray, weights: np.ndarray) -> float:
+        return uncertainty_gamma(y, weights)
+
+
+class CBAdditiveQuantileRegressor(CBQuantileRegressor, IdentityLinkMixin):
+    """
+    Cyclic Boosting additive quantile-regression mode. A quantile loss,
+    according to the desired quantile to be predicted, is minimized in each bin
+    of each feature.
+
+    This should be used for unconstrained target ranges, i.e., -infinity to
+    infinity.
+
+    Parameters
+    ----------
+    quantile : float
+        quantile to be estimated
+    See: class:`cyclic_boosting.base` for all other parameters.
+    """
+
+    def __init__(
+        self,
+        feature_groups=None,
+        hierarchical_feature_groups=None,
+        feature_properties=None,
+        weight_column=None,
+        prior_prediction_column=None,
+        minimal_loss_change=1e-10,
+        minimal_factor_change=1e-10,
+        maximal_iterations=10,
+        observers=None,
+        smoother_choice=None,
+        output_column=None,
+        learn_rate=None,
+        quantile=None,
+        aggregate=True,
+    ):
+        CBQuantileRegressor.__init__(
+            self,
+            feature_groups=feature_groups,
+            hierarchical_feature_groups=hierarchical_feature_groups,
+            feature_properties=feature_properties,
+            weight_column=weight_column,
+            prior_prediction_column=prior_prediction_column,
+            minimal_loss_change=minimal_loss_change,
+            minimal_factor_change=minimal_factor_change,
+            maximal_iterations=maximal_iterations,
+            observers=observers,
+            smoother_choice=smoother_choice,
+            output_column=output_column,
+            learn_rate=learn_rate,
+            quantile=quantile,
+            aggregate=aggregate,
+        )
+
+    def _check_y(self, y: np.ndarray) -> None:
+        check_y_additive(y)
+
+    def model(self, param: float, yhat_others: np.ndarray) -> np.ndarray:
+        return model_additive(param, yhat_others)
+
+    def uncertainty(self, y: np.ndarray, weights: np.ndarray) -> float:
+        return uncertainty_gaussian(y, weights)
+
+
+def model_multiplicative(param: float, yhat_others: np.ndarray) -> np.ndarray:
+    return param * yhat_others
+
+
+def model_additive(param: float, yhat_others: np.ndarray) -> np.ndarray:
+    return param + yhat_others
+
+
+def uncertainty_gamma(y: np.ndarray, weights: np.ndarray) -> float:
+    # use moment-matching of a Gamma posterior with a log-normal
+    # distribution as approximation
+    alpha_prior = 2
+    alpha_posterior = np.sum(weights * y) + alpha_prior
+    sigma = np.sqrt(np.log(1 + alpha_posterior) - np.log(alpha_posterior))
+    return sigma
+
+
+def uncertainty_gaussian(y: np.ndarray, weights: np.ndarray) -> float:
+    sum_weights = np.sum(weights)
+    weighted_mean_y = np.sum(y * weights) / sum_weights
+    weighted_squared_residual_sum = np.sum(weights * (y - weighted_mean_y) ** 2)
+
+    variance_prior = weighted_squared_residual_sum / sum_weights
+    if variance_prior <= 1e-9:
+        variance_prior = 1.0
+
+    n_prior = 1
+    a_0 = 0.5 * n_prior
+    b_0 = a_0 * variance_prior
+    a = a_0 + 0.5 * sum_weights
+    b = b_0 + 0.5 * weighted_squared_residual_sum
+    variance_y = b / a
+    w = weights / variance_y
+
+    sum_w = np.sum(w)
+    sum_vw = np.sum(weights * w)
+    w0 = 1e-2
+    sum_w += w0
+    sum_vw += w0
+    variance_weighted_mean = sum_vw / sum_w**2
+
+    return np.sqrt(variance_weighted_mean)
+
+
+def uncertainty_beta(y: np.ndarray, weights: np.ndarray, link_func) -> float:
+    # use moment-matching of a Beta posterior with a log-normal
+    # distribution as approximation
+    alpha_prior, beta_prior = get_beta_priors()
+    alpha_posterior = np.sum(weights * y) + alpha_prior
+    beta_posterior = np.sum(weights * (1 - y)) + beta_prior
+    shift = 0.4 * (alpha_posterior / (alpha_posterior + beta_posterior) - 0.5)
+    perc1 = 0.75 - shift
+    perc2 = 0.25 - shift
+    posterior = beta(alpha_posterior, beta_posterior)
+    _, sigma = gaussian_matching_by_quantiles(posterior, link_func, perc1, perc2)
+    return sigma
+
+
+def check_y_multiplicative(y: np.ndarray) -> None:
+    """Check that y has no negative values."""
+    if not (y >= 0.0).all():
+        raise ValueError(
+            "The target y must be positive semi-definite " "and not NAN. y[~(y>=0)] = {0}".format(y[~(y >= 0)])
+        )
+
+
+def check_y_additive(y: np.ndarray) -> None:
+    if not np.isfinite(y).all():
+        raise ValueError("The target y must be real value and not NAN.")
+
+
+def check_y_classification(y: np.ndarray) -> None:
+    """Check that y has only values 0. or 1."""
+    if not ((y == 0.0) | (y == 1.0)).all():
+        raise ValueError(
+            "The target y must be either 0 or 1 "
+            "and not NAN. y[(y != 0) & (y != 1)] = {0}".format(y[(y != 0) & (y != 1)])
+        )
+
+
+class CBMultiplicativeGenericRegressor(CBGenericLoss, sklearn.base.RegressorMixin, LogLinkMixin):
+    """
+    Multiplicative regression mode allowing an arbitrary loss function to be
+    minimized in each feature bin.This should be used for non-negative target
+    ranges, i.e., 0 to infinity.
+
+    Parameters
+    ----------
+    costs : function
+        loss (to be exact, cost) function to be minimized
+    See :class:`cyclic_boosting.base` for all other parameters.
+    """
+
+    def __init__(
+        self,
+        feature_groups=None,
+        hierarchical_feature_groups=None,
+        feature_properties=None,
+        weight_column=None,
+        prior_prediction_column=None,
+        minimal_loss_change=1e-10,
+        minimal_factor_change=1e-10,
+        maximal_iterations=10,
+        observers=None,
+        smoother_choice=None,
+        output_column=None,
+        learn_rate=None,
+        aggregate=True,
+        costs=None,
+    ):
+        CyclicBoostingBase.__init__(
+            self,
+            feature_groups=feature_groups,
+            hierarchical_feature_groups=hierarchical_feature_groups,
+            feature_properties=feature_properties,
+            weight_column=weight_column,
+            prior_prediction_column=prior_prediction_column,
+            minimal_loss_change=minimal_loss_change,
+            minimal_factor_change=minimal_factor_change,
+            maximal_iterations=maximal_iterations,
+            observers=observers,
+            smoother_choice=smoother_choice,
+            output_column=output_column,
+            learn_rate=learn_rate,
+            aggregate=aggregate,
+        )
+
+        self.costs = costs
+
+    def loss(self, prediction: np.ndarray, y: np.ndarray, weights: np.ndarray) -> float:
+        return self.costs(prediction, y, weights)
+
+    def _check_y(self, y: np.ndarray) -> None:
+        check_y_multiplicative(y)
+
+    def costs(self, prediction: np.ndarray, y: np.ndarray, weights: np.ndarray) -> float:
+        return self.costs(prediction, y, weights)
+
+    def model(self, param: float, yhat_others: np.ndarray) -> np.ndarray:
+        return model_multiplicative(param, yhat_others)
+
+    def uncertainty(self, y: np.ndarray, weights: np.ndarray) -> float:
+        return uncertainty_gamma(y, weights)
+
+
+class CBAdditiveGenericRegressor(CBGenericLoss, sklearn.base.RegressorMixin, IdentityLinkMixin):
+    """
+    Additive regression mode allowing an arbitrary loss function to be
+    minimized in each feature bin. This should be used for unconstrained target
+    ranges, i.e., -infinity to infinity.
+
+    Parameters
+    ----------
+    costs : function
+        loss (to be exact, cost) function to be minimized
+    See :class:`cyclic_boosting.base` for all other parameters.
+    """
+
+    def __init__(
+        self,
+        feature_groups=None,
+        hierarchical_feature_groups=None,
+        feature_properties=None,
+        weight_column=None,
+        prior_prediction_column=None,
+        minimal_loss_change=1e-10,
+        minimal_factor_change=1e-10,
+        maximal_iterations=10,
+        observers=None,
+        smoother_choice=None,
+        output_column=None,
+        learn_rate=None,
+        aggregate=True,
+        costs=None,
+    ):
+        CyclicBoostingBase.__init__(
+            self,
+            feature_groups=feature_groups,
+            hierarchical_feature_groups=hierarchical_feature_groups,
+            feature_properties=feature_properties,
+            weight_column=weight_column,
+            prior_prediction_column=prior_prediction_column,
+            minimal_loss_change=minimal_loss_change,
+            minimal_factor_change=minimal_factor_change,
+            maximal_iterations=maximal_iterations,
+            observers=observers,
+            smoother_choice=smoother_choice,
+            output_column=output_column,
+            learn_rate=learn_rate,
+            aggregate=aggregate,
+        )
+
+        self.costs = costs
+
+    def loss(self, prediction: np.ndarray, y: np.ndarray, weights: np.ndarray) -> float:
+        return self.costs(prediction, y, weights)
+
+    def _check_y(self, y: np.ndarray) -> None:
+        check_y_additive(y)
+
+    def costs(self, prediction: np.ndarray, y: np.ndarray, weights: np.ndarray) -> float:
+        return self.costs(prediction, y, weights)
+
+    def model(self, param: float, yhat_others: np.ndarray) -> np.ndarray:
+        return model_additive(param, yhat_others)
+
+    def uncertainty(self, y: np.ndarray, weights: np.ndarray) -> float:
+        return uncertainty_gaussian(y, weights)
+
+
+class CBGenericClassifier(CBGenericLoss, sklearn.base.ClassifierMixin, LogitLinkMixin):
+    """
+    Multiplicative (binary, i.e., target values 0 and 1) classification mode
+    allowing an arbitrary loss function to be minimized in each feature bin.
+
+    Parameters
+    ----------
+    costs : function
+        loss (to be exact, cost) function to be minimized
+    See :class:`cyclic_boosting.base` for all other parameters.
+    """
+
+    def __init__(
+        self,
+        feature_groups=None,
+        hierarchical_feature_groups=None,
+        feature_properties=None,
+        weight_column=None,
+        prior_prediction_column=None,
+        minimal_loss_change=1e-10,
+        minimal_factor_change=1e-10,
+        maximal_iterations=10,
+        observers=None,
+        smoother_choice=None,
+        output_column=None,
+        learn_rate=None,
+        aggregate=True,
+        costs=None,
+    ):
+        CyclicBoostingBase.__init__(
+            self,
+            feature_groups=feature_groups,
+            hierarchical_feature_groups=hierarchical_feature_groups,
+            feature_properties=feature_properties,
+            weight_column=weight_column,
+            prior_prediction_column=prior_prediction_column,
+            minimal_loss_change=minimal_loss_change,
+            minimal_factor_change=minimal_factor_change,
+            maximal_iterations=maximal_iterations,
+            observers=observers,
+            smoother_choice=smoother_choice,
+            output_column=output_column,
+            learn_rate=learn_rate,
+            aggregate=aggregate,
+        )
+
+        self.costs = costs
+
+    def loss(self, prediction: np.ndarray, y: np.ndarray, weights: np.ndarray) -> float:
+        return self.costs(prediction, y, weights)
+
+    def _check_y(self, y: np.ndarray) -> None:
+        check_y_classification(y)
+
+    def costs(self, prediction: np.ndarray, y: np.ndarray, weights: np.ndarray) -> float:
+        return self.costs(prediction, y, weights)
+
+    def model(self, param: float, yhat_others: np.ndarray) -> np.ndarray:
+        return model_multiplicative(param, yhat_others)
+
+    def uncertainty(self, y: np.ndarray, weights: np.ndarray) -> float:
+        return uncertainty_beta(y, weights, self.link_func)
+
+
+__all__ = [
+    "CBMultiplicativeQuantileRegressor",
+    "CBAdditiveQuantileRegressor",
+    "CBMultiplicativeGenericRegressor",
+    "CBAdditiveGenericRegressor",
+    "CBGenericClassifier",
+]

--- a/skpro/libs/cyclic_boosting/generic_loss.py
+++ b/skpro/libs/cyclic_boosting/generic_loss.py
@@ -1,24 +1,32 @@
-
 import abc
 import logging
 import warnings
+from typing import Tuple, Union
 
 import numpy as np
 import pandas as pd
-
 import sklearn.base
 from scipy.optimize import minimize
 from scipy.stats import beta
 
-from skpro.libs.cyclic_boosting.base import CyclicBoostingBase, gaussian_matching_by_quantiles, Feature, CBLinkPredictionsFactors
-from skpro.libs.cyclic_boosting.link import LogLinkMixin, IdentityLinkMixin, LogitLinkMixin
-from skpro.libs.cyclic_boosting.utils import continuous_quantile_from_discrete_pdf, get_X_column
+from skpro.libs.cyclic_boosting.base import (
+    CBLinkPredictionsFactors,
+    CyclicBoostingBase,
+    Feature,
+    gaussian_matching_by_quantiles,
+)
 from skpro.libs.cyclic_boosting.classification import get_beta_priors
-
-from typing import Tuple, Union
+from skpro.libs.cyclic_boosting.link import (
+    IdentityLinkMixin,
+    LogitLinkMixin,
+    LogLinkMixin,
+)
+from skpro.libs.cyclic_boosting.utils import (
+    continuous_quantile_from_discrete_pdf,
+    get_X_column,
+)
 
 _logger = logging.getLogger(__name__)
-
 
 
 class CBGenericLoss(CyclicBoostingBase, metaclass=abc.ABCMeta):
@@ -31,11 +39,17 @@ class CBGenericLoss(CyclicBoostingBase, metaclass=abc.ABCMeta):
     ``CBNBinomRegressor``, or ``CBLocationRegressor``).
     """
 
-    def precalc_parameters(self, feature: Feature, y: np.ndarray, pred: CBLinkPredictionsFactors) -> None:
+    def precalc_parameters(
+        self, feature: Feature, y: np.ndarray, pred: CBLinkPredictionsFactors
+    ) -> None:
         pass
 
     def calc_parameters(
-        self, feature: Feature, y: np.ndarray, pred: CBLinkPredictionsFactors, prefit_data
+        self,
+        feature: Feature,
+        y: np.ndarray,
+        pred: CBLinkPredictionsFactors,
+        prefit_data,
     ) -> Tuple[np.ndarray, np.ndarray]:
         """
         Calling of the optimization (loss minimization) for the different bins
@@ -69,7 +83,9 @@ class CBGenericLoss(CyclicBoostingBase, metaclass=abc.ABCMeta):
         bins, split_indices = np.unique(sorted_bins, return_index=True)
         split_indices = split_indices[1:]
 
-        y_pred = np.hstack((y[..., np.newaxis], self.unlink_func(pred.predict_link())[..., np.newaxis]))
+        y_pred = np.hstack(
+            (y[..., np.newaxis], self.unlink_func(pred.predict_link())[..., np.newaxis])
+        )
         y_pred = np.hstack((y_pred, self.weights[..., np.newaxis]))
         y_pred_bins = np.split(y_pred[sorting], split_indices)
 
@@ -96,7 +112,9 @@ class CBGenericLoss(CyclicBoostingBase, metaclass=abc.ABCMeta):
 
         return parameters, uncertainties
 
-    def optimization(self, y: np.ndarray, yhat_others: np.ndarray, weights: np.ndarray) -> Tuple[float, float]:
+    def optimization(
+        self, y: np.ndarray, yhat_others: np.ndarray, weights: np.ndarray
+    ) -> Tuple[float, float]:
         """
         Minimization of the costs (potentially including sample weights) for
         individual feature bins. The initial value for the parameters is set to
@@ -120,10 +138,14 @@ class CBGenericLoss(CyclicBoostingBase, metaclass=abc.ABCMeta):
             estimated parameter and its uncertainty
         """
         neutral_factor = self.unlink_func(np.array(self.neutral_factor_link))
-        res = minimize(self.objective_function, neutral_factor, args=(yhat_others, y, weights))
+        res = minimize(
+            self.objective_function, neutral_factor, args=(yhat_others, y, weights)
+        )
         return float(res.x[0]), self.uncertainty(y, weights)
 
-    def objective_function(self, param: float, yhat_others: np.ndarray, y: np.ndarray, weights: np.ndarray) -> float:
+    def objective_function(
+        self, param: float, yhat_others: np.ndarray, y: np.ndarray, weights: np.ndarray
+    ) -> float:
         """
         Calculation of the in-sample costs (potentially including sample
         weights) for individual feature bins according to a given loss
@@ -150,7 +172,9 @@ class CBGenericLoss(CyclicBoostingBase, metaclass=abc.ABCMeta):
         return self.costs(model, y, weights)
 
     @abc.abstractmethod
-    def costs(self, prediction: np.ndarray, y: np.ndarray, weights: np.ndarray) -> float:
+    def costs(
+        self, prediction: np.ndarray, y: np.ndarray, weights: np.ndarray
+    ) -> float:
         raise NotImplementedError("implement in subclass")
 
     @abc.abstractmethod
@@ -177,8 +201,9 @@ class CBGenericLoss(CyclicBoostingBase, metaclass=abc.ABCMeta):
         raise NotImplementedError("implement in subclass")
 
 
-
-class CBQuantileRegressor(CBGenericLoss, sklearn.base.RegressorMixin, metaclass=abc.ABCMeta):
+class CBQuantileRegressor(
+    CBGenericLoss, sklearn.base.RegressorMixin, metaclass=abc.ABCMeta
+):
     """
     Cyclic Boosting generic quantile regressor. A quantile loss,
     according to the desired quantile to be predicted, is minimized in each bin
@@ -251,15 +276,29 @@ class CBQuantileRegressor(CBGenericLoss, sklearn.base.RegressorMixin, metaclass=
         """
         return self.quantile_costs(prediction, y, weights, self.quantile)
 
-    def _init_global_scale(self, X: Union[pd.DataFrame, np.ndarray], y: np.ndarray) -> None:
-        self.global_scale_link_, self.prior_pred_link_offset_ = self.quantile_global_scale(
-            X, y, self.quantile, self.weights, self.prior_prediction_column, self.link_func
+    def _init_global_scale(
+        self, X: Union[pd.DataFrame, np.ndarray], y: np.ndarray
+    ) -> None:
+        (
+            self.global_scale_link_,
+            self.prior_pred_link_offset_,
+        ) = self.quantile_global_scale(
+            X,
+            y,
+            self.quantile,
+            self.weights,
+            self.prior_prediction_column,
+            self.link_func,
         )
 
-    def costs(self, prediction: np.ndarray, y: np.ndarray, weights: np.ndarray) -> float:
+    def costs(
+        self, prediction: np.ndarray, y: np.ndarray, weights: np.ndarray
+    ) -> float:
         return self.quantile_costs(prediction, y, weights, self.quantile)
 
-    def prepare_plots(self, X: np.ndarray, y: np.ndarray, prediction: np.ndarray) -> None:
+    def prepare_plots(
+        self, X: np.ndarray, y: np.ndarray, prediction: np.ndarray
+    ) -> None:
         for feature in self.features:
             if feature.feature_type is None:
                 weights = self.weights
@@ -269,13 +308,18 @@ class CBQuantileRegressor(CBGenericLoss, sklearn.base.RegressorMixin, metaclass=
             feature.bind_data(X, weights)
 
             sum_w, _, sum_pw = (
-                np.bincount(feature.lex_binned_data, weights=w) for w in [weights, weights * y, weights * prediction]
+                np.bincount(feature.lex_binned_data, weights=w)
+                for w in [weights, weights * y, weights * prediction]
             )
 
-            df = pd.DataFrame({"y": y, "weights": weights, "binnumbers": feature.lex_binned_data})
+            df = pd.DataFrame(
+                {"y": y, "weights": weights, "binnumbers": feature.lex_binned_data}
+            )
 
             def df_continuous_quantile_from_discrete_pdf(df, quantile):
-                return continuous_quantile_from_discrete_pdf(df["y"], quantile, df["weights"])
+                return continuous_quantile_from_discrete_pdf(
+                    df["y"], quantile, df["weights"]
+                )
 
             mean_target_binned = np.asarray(
                 df.groupby("binnumbers")[["y", "weights"]].apply(
@@ -284,7 +328,9 @@ class CBQuantileRegressor(CBGenericLoss, sklearn.base.RegressorMixin, metaclass=
             )
 
             mean_prediction_binned = sum_pw / sum_w
-            mean_prediction_binned = np.where(np.isfinite(mean_prediction_binned), mean_prediction_binned, 1.0)
+            mean_prediction_binned = np.where(
+                np.isfinite(mean_prediction_binned), mean_prediction_binned, 1.0
+            )
 
             # keep potential empty bins in multi-dimensional features
             all_bins = range(max(feature.lex_binned_data) + 1)
@@ -292,7 +338,9 @@ class CBQuantileRegressor(CBGenericLoss, sklearn.base.RegressorMixin, metaclass=
             for i in empty_bins:
                 mean_target_binned = np.insert(mean_target_binned, i, 1.0)
 
-            mean_y_finite = continuous_quantile_from_discrete_pdf(y, self.quantile, weights)
+            mean_y_finite = continuous_quantile_from_discrete_pdf(
+                y, self.quantile, weights
+            )
             mean_prediction_finite = np.sum(sum_pw) / np.sum(sum_w)
 
             if len(mean_target_binned) + 1 == feature.n_bins:
@@ -305,9 +353,13 @@ class CBQuantileRegressor(CBGenericLoss, sklearn.base.RegressorMixin, metaclass=
                 feature.y = mean_target_binned - mean_y_finite
                 feature.prediction = mean_prediction_binned - mean_prediction_finite
             else:
-                feature.mean_dev = np.log(mean_prediction_binned + 1e-12) - np.log(mean_target_binned + 1e-12)
+                feature.mean_dev = np.log(mean_prediction_binned + 1e-12) - np.log(
+                    mean_target_binned + 1e-12
+                )
                 feature.y = np.log(mean_target_binned / mean_y_finite + 1e-12)
-                feature.prediction = np.log(mean_prediction_binned / mean_prediction_finite + 1e-12)
+                feature.prediction = np.log(
+                    mean_prediction_binned / mean_prediction_finite + 1e-12
+                )
 
             feature.y_finite = mean_y_finite
             feature.prediction_finite = mean_prediction_finite
@@ -317,11 +369,20 @@ class CBQuantileRegressor(CBGenericLoss, sklearn.base.RegressorMixin, metaclass=
     def _call_observe_iterations(self, iteration, X, y, prediction, delta) -> None:
         for observer in self.observers:
             observer.observe_iterations(
-                iteration, X, y, prediction, self.weights, self.get_state(), delta, self.quantile
+                iteration,
+                X,
+                y,
+                prediction,
+                self.weights,
+                self.get_state(),
+                delta,
+                self.quantile,
             )
 
     @staticmethod
-    def quantile_costs(prediction: np.ndarray, y: np.ndarray, weights: np.ndarray, quantile: float) -> float:
+    def quantile_costs(
+        prediction: np.ndarray, y: np.ndarray, weights: np.ndarray, quantile: float
+    ) -> float:
         """
         Calculation of the in-sample quantile costs (potentially including sample
         weights).
@@ -344,7 +405,10 @@ class CBQuantileRegressor(CBGenericLoss, sklearn.base.RegressorMixin, metaclass=
         """
         if len(y) > 0:
             sum_weighted_error = np.nansum(
-                ((y < prediction) * (1 - quantile) * (prediction - y) + (y >= prediction) * quantile * (y - prediction))
+                (
+                    (y < prediction) * (1 - quantile) * (prediction - y)
+                    + (y >= prediction) * quantile * (y - prediction)
+                )
                 * weights
             )
             quantile_costs = sum_weighted_error / np.nansum(weights)
@@ -375,7 +439,9 @@ class CBQuantileRegressor(CBGenericLoss, sklearn.base.RegressorMixin, metaclass=
         if weights is None:
             raise RuntimeError("The weights have to be initialized.")
 
-        global_scale_link_ = link_func(continuous_quantile_from_discrete_pdf(y, quantile, weights))
+        global_scale_link_ = link_func(
+            continuous_quantile_from_discrete_pdf(y, quantile, weights)
+        )
 
         prior_pred_link_offset_ = None
         if prior_prediction_column is not None:
@@ -388,7 +454,9 @@ class CBQuantileRegressor(CBGenericLoss, sklearn.base.RegressorMixin, metaclass=
                     )
                 )
 
-            prior_pred_mean = np.sum(prior_pred[finite] * weights[finite]) / np.sum(weights[finite])
+            prior_pred_mean = np.sum(prior_pred[finite] * weights[finite]) / np.sum(
+                weights[finite]
+            )
 
             prior_pred_link_mean = link_func(prior_pred_mean)
 
@@ -590,7 +658,8 @@ def check_y_multiplicative(y: np.ndarray) -> None:
     """Check that y has no negative values."""
     if not (y >= 0.0).all():
         raise ValueError(
-            "The target y must be positive semi-definite " "and not NAN. y[~(y>=0)] = {0}".format(y[~(y >= 0)])
+            "The target y must be positive semi-definite "
+            "and not NAN. y[~(y>=0)] = {}".format(y[~(y >= 0)])
         )
 
 
@@ -604,11 +673,13 @@ def check_y_classification(y: np.ndarray) -> None:
     if not ((y == 0.0) | (y == 1.0)).all():
         raise ValueError(
             "The target y must be either 0 or 1 "
-            "and not NAN. y[(y != 0) & (y != 1)] = {0}".format(y[(y != 0) & (y != 1)])
+            "and not NAN. y[(y != 0) & (y != 1)] = {}".format(y[(y != 0) & (y != 1)])
         )
 
 
-class CBMultiplicativeGenericRegressor(CBGenericLoss, sklearn.base.RegressorMixin, LogLinkMixin):
+class CBMultiplicativeGenericRegressor(
+    CBGenericLoss, sklearn.base.RegressorMixin, LogLinkMixin
+):
     """
     Multiplicative regression mode allowing an arbitrary loss function to be
     minimized in each feature bin.This should be used for non-negative target
@@ -663,7 +734,9 @@ class CBMultiplicativeGenericRegressor(CBGenericLoss, sklearn.base.RegressorMixi
     def _check_y(self, y: np.ndarray) -> None:
         check_y_multiplicative(y)
 
-    def costs(self, prediction: np.ndarray, y: np.ndarray, weights: np.ndarray) -> float:
+    def costs(
+        self, prediction: np.ndarray, y: np.ndarray, weights: np.ndarray
+    ) -> float:
         return self.costs(prediction, y, weights)
 
     def model(self, param: float, yhat_others: np.ndarray) -> np.ndarray:
@@ -673,7 +746,9 @@ class CBMultiplicativeGenericRegressor(CBGenericLoss, sklearn.base.RegressorMixi
         return uncertainty_gamma(y, weights)
 
 
-class CBAdditiveGenericRegressor(CBGenericLoss, sklearn.base.RegressorMixin, IdentityLinkMixin):
+class CBAdditiveGenericRegressor(
+    CBGenericLoss, sklearn.base.RegressorMixin, IdentityLinkMixin
+):
     """
     Additive regression mode allowing an arbitrary loss function to be
     minimized in each feature bin. This should be used for unconstrained target
@@ -728,7 +803,9 @@ class CBAdditiveGenericRegressor(CBGenericLoss, sklearn.base.RegressorMixin, Ide
     def _check_y(self, y: np.ndarray) -> None:
         check_y_additive(y)
 
-    def costs(self, prediction: np.ndarray, y: np.ndarray, weights: np.ndarray) -> float:
+    def costs(
+        self, prediction: np.ndarray, y: np.ndarray, weights: np.ndarray
+    ) -> float:
         return self.costs(prediction, y, weights)
 
     def model(self, param: float, yhat_others: np.ndarray) -> np.ndarray:
@@ -792,7 +869,9 @@ class CBGenericClassifier(CBGenericLoss, sklearn.base.ClassifierMixin, LogitLink
     def _check_y(self, y: np.ndarray) -> None:
         check_y_classification(y)
 
-    def costs(self, prediction: np.ndarray, y: np.ndarray, weights: np.ndarray) -> float:
+    def costs(
+        self, prediction: np.ndarray, y: np.ndarray, weights: np.ndarray
+    ) -> float:
         return self.costs(prediction, y, weights)
 
     def model(self, param: float, yhat_others: np.ndarray) -> np.ndarray:

--- a/skpro/libs/cyclic_boosting/interaction_selection.py
+++ b/skpro/libs/cyclic_boosting/interaction_selection.py
@@ -1,0 +1,110 @@
+from itertools import combinations
+
+import numpy as np
+import pandas as pd
+from sklearn.feature_selection import SelectKBest, f_regression, f_classif
+
+from skpro.libs.cyclic_boosting.binning import BinNumberTransformer
+from skpro.libs.cyclic_boosting.utils import multidim_binnos_to_lexicographic_binnos
+
+from typing import List, Tuple, Dict, Optional
+
+
+def create_interactions(features1D: List[str], dim: int) -> List[Tuple]:
+    """
+    Creation of all possible dim-dimensional combinations from one-dimensional feature list.
+
+    Parameters
+    ----------
+    features1D
+        list of one-dimensional features
+    dim : int
+        maximal dimensionality of interactions terms to be created
+
+    Returns
+    -------
+        list of tuples of strings (feature names) representing all dim-dimensional feature combinations
+    """
+    interactions = []
+    for n in range(2, dim + 1):
+        interactions += list(combinations(features1D, n))
+    return interactions
+
+
+def build_binned_interaction_features(
+    X: pd.DataFrame,
+    interaction_terms: List[Tuple],
+    feature_properties: Dict[str, object],
+    number_of_bins: Optional[int] = 100,
+) -> pd.DataFrame:
+    """
+    Creation of multi-dimensional features from one-dimensional ones for all interaction_terms.
+
+    Parameters
+    ----------
+    X : pd.DataFrame
+        design matrix
+    interaction_terms
+        list of tuples of all multi-dimensional feature combinations to be used as interaction terms
+    feature_properties : dict
+        names and pre-processing flags of all one-dimensional features
+    number_of_bins : int
+        number of bins to be used for binning of non-categorical features
+
+    Returns
+    -------
+    pd.DataFrame
+        data frame with different interaction terms as flattened (binned) multi-dimensional features
+    """
+    binner = BinNumberTransformer(n_bins=number_of_bins, feature_properties=feature_properties, inplace=False)
+    binned_1D = binner.fit_transform(X)
+
+    features_multidim = pd.DataFrame()
+    for it in interaction_terms:
+        cols = []
+        for i in it:
+            cols.append(binned_1D[i])
+        binned_multidim = np.column_stack(tuple(cols))
+        features_multidim[it], _ = multidim_binnos_to_lexicographic_binnos(binned_multidim)
+
+    return features_multidim
+
+
+def select_interaction_terms_anova(
+    X: pd.DataFrame,
+    y: np.ndarray,
+    feature_properties: Dict[str, object],
+    interaction_dim: int,
+    k_best: int,
+    classification: Optional[bool] = False,
+) -> List[str]:
+    """
+    ANOVA selection of interaction terms for a given data set by means of binning.
+
+    Parameters
+    ----------
+    X : pd.DataFrame
+        design matrix
+    y : np.ndarray
+        target
+    feature_properties : dict
+        names and pre-processing flags of all one-dimensional features
+    interaction_dim
+        maximal dimensionality of interactions terms to be considered
+    k_best : int
+        number of interaction terms to be selected
+
+    Returns
+    -------
+        list of the names of the selected interaction terms
+    """
+    interaction_terms = create_interactions(list(feature_properties.keys()), interaction_dim)
+
+    interaction_term_features = build_binned_interaction_features(X, interaction_terms, feature_properties)
+
+    if classification:
+        anova_est = SelectKBest(f_classif, k=k_best)
+    else:
+        anova_est = SelectKBest(f_regression, k=k_best)
+    anova_est.fit(interaction_term_features, y)
+    return list(anova_est.get_feature_names_out(input_features=interaction_term_features.columns))

--- a/skpro/libs/cyclic_boosting/interaction_selection.py
+++ b/skpro/libs/cyclic_boosting/interaction_selection.py
@@ -1,13 +1,12 @@
 from itertools import combinations
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
-from sklearn.feature_selection import SelectKBest, f_regression, f_classif
+from sklearn.feature_selection import SelectKBest, f_classif, f_regression
 
 from skpro.libs.cyclic_boosting.binning import BinNumberTransformer
 from skpro.libs.cyclic_boosting.utils import multidim_binnos_to_lexicographic_binnos
-
-from typing import List, Tuple, Dict, Optional
 
 
 def create_interactions(features1D: List[str], dim: int) -> List[Tuple]:
@@ -56,7 +55,9 @@ def build_binned_interaction_features(
     pd.DataFrame
         data frame with different interaction terms as flattened (binned) multi-dimensional features
     """
-    binner = BinNumberTransformer(n_bins=number_of_bins, feature_properties=feature_properties, inplace=False)
+    binner = BinNumberTransformer(
+        n_bins=number_of_bins, feature_properties=feature_properties, inplace=False
+    )
     binned_1D = binner.fit_transform(X)
 
     features_multidim = pd.DataFrame()
@@ -65,7 +66,9 @@ def build_binned_interaction_features(
         for i in it:
             cols.append(binned_1D[i])
         binned_multidim = np.column_stack(tuple(cols))
-        features_multidim[it], _ = multidim_binnos_to_lexicographic_binnos(binned_multidim)
+        features_multidim[it], _ = multidim_binnos_to_lexicographic_binnos(
+            binned_multidim
+        )
 
     return features_multidim
 
@@ -98,13 +101,21 @@ def select_interaction_terms_anova(
     -------
         list of the names of the selected interaction terms
     """
-    interaction_terms = create_interactions(list(feature_properties.keys()), interaction_dim)
+    interaction_terms = create_interactions(
+        list(feature_properties.keys()), interaction_dim
+    )
 
-    interaction_term_features = build_binned_interaction_features(X, interaction_terms, feature_properties)
+    interaction_term_features = build_binned_interaction_features(
+        X, interaction_terms, feature_properties
+    )
 
     if classification:
         anova_est = SelectKBest(f_classif, k=k_best)
     else:
         anova_est = SelectKBest(f_regression, k=k_best)
     anova_est.fit(interaction_term_features, y)
-    return list(anova_est.get_feature_names_out(input_features=interaction_term_features.columns))
+    return list(
+        anova_est.get_feature_names_out(
+            input_features=interaction_term_features.columns
+        )
+    )

--- a/skpro/libs/cyclic_boosting/learning_rate.py
+++ b/skpro/libs/cyclic_boosting/learning_rate.py
@@ -1,0 +1,86 @@
+
+import numpy as np
+from skpro.libs.cyclic_boosting.features import Feature
+from typing import Optional, Union
+
+
+def constant_learn_rate_one(iteration: int, maximal_iteration: int, feature: Optional[Feature] = None) -> float:
+    """Function to specify the learning rate of a cyclic boosting iteration.
+    The learning rate returned is always 1.
+
+    Parameters
+    ----------
+
+    iteration: int
+        Current major cyclic boosting iteration.
+
+    maximal_iteration: int
+        Maximal cyclic boosting iteration.
+
+    feature: :class:`cyclic_boosting.base.Feature`
+        Feature
+    """
+    return 1.0
+
+
+def linear_learn_rate(iteration: int, maximal_iteration: Union[int, float], feature: Optional[Feature] = None) -> float:
+    """Function to specify the learning rate of a cyclic boosting iteration.
+    The learning rate is linear increasing each iteration until it reaches 1 in
+    the last iteration.
+
+
+    Parameters
+    ----------
+
+    iteration: int
+        Current major cyclic boosting iteration.
+
+    maximal_iteration: int
+        Maximal cyclic boosting iteration.
+
+    feature: :class:`cyclic_boosting.base.Feature`
+        Feature
+    """
+    return iteration * (1.0 / maximal_iteration)
+
+
+def logistic_learn_rate(iteration: int, maximal_iteration: int, feature: Optional[Feature] = None) -> float:
+    """Function to specify the learning rate of a cyclic boosting iteration.
+    The learning rate has a logistic form.
+
+    Parameters
+    ----------
+
+    iteration: int
+        Current major cyclic boosting iteration.
+
+    maximal_iteration: int
+        Maximal cyclic boosting iteration.
+
+    feature: :class:`cyclic_boosting.base.Feature`
+        Feature
+    """
+    saturation_value = 0.999999999
+    x_t = maximal_iteration / np.log((1 - saturation_value) / (1 + saturation_value))
+    return (1.0 / (1.0 + np.exp(iteration / x_t)) - 0.5) * 2
+
+
+def half_linear_learn_rate(iteration: int, maximal_iteration: int, feature: Optional[Feature] = None) -> float:
+    """Function to specify the learning rate of a cyclic boosting iteration.
+    The learning rate is linear increasing each iteration until it reaches 1 in
+    half of the iterations.
+
+
+    Parameters
+    ----------
+
+    iteration: int
+        Current major cyclic boosting iteration.
+
+    maximal_iteration: int
+        Maximal cyclic boosting iteration.
+
+    feature: :class:`cyclic_boosting.base.Feature`
+        Feature
+    """
+    return np.minimum(linear_learn_rate(iteration, maximal_iteration * 0.5, feature), 1.0)

--- a/skpro/libs/cyclic_boosting/learning_rate.py
+++ b/skpro/libs/cyclic_boosting/learning_rate.py
@@ -1,10 +1,13 @@
-
-import numpy as np
-from skpro.libs.cyclic_boosting.features import Feature
 from typing import Optional, Union
 
+import numpy as np
 
-def constant_learn_rate_one(iteration: int, maximal_iteration: int, feature: Optional[Feature] = None) -> float:
+from skpro.libs.cyclic_boosting.features import Feature
+
+
+def constant_learn_rate_one(
+    iteration: int, maximal_iteration: int, feature: Optional[Feature] = None
+) -> float:
     """Function to specify the learning rate of a cyclic boosting iteration.
     The learning rate returned is always 1.
 
@@ -23,7 +26,11 @@ def constant_learn_rate_one(iteration: int, maximal_iteration: int, feature: Opt
     return 1.0
 
 
-def linear_learn_rate(iteration: int, maximal_iteration: Union[int, float], feature: Optional[Feature] = None) -> float:
+def linear_learn_rate(
+    iteration: int,
+    maximal_iteration: Union[int, float],
+    feature: Optional[Feature] = None,
+) -> float:
     """Function to specify the learning rate of a cyclic boosting iteration.
     The learning rate is linear increasing each iteration until it reaches 1 in
     the last iteration.
@@ -44,7 +51,9 @@ def linear_learn_rate(iteration: int, maximal_iteration: Union[int, float], feat
     return iteration * (1.0 / maximal_iteration)
 
 
-def logistic_learn_rate(iteration: int, maximal_iteration: int, feature: Optional[Feature] = None) -> float:
+def logistic_learn_rate(
+    iteration: int, maximal_iteration: int, feature: Optional[Feature] = None
+) -> float:
     """Function to specify the learning rate of a cyclic boosting iteration.
     The learning rate has a logistic form.
 
@@ -65,7 +74,9 @@ def logistic_learn_rate(iteration: int, maximal_iteration: int, feature: Optiona
     return (1.0 / (1.0 + np.exp(iteration / x_t)) - 0.5) * 2
 
 
-def half_linear_learn_rate(iteration: int, maximal_iteration: int, feature: Optional[Feature] = None) -> float:
+def half_linear_learn_rate(
+    iteration: int, maximal_iteration: int, feature: Optional[Feature] = None
+) -> float:
     """Function to specify the learning rate of a cyclic boosting iteration.
     The learning rate is linear increasing each iteration until it reaches 1 in
     half of the iterations.
@@ -83,4 +94,6 @@ def half_linear_learn_rate(iteration: int, maximal_iteration: int, feature: Opti
     feature: :class:`cyclic_boosting.base.Feature`
         Feature
     """
-    return np.minimum(linear_learn_rate(iteration, maximal_iteration * 0.5, feature), 1.0)
+    return np.minimum(
+        linear_learn_rate(iteration, maximal_iteration * 0.5, feature), 1.0
+    )

--- a/skpro/libs/cyclic_boosting/link.py
+++ b/skpro/libs/cyclic_boosting/link.py
@@ -1,0 +1,111 @@
+"""This module contains some general/canonical link-mean-function pairs such as
+
+- :class:`~LogLinkMixin`
+- :class:`~LogitLinkMixin`
+"""
+
+
+import abc
+
+import numexpr
+import numpy as np
+
+
+
+
+class LinkFunction(object, metaclass=abc.ABCMeta):
+    r"""Abstract base class for link function computations."""
+
+    @abc.abstractmethod
+    def is_in_range(self, values: np.ndarray):
+        """Check if values can be transformed by the link function."""
+        pass
+
+    @abc.abstractmethod
+    def link_func(self, m: np.ndarray):
+        """Transform values in m to link space"""
+        pass
+
+    @abc.abstractmethod
+    def unlink_func(self, l: np.ndarray):
+        """Inverse of :meth:`~link_func`"""
+        pass
+
+
+class LogLinkMixin(LinkFunction):
+    r"""Link function and mean function for example for Poisson-distributed
+    data.
+
+    Supported values are in the range :math:`x > 0`"""
+
+    def unlink_func(self, l: np.ndarray) -> np.ndarray:
+        r"""Calculates the inverse of the link function
+
+        .. math::
+
+           \mu = \exp(l)
+        """
+        return numexpr.evaluate("exp(l)")
+
+    def is_in_range(self, m: np.ndarray) -> bool:
+        return np.all(m > 0.0)
+
+    def link_func(self, m: np.ndarray) -> np.ndarray:
+        r"""Calculates the log-link
+
+        .. math::
+
+           l = \log(\mu)
+        """
+        return numexpr.evaluate("log(m)")
+
+
+class LogitLinkMixin(LinkFunction):
+    r"""Link for the logit transformation.
+
+    Supported values are in the range :math:`0 \leq x \leq 1`
+    """
+
+    def is_in_range(self, p: np.ndarray) -> bool:
+        return np.all(numexpr.evaluate("(p >= 0.0) & (p <= 1.0)"))
+
+    def link_func(self, p: np.ndarray) -> np.ndarray:
+        r"""Calculates the logit-link
+
+        .. math::
+
+           l = \log(\frac{p}{1-p})
+        """
+        return numexpr.evaluate("log(p / (1. - p))")
+
+    def unlink_func(self, l: np.ndarray) -> np.ndarray:
+        r"""Inverse of logit-link
+
+        .. math::
+
+           p = \frac{1}{1+ \exp(-l)}
+        """
+        return numexpr.evaluate("1. / (1. + exp(-l))")
+
+
+class IdentityLinkMixin(LinkFunction):
+    """Identity link"""
+
+    def is_in_range(self, m: np.ndarray):
+        return True
+
+    def link_func(self, m: np.ndarray):
+        r"""Returns a copy of the input"""
+        return m.copy()
+
+    def unlink_func(self, l: np.ndarray):
+        r"""Returns a copy of the input"""
+        return l.copy()
+
+
+__all__ = [
+    "LinkFunction",
+    "LogLinkMixin",
+    "LogitLinkMixin",
+    "IdentityLinkMixin",
+]

--- a/skpro/libs/cyclic_boosting/link.py
+++ b/skpro/libs/cyclic_boosting/link.py
@@ -11,9 +11,7 @@ import numexpr
 import numpy as np
 
 
-
-
-class LinkFunction(object, metaclass=abc.ABCMeta):
+class LinkFunction(metaclass=abc.ABCMeta):
     r"""Abstract base class for link function computations."""
 
     @abc.abstractmethod

--- a/skpro/libs/cyclic_boosting/location.py
+++ b/skpro/libs/cyclic_boosting/location.py
@@ -1,0 +1,232 @@
+"""
+Cyclic Boosting Regression for a location parameter target.
+"""
+
+
+import logging
+
+import numexpr
+import numpy as np
+import sklearn.base
+
+from skpro.libs.cyclic_boosting.base import CyclicBoostingBase, calc_factors_generic
+from skpro.libs.cyclic_boosting.link import IdentityLinkMixin
+from skpro.libs.cyclic_boosting.utils import weighted_stddev
+
+_logger = logging.getLogger(__name__)
+
+
+class CBLocPoissonRegressor(CyclicBoostingBase, sklearn.base.RegressorMixin, IdentityLinkMixin):
+    def precalc_parameters(self, feature, y, pred):
+        lex_binnumbers = feature.lex_binned_data
+        minlength = feature.n_bins
+        weights = self.weights
+
+        global_std = weighted_stddev(y, weights)
+        y_sum = np.bincount(lex_binnumbers, weights=y * weights, minlength=minlength)
+        bincount = np.bincount(lex_binnumbers, weights=weights, minlength=minlength)
+        return y_sum, bincount, global_std
+
+    def _check_y(self, y):
+        """Check that y has no negative values."""
+        if not np.isfinite(y).all():
+            raise ValueError("The target y must be real value and not NAN.")
+
+    def _regularize_summands(self, bincount, summands, uncertainties, global_std):
+        r"""Regularize the summands to the prior mean. Depenending on the
+        measured statistics of the bin.
+
+        :math:`\mu_n = \sigma_{n}^{2} \left(\frac{\mu_0}{sigma_{0}^{2}} +
+            \frac{n \bar{x}}{\sigma_{x}^{2}}`
+        """
+        prior_mean = 0.0
+        reg_mean = (
+            1.0
+            / (bincount / uncertainties**2 + 1.0 / global_std**2)
+            * (bincount * summands / uncertainties**2 + prior_mean / global_std**2)
+        )
+        return reg_mean
+
+    def calc_parameters(self, feature, y, pred, prefit_data=None):
+        lex_binnumbers = feature.lex_binned_data
+        minlength = feature.n_bins
+        prediction = self.unlink_func(pred.predict_link())
+        prediction = np.where(prediction > 0, prediction, 0)
+        y_sum, bincount, global_std = prefit_data
+        weights = self.weights
+
+        variance = numexpr.evaluate("where(prediction <= 0., 1, prediction)")
+
+        factor_numerator = np.bincount(
+            lex_binnumbers,
+            weights=weights * (y - prediction) / variance,
+            minlength=minlength,
+        )
+        denominator = np.bincount(lex_binnumbers, weights=weights / variance, minlength=minlength)
+        uncertainty_numerator = np.bincount(lex_binnumbers, weights=weights**2 / variance, minlength=minlength)
+
+        denominator = np.where(denominator > 0, denominator, 1)
+        summands = factor_numerator / denominator
+        uncertainties = uncertainty_numerator / denominator
+        uncertainties = np.where(uncertainties > 0, uncertainties, global_std)
+
+        summands = self._regularize_summands(bincount, summands, uncertainties, global_std)
+        return summands, uncertainties
+
+    def predict(self, X, y=None):
+        result = super(CBLocPoissonRegressor, self).predict(X, y=y)
+        return np.where(result > 0, result, 0)
+
+
+def precalc_variance_y(feature, y, weights, n_prior=1):
+    """Calculate expected value of posterior of variance parameter for a gaussian
+    with a gamma distributed prior Gamma(a_0, b_0) and known mean for each bin.
+
+    Reference: Bishop: Pattern Recognition and Machine Learning, page 100
+
+    The prior variance b_0 / a_0 is set to the global variance of y.
+
+    Parameters
+    ----------
+    lex_binnumbers: :class:`numpy.ndarray` (float64, ndims=1)
+        1-dimensional numpy array containing the bin numbers.
+    y: :class:`numpy.ndarray` (float64, ndims=1)
+        target, truth
+    weights: :class:`numpy.ndarray` (float64, ndims=1)
+       sample weights
+    minlength: int
+        number of bins for this feature including the `nan` bin
+    n_prior: 'effective' prior observations,
+        see bishop page 101 for a discussion
+
+    Returns
+    -------
+    ndarray
+        The estimated variance of y for each bin
+    """
+    lex_binnumbers = feature.lex_binned_data
+    minlength = feature.n_bins
+
+    weighted_mean_y = np.sum(y * weights) / np.sum(weights)
+    variance_prior = np.sum((y - weighted_mean_y) * (y - weighted_mean_y) * weights) / np.sum(weights)
+    if variance_prior <= 1e-9:  # No variation in y; happens only in tests
+        variance_prior = 1.0
+
+    sum_y = np.bincount(lex_binnumbers, weights=weights * y, minlength=minlength)
+    sum_weights = np.bincount(lex_binnumbers, weights=weights, minlength=minlength)
+    mean_y = sum_y[lex_binnumbers] / sum_weights[lex_binnumbers]
+    weighted_squared_residual_sum = np.bincount(
+        lex_binnumbers, weights=weights * (y - mean_y) ** 2, minlength=minlength
+    )
+
+    a_0 = 0.5 * n_prior
+    b_0 = a_0 * variance_prior
+    a = a_0 + 0.5 * sum_weights
+    b = b_0 + 0.5 * weighted_squared_residual_sum
+    return b / a
+
+
+def calc_parameters_intercept(lex_binnumbers, prediction, minlength, y, variance_y, weights):
+    """Calculates intercepts and uncertainties for each bin of a feature group.
+
+    Parameters
+    ----------
+    lex_binnumbers: :class:`numpy.ndarray` (float64, ndims=1)
+        1-dimensional numpy array containing the bin numbers.
+    prediction: :class:`numpy.ndarray` (float64, ndims=1)
+        prediction of all *other* features.
+    minlength: int
+        number of bins for this feature including the `nan` bin
+    y: :class:`numpy.ndarray` (float64, ndims=1)
+        target, truth
+    variance_y: :class:`numpy.ndarray` (float64, ndims=1)
+       Variance estimate for each target value
+    weights: :class:`numpy.ndarray` (float64, ndims=1)
+       sample weights
+    external_col: :class:`numpy.ndarray` (float64, ndims=1)
+       external column array
+
+    Returns
+    -------
+    tuple
+        ``intercepts`` and ``uncertainties``.
+    """
+    w = weights / variance_y
+    w_x = w * (y - prediction)
+    w_x2 = w * (y - prediction) ** 2
+    x0 = 0
+    w0 = 1e-2
+    return calc_factors_generic(lex_binnumbers, w_x, w, w_x2, weights, minlength, x0, w0)
+
+
+class CBLocationRegressor(sklearn.base.RegressorMixin, CyclicBoostingBase, IdentityLinkMixin):
+    def _check_y(self, y):
+        """Check that y has no negative values."""
+        if not np.isfinite(y).all():
+            raise ValueError("The target y must be real value and not NAN.")
+
+    def precalc_parameters(self, feature, y, pred):
+        """Calculations that are not  dependent on intermediate predictions. If
+        these are not needed, return :obj:`None` in the subclass.
+
+        Results returned by this method will be served to
+        :meth:`factors_and_uncertainties` as the ``prefit_data`` argument.
+
+        Parameters
+        ----------
+        feature: :class:`~.Feature`
+            class containing all features
+        y: np.ndarray
+            target, truth
+        prediction_link: np.ndarray
+            prediction in link space.
+        """
+        return precalc_variance_y(feature, y, self.weights)
+
+    def calc_parameters(self, feature, y, pred, prefit_data):
+        """Calculates factors and uncertainties of the bins of a feature group
+        in the original space (not the link space) and transforms them to the
+        link space afterwards
+
+        The factors and uncertainties cannot be determined in link space, not
+        least because target values like 0 diverge in link spaces like `log`
+        or `logit`.
+
+        Parameters
+        ----------
+        feature: :class:`~.Feature`
+            class containing all features
+        y: np.ndarray
+            target, truth
+        prediction_link: np.ndarray
+            prediction in link space of all *other* features.
+        prefit_data
+            data returned by :meth:`~.precalc_parameters` during fit
+
+        Returns
+        -------
+        tuple
+            This method must return a tuple of ``factors`` and
+            ``uncertainties`` in the **link space**.
+        """
+        lex_binnumbers = feature.lex_binned_data
+        minlength = feature.n_bins
+        variance_y = prefit_data[lex_binnumbers]
+        return calc_parameters_intercept(lex_binnumbers, pred.predict_link(), minlength, y, variance_y, self.weights)
+
+    def calibrate_to_weighted_mean(self, feature):
+        if feature.missing_not_learned:
+            calibrated_factors_link = (
+                feature.factors_link[:-1]
+                - (feature.factors_link[:-1] * feature.bin_weightsums[:-1]).sum() / feature.bin_weightsums[:-1].sum()
+            )
+            calibrated_factors_link = np.append(calibrated_factors_link, self.neutral_factor_link)
+        else:
+            calibrated_factors_link = (
+                feature.factors_link
+                - (feature.factors_link * feature.bin_weightsums).sum() / feature.bin_weightsums.sum()
+            )
+        return calibrated_factors_link
+
+
+__all__ = ["CBLocationRegressor", "CBLocPoissonRegressor"]

--- a/skpro/libs/cyclic_boosting/location.py
+++ b/skpro/libs/cyclic_boosting/location.py
@@ -16,7 +16,9 @@ from skpro.libs.cyclic_boosting.utils import weighted_stddev
 _logger = logging.getLogger(__name__)
 
 
-class CBLocPoissonRegressor(CyclicBoostingBase, sklearn.base.RegressorMixin, IdentityLinkMixin):
+class CBLocPoissonRegressor(
+    CyclicBoostingBase, sklearn.base.RegressorMixin, IdentityLinkMixin
+):
     def precalc_parameters(self, feature, y, pred):
         lex_binnumbers = feature.lex_binned_data
         minlength = feature.n_bins
@@ -62,19 +64,25 @@ class CBLocPoissonRegressor(CyclicBoostingBase, sklearn.base.RegressorMixin, Ide
             weights=weights * (y - prediction) / variance,
             minlength=minlength,
         )
-        denominator = np.bincount(lex_binnumbers, weights=weights / variance, minlength=minlength)
-        uncertainty_numerator = np.bincount(lex_binnumbers, weights=weights**2 / variance, minlength=minlength)
+        denominator = np.bincount(
+            lex_binnumbers, weights=weights / variance, minlength=minlength
+        )
+        uncertainty_numerator = np.bincount(
+            lex_binnumbers, weights=weights**2 / variance, minlength=minlength
+        )
 
         denominator = np.where(denominator > 0, denominator, 1)
         summands = factor_numerator / denominator
         uncertainties = uncertainty_numerator / denominator
         uncertainties = np.where(uncertainties > 0, uncertainties, global_std)
 
-        summands = self._regularize_summands(bincount, summands, uncertainties, global_std)
+        summands = self._regularize_summands(
+            bincount, summands, uncertainties, global_std
+        )
         return summands, uncertainties
 
     def predict(self, X, y=None):
-        result = super(CBLocPoissonRegressor, self).predict(X, y=y)
+        result = super().predict(X, y=y)
         return np.where(result > 0, result, 0)
 
 
@@ -108,7 +116,9 @@ def precalc_variance_y(feature, y, weights, n_prior=1):
     minlength = feature.n_bins
 
     weighted_mean_y = np.sum(y * weights) / np.sum(weights)
-    variance_prior = np.sum((y - weighted_mean_y) * (y - weighted_mean_y) * weights) / np.sum(weights)
+    variance_prior = np.sum(
+        (y - weighted_mean_y) * (y - weighted_mean_y) * weights
+    ) / np.sum(weights)
     if variance_prior <= 1e-9:  # No variation in y; happens only in tests
         variance_prior = 1.0
 
@@ -126,7 +136,9 @@ def precalc_variance_y(feature, y, weights, n_prior=1):
     return b / a
 
 
-def calc_parameters_intercept(lex_binnumbers, prediction, minlength, y, variance_y, weights):
+def calc_parameters_intercept(
+    lex_binnumbers, prediction, minlength, y, variance_y, weights
+):
     """Calculates intercepts and uncertainties for each bin of a feature group.
 
     Parameters
@@ -156,10 +168,14 @@ def calc_parameters_intercept(lex_binnumbers, prediction, minlength, y, variance
     w_x2 = w * (y - prediction) ** 2
     x0 = 0
     w0 = 1e-2
-    return calc_factors_generic(lex_binnumbers, w_x, w, w_x2, weights, minlength, x0, w0)
+    return calc_factors_generic(
+        lex_binnumbers, w_x, w, w_x2, weights, minlength, x0, w0
+    )
 
 
-class CBLocationRegressor(sklearn.base.RegressorMixin, CyclicBoostingBase, IdentityLinkMixin):
+class CBLocationRegressor(
+    sklearn.base.RegressorMixin, CyclicBoostingBase, IdentityLinkMixin
+):
     def _check_y(self, y):
         """Check that y has no negative values."""
         if not np.isfinite(y).all():
@@ -212,19 +228,25 @@ class CBLocationRegressor(sklearn.base.RegressorMixin, CyclicBoostingBase, Ident
         lex_binnumbers = feature.lex_binned_data
         minlength = feature.n_bins
         variance_y = prefit_data[lex_binnumbers]
-        return calc_parameters_intercept(lex_binnumbers, pred.predict_link(), minlength, y, variance_y, self.weights)
+        return calc_parameters_intercept(
+            lex_binnumbers, pred.predict_link(), minlength, y, variance_y, self.weights
+        )
 
     def calibrate_to_weighted_mean(self, feature):
         if feature.missing_not_learned:
             calibrated_factors_link = (
                 feature.factors_link[:-1]
-                - (feature.factors_link[:-1] * feature.bin_weightsums[:-1]).sum() / feature.bin_weightsums[:-1].sum()
+                - (feature.factors_link[:-1] * feature.bin_weightsums[:-1]).sum()
+                / feature.bin_weightsums[:-1].sum()
             )
-            calibrated_factors_link = np.append(calibrated_factors_link, self.neutral_factor_link)
+            calibrated_factors_link = np.append(
+                calibrated_factors_link, self.neutral_factor_link
+            )
         else:
             calibrated_factors_link = (
                 feature.factors_link
-                - (feature.factors_link * feature.bin_weightsums).sum() / feature.bin_weightsums.sum()
+                - (feature.factors_link * feature.bin_weightsums).sum()
+                / feature.bin_weightsums.sum()
             )
         return calibrated_factors_link
 

--- a/skpro/libs/cyclic_boosting/nbinom.py
+++ b/skpro/libs/cyclic_boosting/nbinom.py
@@ -1,0 +1,272 @@
+"""
+Cyclic Boosting Negative Binomial c regressor. var = mu + c * mu * mu
+"""
+
+import logging
+
+from math import lgamma
+
+import numba as nb
+import numpy as np
+import sklearn.base
+
+from skpro.libs.cyclic_boosting.base import CyclicBoostingBase
+from skpro.libs.cyclic_boosting.learning_rate import constant_learn_rate_one
+from skpro.libs.cyclic_boosting.link import LogitLinkMixin
+from skpro.libs.cyclic_boosting.utils import get_X_column
+
+_logger = logging.getLogger(__name__)
+
+
+def _try_compile_parallel_func(**targetoptions):
+    """
+    Decorator that tries to compile a wrapped function in numba parallel mode. If that
+    fails it will compile the function in non-parallel mode.
+    """
+
+    def wrapper(f):
+        try:
+            wrapper = nb.jit(**targetoptions, parallel=True)
+            func = wrapper(f)
+
+        except:  # noqa
+            _logger.warning(f"Could not compile function {f} in parallel mode, falling back to" f"non-parallel mode.")
+            wrapper = nb.jit(**targetoptions, parallel=False)
+            func = wrapper(f)
+
+        return func
+
+    return wrapper
+
+
+class CBNBinomC(CyclicBoostingBase, sklearn.base.RegressorMixin, LogitLinkMixin):
+    """Maximum Likelihood estimation of the c parameter of the Negative Binomial
+    Negative Binomial Variance: mu + c * mu**2
+    Estimator predicts c with the constraint: c in (0,1)
+    Follows https://en.wikipedia.org/wiki/Negative_binomial_distribution notation with c = 1/r
+
+    Parameters
+    ----------
+
+    mean_prediction_column: string or None
+        Column for the mean of the Negative Binomial
+
+    gamma: float
+        Lasso term, zero for non-penalized fit. The larger the value the harder the regularization.
+
+    bayes: bool
+        use expectation of the posterior instead of maximum likelihood in each cyclic boosting step
+
+    The rest of the parameters are documented in CyclicBoostingBase.
+    """
+
+    def __init__(
+        self,
+        mean_prediction_column,
+        feature_groups=None,
+        feature_properties=None,
+        weight_column=None,
+        prior_prediction_column=None,
+        minimal_loss_change=1e-4,
+        minimal_factor_change=1e-4,
+        maximal_iterations=10,
+        observers=None,
+        smoother_choice=None,
+        output_column=None,
+        learn_rate=constant_learn_rate_one,
+        gamma=0.0,
+        bayes=False,
+        n_steps=15,
+    ):
+        CyclicBoostingBase.__init__(
+            self,
+            feature_groups=feature_groups,
+            feature_properties=feature_properties,
+            weight_column=weight_column,
+            prior_prediction_column=prior_prediction_column,
+            minimal_loss_change=minimal_loss_change,
+            minimal_factor_change=minimal_factor_change,
+            maximal_iterations=maximal_iterations,
+            observers=observers,
+            smoother_choice=smoother_choice,
+            output_column=output_column,
+            learn_rate=learn_rate,
+        )
+        self.mean_prediction_column = mean_prediction_column
+        self.gamma = gamma
+        self.bayes = bayes
+        self.n_steps = n_steps
+
+    def _check_y(self, y):
+        """Check that y has no negative values."""
+        if not (y >= 0.0).all():
+            raise ValueError(
+                "The target y must be positive semi-definite " "and not NAN. y[~(y>=0)] = {0}".format(y[~(y >= 0)])
+            )
+
+    def precalc_parameters(self, feature, y, pred):
+        return None
+
+    def calc_parameters(self, feature, y, pred, prefit_data):
+        c_link = pred.predict_link()
+        binnumbers = feature.lex_binned_data
+        minlength = feature.n_bins
+        new_c_link = get_new_c_link_for_iteration(self.iteration_ + 1, self.n_steps)
+        # TODO: use weights
+        c_link_estimate = calc_parameters_nbinom_c(
+            y,
+            self.mu,
+            c_link,
+            binnumbers,
+            minlength,
+            self.gamma,
+            int(self.bayes),
+            new_c_link,
+        )
+
+        bincounts = np.bincount(binnumbers, minlength=minlength)
+        bincounts[bincounts < 1] = 1.0
+        return c_link_estimate, 1.0 / np.sqrt(bincounts)
+
+    def loss(self, c, y, weights):
+        # TODO: use weights
+        return loss_nbinom_c(y.astype(np.float64), self.mu, c, self.gamma)
+
+    def fit(self, X, y=None):
+        self.mu = X[self.mean_prediction_column].values
+        _ = self._fit_predict(X, y)
+        del self.mu
+        return self
+
+    def _get_prior_predictions(self, X):
+        if self.prior_prediction_column is None:
+            prior_prediction_link = np.repeat(self.neutral_factor_link, X.shape[0])
+        else:
+            prior_pred = get_X_column(X, self.prior_prediction_column)
+            np.clip(prior_pred, 0, 1, prior_pred)
+            prior_prediction_link = self.link_func(prior_pred)
+            finite = np.isfinite(prior_prediction_link)
+            prior_prediction_link[~finite] = self.neutral_factor_link
+
+        return prior_prediction_link
+
+    def _init_global_scale(self, X, y):
+        if self.weights is None:
+            raise RuntimeError("The weights have to be initialized.")
+        self.global_scale_link_ = self.neutral_factor_link
+        self.prior_pred_link_offset_ = self.neutral_factor_link
+
+
+def get_new_c_link_for_iteration(iteration, n_steps):
+    new_c_link = np.r_[
+        -np.logspace(-3, 1.0 / iteration, n_steps // iteration)[::-1],
+        0,
+        np.logspace(-3, 1.0 / iteration, n_steps // iteration),
+    ]
+    return np.ascontiguousarray(new_c_link)
+
+
+@nb.njit()
+def nbinom_log_pmf(x: nb.float64, n: nb.float64, p: nb.float64) -> nb.float64:
+    """
+    Negative binomial log PMF.
+    """
+    coeff = lgamma(n + x) - lgamma(x + 1) - lgamma(n)
+    return coeff + n * np.log(p) + x * np.log(1 - p)
+
+
+@_try_compile_parallel_func(
+    nogil=True,
+    nopython=True,
+)
+def loss_nbinom_c(y: nb.float64[:], mu: nb.float64[:], c: nb.float64[:], gamma: nb.float64) -> nb.float64:
+    n_samples = len(y)
+
+    p = np.minimum(1.0 / (1 + c * mu), 1.0 - 1e-8)
+    n = mu * p / (1 - p)
+
+    loss = np.zeros(n_samples)
+    for i in nb.prange(n_samples):
+        loss[i] = -nbinom_log_pmf(y[i], n[i], p[i])
+
+    loss[~np.isfinite(loss)] = 400
+    loss += gamma * np.fabs(c)
+
+    return np.mean(loss)
+
+
+@nb.njit()
+def binned_loss_nbinom_c(
+    y: nb.float64[:],
+    mu: nb.float64[:],
+    c_link: nb.float64[:],
+    binnumbers: nb.int64[:],
+    minlength: nb.int64,
+    gamma: nb.float64,
+    new_c_link: nb.float64,
+) -> nb.float64[:]:
+    n_samples = len(y)
+
+    c = 1.0 / (1.0 + np.exp(-(new_c_link + c_link)))
+    p = np.minimum(1.0 / (1.0 + c * mu), 1.0 - 1e-8)
+    n = mu * p / (1 - p)
+
+    loss = np.zeros(minlength)
+    for i in range(n_samples):
+        ibin = binnumbers[i]
+        loss_i = -nbinom_log_pmf(y[i], n[i], p[i]) + gamma * np.fabs(c[i])
+        if np.isfinite(loss_i):
+            loss[ibin] += loss_i
+        else:
+            loss[ibin] += 400 + gamma * np.fabs(c[i])
+
+    return loss
+
+
+@_try_compile_parallel_func(
+    nogil=True,
+    nopython=True,
+)
+def compute_2d_loss(
+    y: nb.float64[:],
+    mu: nb.float64[:],
+    c_link: nb.float64[:],
+    binnumbers: nb.int64[:],
+    minlength: nb.int64,
+    gamma: nb.float64,
+    new_c_link: nb.float64[:],
+) -> nb.float64[:, :]:
+    n_new_c = len(new_c_link)
+    loss = np.empty((n_new_c, minlength), dtype=np.float64)
+
+    for i in nb.prange(n_new_c):
+        loss[i] = binned_loss_nbinom_c(y.astype(np.float64), mu, c_link, binnumbers, minlength, gamma, new_c_link[i])
+
+    return loss
+
+
+@nb.njit(nogil=True)
+def bayes_result(loss: nb.float64[:, :], minlength: nb.int64, new_c_link: nb.float64[:]) -> nb.float64[:]:
+    result = np.zeros(minlength)
+
+    for j in range(minlength):
+        l = -loss[:, j]
+        l -= l.max()
+        l = np.exp(l)
+        l[~np.isfinite(l)] = 0.0
+        l /= np.sum(l)
+        result[j] = np.sum(l * new_c_link)
+
+    return result
+
+
+def calc_parameters_nbinom_c(y, mu, c_link, binnumbers, minlength, gamma, bayes, new_c_link):
+    loss = compute_2d_loss(y, mu, c_link, binnumbers, minlength, gamma, new_c_link)
+
+    if bayes:
+        result = bayes_result(loss, minlength, new_c_link)
+
+    else:
+        result = new_c_link[np.argmin(loss, axis=0)]
+
+    return result

--- a/skpro/libs/cyclic_boosting/nbinom.py
+++ b/skpro/libs/cyclic_boosting/nbinom.py
@@ -3,7 +3,6 @@ Cyclic Boosting Negative Binomial c regressor. var = mu + c * mu * mu
 """
 
 import logging
-
 from math import lgamma
 
 import numba as nb
@@ -30,7 +29,10 @@ def _try_compile_parallel_func(**targetoptions):
             func = wrapper(f)
 
         except:  # noqa
-            _logger.warning(f"Could not compile function {f} in parallel mode, falling back to" f"non-parallel mode.")
+            _logger.warning(
+                f"Could not compile function {f} in parallel mode, falling back to"
+                f"non-parallel mode."
+            )
             wrapper = nb.jit(**targetoptions, parallel=False)
             func = wrapper(f)
 
@@ -101,7 +103,8 @@ class CBNBinomC(CyclicBoostingBase, sklearn.base.RegressorMixin, LogitLinkMixin)
         """Check that y has no negative values."""
         if not (y >= 0.0).all():
             raise ValueError(
-                "The target y must be positive semi-definite " "and not NAN. y[~(y>=0)] = {0}".format(y[~(y >= 0)])
+                "The target y must be positive semi-definite "
+                "and not NAN. y[~(y>=0)] = {}".format(y[~(y >= 0)])
             )
 
     def precalc_parameters(self, feature, y, pred):
@@ -179,7 +182,9 @@ def nbinom_log_pmf(x: nb.float64, n: nb.float64, p: nb.float64) -> nb.float64:
     nogil=True,
     nopython=True,
 )
-def loss_nbinom_c(y: nb.float64[:], mu: nb.float64[:], c: nb.float64[:], gamma: nb.float64) -> nb.float64:
+def loss_nbinom_c(
+    y: nb.float64[:], mu: nb.float64[:], c: nb.float64[:], gamma: nb.float64
+) -> nb.float64:
     n_samples = len(y)
 
     p = np.minimum(1.0 / (1 + c * mu), 1.0 - 1e-8)
@@ -240,13 +245,23 @@ def compute_2d_loss(
     loss = np.empty((n_new_c, minlength), dtype=np.float64)
 
     for i in nb.prange(n_new_c):
-        loss[i] = binned_loss_nbinom_c(y.astype(np.float64), mu, c_link, binnumbers, minlength, gamma, new_c_link[i])
+        loss[i] = binned_loss_nbinom_c(
+            y.astype(np.float64),
+            mu,
+            c_link,
+            binnumbers,
+            minlength,
+            gamma,
+            new_c_link[i],
+        )
 
     return loss
 
 
 @nb.njit(nogil=True)
-def bayes_result(loss: nb.float64[:, :], minlength: nb.int64, new_c_link: nb.float64[:]) -> nb.float64[:]:
+def bayes_result(
+    loss: nb.float64[:, :], minlength: nb.int64, new_c_link: nb.float64[:]
+) -> nb.float64[:]:
     result = np.zeros(minlength)
 
     for j in range(minlength):
@@ -260,7 +275,9 @@ def bayes_result(loss: nb.float64[:, :], minlength: nb.int64, new_c_link: nb.flo
     return result
 
 
-def calc_parameters_nbinom_c(y, mu, c_link, binnumbers, minlength, gamma, bayes, new_c_link):
+def calc_parameters_nbinom_c(
+    y, mu, c_link, binnumbers, minlength, gamma, bayes, new_c_link
+):
     loss = compute_2d_loss(y, mu, c_link, binnumbers, minlength, gamma, new_c_link)
 
     if bayes:

--- a/skpro/libs/cyclic_boosting/observers.py
+++ b/skpro/libs/cyclic_boosting/observers.py
@@ -1,0 +1,232 @@
+
+import copy
+
+import numpy as np
+
+from skpro.libs.cyclic_boosting import utils
+
+
+class BaseObserver(object):
+    """
+    Base class for observers
+
+    Observers are used to extract information from cyclic boosting estimators
+    that might be of further interest, but are not needed by the estimator in
+    order to make predictions.
+    """
+
+    def observe_iterations(self, iteration, X, y, prediction, weights, estimator_state):
+        """
+        Called after each iteration of the algorithm.
+
+        Parameters
+        ----------
+        iteration : int
+            number of the iteration
+
+        X : :class:`pandas.DataFrame` or :class:`numpy.ndarray`
+            feature matrix
+
+        y : numpy.ndarray
+            target array
+
+        prediction : numpy.ndarray
+            current target prediction
+
+        weights : numpy.ndarray
+            target weights
+
+        estimator_state : dict
+            state of the estimator. See
+            :meth:`cyclic_boosting.base.CyclicBoostingBase.get_state` for
+            information on what will be passed here
+
+        """
+
+    def observe_feature_iterations(self, iteration, feature_i, X, y, prediction, weights, estimator_state):
+        """
+        Called after each feature has been processed as part of a full
+        iteration of the algorithm.
+
+        Parameters
+        ----------
+        iteration : int
+            number of the iteration
+
+        feature_i : int
+            number of the feature that was processed
+
+        X : :class:`pandas.DataFrame` or :class:`numpy.ndarray`
+            feature matrix
+
+        y : numpy.ndarray
+            target array
+
+        prediction : numpy.ndarray
+            current target prediction
+
+        weights : numpy.ndarray
+            target weights
+
+        estimator_state : dict
+            state of the estimator. See
+            :meth:`~cyclic_boosting.base.CyclicBoostingBase.get_state` for
+            information on what will be passed here
+
+        local_variables : dict
+            local variables
+
+        """
+
+
+class PlottingObserver(BaseObserver):
+    """
+    Observer retrieving all information necessary to obtain analysis plots
+    based on a cyclic boosting training.
+
+    Instances of this class are intended to be passed as elements of the
+    ``observers`` parameter to a cyclic boosting estimator, where each will
+    gather information on a specific iteration. Afterwards, they can be passed
+    to :func:`~cyclic_boosting.plots.plot_analysis`.
+
+    Parameters
+    ----------
+    iteration : int
+        The observer will save all necessary information for the analysis plots
+        based on the state of the internal variables of the estimator
+        after the given iteration has been calculated.
+        Default is `-1`, which signifies the last iteration.
+
+    """
+
+    def __init__(self, iteration=-1):
+        if iteration == 0:
+            raise ValueError("This plotting observer only makes sense with iterations >= 1.")
+        self.iteration = iteration
+
+        self.features = None
+        self.link_function = None
+        self.n_feature_bins = None
+        self.loss = list()
+        self.factor_change = list()
+        self.histograms = None
+
+        self._fitted = False
+
+    def observe_iterations(self, iteration, X, y, prediction, weights, estimator_state, delta=None, quantile=None):
+        """Observe iterations in cyclic_boosting estimator to collect information for
+        necessary for plots. This function is called in each major loop and once in the
+        end.
+
+        Parameters
+        ----------
+
+        iteration: int
+            current major iteration of cyclic boosting loop
+
+        X: pd.DataFrame or numpy.ndarray shape(n, k)
+            feature matrix
+
+        y: np.ndarray
+            target array
+
+        prediction: np.ndarray
+            array of current cyclic boosting prediction
+
+        weights: np.ndarray
+            array of event weights
+
+        estimator_state: dict
+            state object of cyclic_boosting estimator
+        """
+        features = estimator_state["features"]
+
+        if (iteration <= self.iteration and iteration != -1) or self.iteration == -1:
+            self.loss.append(estimator_state["insample_loss"])
+            if iteration != 0:
+                # for iteration 0 there are no old fators to compare with
+                self.factor_change.append(delta)
+
+        if iteration == self.iteration:
+            self._fitted = True
+            self.features = copy.deepcopy(features)
+            self.n_feature_bins = {feature.feature_group: feature.n_multi_bins_finite for feature in self.features}
+            self.link_function = estimator_state["link_function"]
+            self.histograms = calc_in_sample_histograms(y, prediction, weights, quantile)
+
+    def observe_feature_iterations(self, iteration, feature_i, X, y, prediction, weights, estimator_state):
+        """Observe iterations in cyclic_boosting estimator to collect information for
+        necessary for plots. This function is called in each feature/minor loop.
+
+        Parameters
+        ----------
+
+        iteration: int
+            current major iteration number of cyclic boosting loop
+
+        feature_i: int
+            current minor iteration number of cyclic boosting loop
+
+        X: pd.DataFrame or numpy.ndarray shape(n, k)
+            feature matrix
+
+        y: np.ndarray
+            target array
+
+        prediction: np.ndarray
+            array of current cyclic boosting prediction
+
+        weights: np.ndarray
+            array of event weights
+
+        estimator_state: dict
+            state object of cyclic_boosting estimator
+        """
+        pass
+
+    def check_fitted(self):
+        if not self._fitted:
+            raise ValueError("Observer not filled.")
+
+
+def calc_in_sample_histograms(y, pred, weights, quantile=None):
+    """
+    Calculates histograms for use with diagonal plot.
+
+    Parameters
+    ----------
+    y : numpy.ndarray
+        truth
+
+    pred : numpy.ndarray
+        prediction
+
+    weights: np.ndarray
+        array of event weights
+
+    Returns
+    -------
+    result : tuple
+        Tuple consisting of:
+
+        * means
+        * bin_centers
+        * errors
+        * counts
+    """
+    nbins = 100
+    bin_boundaries, bin_centers = utils.calc_linear_bins(pred, nbins)
+    bin_numbers = utils.digitize(pred, bin_boundaries)
+    means, _, counts, errors = utils.calc_means_medians(bin_numbers, y, weights)
+    if quantile is not None:
+        means = utils.calc_weighted_quantile(bin_numbers, y, weights, quantile)
+        errors = None
+    bin_centers = bin_centers[np.where(~np.isnan(means.reindex(np.arange(1, nbins + 1))))]
+    # quantiles do not work for classification mode
+    if np.isin(y, [0, 1]).all():
+        return means, bin_centers, None, counts
+    else:
+        return means, bin_centers, errors, counts
+
+
+__all__ = ["PlottingObserver", "BaseObserver", "calc_in_sample_histograms"]

--- a/skpro/libs/cyclic_boosting/observers.py
+++ b/skpro/libs/cyclic_boosting/observers.py
@@ -1,4 +1,3 @@
-
 import copy
 
 import numpy as np
@@ -6,7 +5,7 @@ import numpy as np
 from skpro.libs.cyclic_boosting import utils
 
 
-class BaseObserver(object):
+class BaseObserver:
     """
     Base class for observers
 
@@ -43,7 +42,9 @@ class BaseObserver(object):
 
         """
 
-    def observe_feature_iterations(self, iteration, feature_i, X, y, prediction, weights, estimator_state):
+    def observe_feature_iterations(
+        self, iteration, feature_i, X, y, prediction, weights, estimator_state
+    ):
         """
         Called after each feature has been processed as part of a full
         iteration of the algorithm.
@@ -101,7 +102,9 @@ class PlottingObserver(BaseObserver):
 
     def __init__(self, iteration=-1):
         if iteration == 0:
-            raise ValueError("This plotting observer only makes sense with iterations >= 1.")
+            raise ValueError(
+                "This plotting observer only makes sense with iterations >= 1."
+            )
         self.iteration = iteration
 
         self.features = None
@@ -113,7 +116,17 @@ class PlottingObserver(BaseObserver):
 
         self._fitted = False
 
-    def observe_iterations(self, iteration, X, y, prediction, weights, estimator_state, delta=None, quantile=None):
+    def observe_iterations(
+        self,
+        iteration,
+        X,
+        y,
+        prediction,
+        weights,
+        estimator_state,
+        delta=None,
+        quantile=None,
+    ):
         """Observe iterations in cyclic_boosting estimator to collect information for
         necessary for plots. This function is called in each major loop and once in the
         end.
@@ -150,11 +163,18 @@ class PlottingObserver(BaseObserver):
         if iteration == self.iteration:
             self._fitted = True
             self.features = copy.deepcopy(features)
-            self.n_feature_bins = {feature.feature_group: feature.n_multi_bins_finite for feature in self.features}
+            self.n_feature_bins = {
+                feature.feature_group: feature.n_multi_bins_finite
+                for feature in self.features
+            }
             self.link_function = estimator_state["link_function"]
-            self.histograms = calc_in_sample_histograms(y, prediction, weights, quantile)
+            self.histograms = calc_in_sample_histograms(
+                y, prediction, weights, quantile
+            )
 
-    def observe_feature_iterations(self, iteration, feature_i, X, y, prediction, weights, estimator_state):
+    def observe_feature_iterations(
+        self, iteration, feature_i, X, y, prediction, weights, estimator_state
+    ):
         """Observe iterations in cyclic_boosting estimator to collect information for
         necessary for plots. This function is called in each feature/minor loop.
 
@@ -221,7 +241,9 @@ def calc_in_sample_histograms(y, pred, weights, quantile=None):
     if quantile is not None:
         means = utils.calc_weighted_quantile(bin_numbers, y, weights, quantile)
         errors = None
-    bin_centers = bin_centers[np.where(~np.isnan(means.reindex(np.arange(1, nbins + 1))))]
+    bin_centers = bin_centers[
+        np.where(~np.isnan(means.reindex(np.arange(1, nbins + 1))))
+    ]
     # quantiles do not work for classification mode
     if np.isin(y, [0, 1]).all():
         return means, bin_centers, None, counts

--- a/skpro/libs/cyclic_boosting/pipelines.py
+++ b/skpro/libs/cyclic_boosting/pipelines.py
@@ -1,0 +1,268 @@
+from skpro.libs.cyclic_boosting import (
+    CBLocationRegressor,
+    CBExponential,
+    CBNBinomRegressor,
+    CBPoissonRegressor,
+    CBLocPoissonRegressor,
+    CBNBinomC,
+    CBClassifier,
+    CBGBSRegressor,
+    CBMultiplicativeQuantileRegressor,
+    CBAdditiveQuantileRegressor,
+    CBMultiplicativeGenericRegressor,
+    CBAdditiveGenericRegressor,
+    CBGenericClassifier,
+    binning,
+)
+
+from sklearn.pipeline import Pipeline
+
+
+def pipeline_CB(
+    estimator=None,
+    feature_groups=None,
+    hierarchical_feature_groups=None,
+    feature_properties=None,
+    weight_column=None,
+    prior_prediction_column=None,
+    minimal_loss_change=1e-3,
+    minimal_factor_change=1e-3,
+    maximal_iterations=10,
+    observers=None,
+    smoother_choice=None,
+    output_column=None,
+    learn_rate=None,
+    number_of_bins=100,
+    aggregate=True,
+    a=1.0,
+    c=0.0,
+    external_colname=None,
+    standard_feature_groups=None,
+    external_feature_groups=None,
+    var_prior_exponent=0.1,
+    prior_exponent_colname=None,
+    mean_prediction_column=None,
+    gamma=0.0,
+    bayes=False,
+    n_steps=15,
+    regalpha=0.0,
+    quantile=None,
+    costs=None,
+    inplace=False,
+):
+    if estimator in [CBPoissonRegressor, CBLocPoissonRegressor, CBLocationRegressor, CBClassifier]:
+        estimatorCB = estimator(
+            feature_groups=feature_groups,
+            hierarchical_feature_groups=hierarchical_feature_groups,
+            feature_properties=feature_properties,
+            weight_column=weight_column,
+            prior_prediction_column=prior_prediction_column,
+            minimal_loss_change=minimal_loss_change,
+            minimal_factor_change=minimal_factor_change,
+            maximal_iterations=maximal_iterations,
+            observers=observers,
+            smoother_choice=smoother_choice,
+            output_column=output_column,
+            learn_rate=learn_rate,
+            aggregate=aggregate,
+        )
+    elif estimator == CBNBinomRegressor:
+        estimatorCB = estimator(
+            feature_groups=feature_groups,
+            hierarchical_feature_groups=hierarchical_feature_groups,
+            feature_properties=feature_properties,
+            weight_column=weight_column,
+            prior_prediction_column=prior_prediction_column,
+            minimal_loss_change=minimal_loss_change,
+            minimal_factor_change=minimal_factor_change,
+            maximal_iterations=maximal_iterations,
+            observers=observers,
+            smoother_choice=smoother_choice,
+            output_column=output_column,
+            learn_rate=learn_rate,
+            aggregate=aggregate,
+            a=a,
+            c=c,
+        )
+    elif estimator == CBExponential:
+        estimatorCB = estimator(
+            external_colname=external_colname,
+            standard_feature_groups=standard_feature_groups,
+            external_feature_groups=external_feature_groups,
+            feature_properties=feature_properties,
+            weight_column=weight_column,
+            prior_prediction_column=prior_prediction_column,
+            minimal_loss_change=minimal_loss_change,
+            minimal_factor_change=minimal_factor_change,
+            maximal_iterations=maximal_iterations,
+            observers=observers,
+            smoother_choice=smoother_choice,
+            output_column=output_column,
+            learn_rate=learn_rate,
+            var_prior_exponent=var_prior_exponent,
+            prior_exponent_colname=prior_exponent_colname,
+        )
+    elif estimator == CBNBinomC:
+        estimatorCB = estimator(
+            mean_prediction_column=mean_prediction_column,
+            feature_groups=feature_groups,
+            feature_properties=feature_properties,
+            weight_column=weight_column,
+            prior_prediction_column=prior_prediction_column,
+            minimal_loss_change=minimal_loss_change,
+            minimal_factor_change=minimal_factor_change,
+            maximal_iterations=maximal_iterations,
+            observers=observers,
+            smoother_choice=smoother_choice,
+            output_column=output_column,
+            learn_rate=learn_rate,
+            gamma=gamma,
+            bayes=bayes,
+            n_steps=n_steps,
+        )
+    elif estimator == CBGBSRegressor:
+        estimatorCB = estimator(
+            feature_groups=feature_groups,
+            hierarchical_feature_groups=hierarchical_feature_groups,
+            feature_properties=feature_properties,
+            weight_column=weight_column,
+            minimal_loss_change=minimal_loss_change,
+            minimal_factor_change=minimal_factor_change,
+            maximal_iterations=maximal_iterations,
+            observers=observers,
+            smoother_choice=smoother_choice,
+            output_column=output_column,
+            learn_rate=learn_rate,
+            aggregate=aggregate,
+            regalpha=regalpha,
+        )
+    elif estimator in [CBMultiplicativeQuantileRegressor, CBAdditiveQuantileRegressor]:
+        estimatorCB = estimator(
+            feature_groups=feature_groups,
+            hierarchical_feature_groups=hierarchical_feature_groups,
+            feature_properties=feature_properties,
+            weight_column=weight_column,
+            prior_prediction_column=prior_prediction_column,
+            minimal_loss_change=minimal_loss_change,
+            minimal_factor_change=minimal_factor_change,
+            maximal_iterations=maximal_iterations,
+            observers=observers,
+            smoother_choice=smoother_choice,
+            output_column=output_column,
+            learn_rate=learn_rate,
+            aggregate=aggregate,
+            quantile=quantile,
+        )
+    elif estimator in [CBMultiplicativeGenericRegressor, CBAdditiveGenericRegressor, CBGenericClassifier]:
+        estimatorCB = estimator(
+            feature_groups=feature_groups,
+            hierarchical_feature_groups=hierarchical_feature_groups,
+            feature_properties=feature_properties,
+            weight_column=weight_column,
+            prior_prediction_column=prior_prediction_column,
+            minimal_loss_change=minimal_loss_change,
+            minimal_factor_change=minimal_factor_change,
+            maximal_iterations=maximal_iterations,
+            observers=observers,
+            smoother_choice=smoother_choice,
+            output_column=output_column,
+            learn_rate=learn_rate,
+            aggregate=aggregate,
+            costs=costs,
+        )
+    else:
+        raise Exception("No valid CB estimator.")
+    binner = binning.BinNumberTransformer(n_bins=number_of_bins, feature_properties=feature_properties, inplace=inplace)
+
+    return Pipeline([("binning", binner), ("CB", estimatorCB)])
+
+
+def pipeline_CBPoissonRegressor(**kwargs):
+    """
+    Convenience function containing CBPoissonRegressor (estimator) + binning.
+    """
+    return pipeline_CB(CBPoissonRegressor, **kwargs)
+
+
+def pipeline_CBNBinomRegressor(**kwargs):
+    """
+    Convenience function containing CBNBinomRegressor (estimator) + binning.
+    """
+    return pipeline_CB(CBNBinomRegressor, **kwargs)
+
+
+def pipeline_CBClassifier(**kwargs):
+    """
+    Convenience function containing CBClassifier (estimator) + binning.
+    """
+    return pipeline_CB(CBClassifier, **kwargs)
+
+
+def pipeline_CBLocationRegressor(**kwargs):
+    """
+    Convenience function containing CBLocationRegressor (estimator) + binning.
+    """
+    return pipeline_CB(CBLocationRegressor, **kwargs)
+
+
+def pipeline_CBExponential(**kwargs):
+    """
+    Convenience function containing CBExponential (estimator) + binning.
+    """
+    return pipeline_CB(CBExponential, **kwargs)
+
+
+def pipeline_CBLocPoissonRegressor(**kwargs):
+    """
+    Convenience function containing CBLocPoissonRegressor (estimator) + binning.
+    """
+    return pipeline_CB(CBLocPoissonRegressor, **kwargs)
+
+
+def pipeline_CBNBinomC(**kwargs):
+    """
+    Convenience function containing CBNBinomC (estimator) + binning.
+    """
+    return pipeline_CB(CBNBinomC, **kwargs)
+
+
+def pipeline_CBGBSRegressor(**kwargs):
+    """
+    Convenience function containing CBGBSRegressor (estimator) + binning.
+    """
+    return pipeline_CB(CBGBSRegressor, **kwargs)
+
+
+def pipeline_CBMultiplicativeQuantileRegressor(**kwargs):
+    """
+    Convenience function containing CBMultiplicativeQuantileRegressor (estimator) + binning.
+    """
+    return pipeline_CB(CBMultiplicativeQuantileRegressor, **kwargs)
+
+
+def pipeline_CBAdditiveQuantileRegressor(**kwargs):
+    """
+    Convenience function containing CBAdditiveQuantileRegressor (estimator) + binning.
+    """
+    return pipeline_CB(CBAdditiveQuantileRegressor, **kwargs)
+
+
+def pipeline_CBMultiplicativeGenericRegressor(**kwargs):
+    """
+    Convenience function containing CBMultiplicativeGenericRegressor (estimator) + binning.
+    """
+    return pipeline_CB(CBMultiplicativeGenericRegressor, **kwargs)
+
+
+def pipeline_CBAdditiveGenericRegressor(**kwargs):
+    """
+    Convenience function containing CBAdditiveGenericRegressor (estimator) + binning.
+    """
+    return pipeline_CB(CBAdditiveGenericRegressor, **kwargs)
+
+
+def pipeline_CBGenericClassifier(**kwargs):
+    """
+    Convenience function containing CBGenericClassifier (estimator) + binning.
+    """
+    return pipeline_CB(CBGenericClassifier, **kwargs)

--- a/skpro/libs/cyclic_boosting/pipelines.py
+++ b/skpro/libs/cyclic_boosting/pipelines.py
@@ -1,21 +1,21 @@
+from sklearn.pipeline import Pipeline
+
 from skpro.libs.cyclic_boosting import (
-    CBLocationRegressor,
+    CBAdditiveGenericRegressor,
+    CBAdditiveQuantileRegressor,
+    CBClassifier,
     CBExponential,
+    CBGBSRegressor,
+    CBGenericClassifier,
+    CBLocationRegressor,
+    CBLocPoissonRegressor,
+    CBMultiplicativeGenericRegressor,
+    CBMultiplicativeQuantileRegressor,
+    CBNBinomC,
     CBNBinomRegressor,
     CBPoissonRegressor,
-    CBLocPoissonRegressor,
-    CBNBinomC,
-    CBClassifier,
-    CBGBSRegressor,
-    CBMultiplicativeQuantileRegressor,
-    CBAdditiveQuantileRegressor,
-    CBMultiplicativeGenericRegressor,
-    CBAdditiveGenericRegressor,
-    CBGenericClassifier,
     binning,
 )
-
-from sklearn.pipeline import Pipeline
 
 
 def pipeline_CB(
@@ -50,7 +50,12 @@ def pipeline_CB(
     costs=None,
     inplace=False,
 ):
-    if estimator in [CBPoissonRegressor, CBLocPoissonRegressor, CBLocationRegressor, CBClassifier]:
+    if estimator in [
+        CBPoissonRegressor,
+        CBLocPoissonRegressor,
+        CBLocationRegressor,
+        CBClassifier,
+    ]:
         estimatorCB = estimator(
             feature_groups=feature_groups,
             hierarchical_feature_groups=hierarchical_feature_groups,
@@ -153,7 +158,11 @@ def pipeline_CB(
             aggregate=aggregate,
             quantile=quantile,
         )
-    elif estimator in [CBMultiplicativeGenericRegressor, CBAdditiveGenericRegressor, CBGenericClassifier]:
+    elif estimator in [
+        CBMultiplicativeGenericRegressor,
+        CBAdditiveGenericRegressor,
+        CBGenericClassifier,
+    ]:
         estimatorCB = estimator(
             feature_groups=feature_groups,
             hierarchical_feature_groups=hierarchical_feature_groups,
@@ -172,7 +181,9 @@ def pipeline_CB(
         )
     else:
         raise Exception("No valid CB estimator.")
-    binner = binning.BinNumberTransformer(n_bins=number_of_bins, feature_properties=feature_properties, inplace=inplace)
+    binner = binning.BinNumberTransformer(
+        n_bins=number_of_bins, feature_properties=feature_properties, inplace=inplace
+    )
 
     return Pipeline([("binning", binner), ("CB", estimatorCB)])
 

--- a/skpro/libs/cyclic_boosting/pipelines.py
+++ b/skpro/libs/cyclic_boosting/pipelines.py
@@ -1,21 +1,22 @@
 from sklearn.pipeline import Pipeline
 
-from skpro.libs.cyclic_boosting import (
+from skpro.libs.cyclic_boosting import binning
+from skpro.libs.cyclic_boosting.classification import CBClassifier
+from skpro.libs.cyclic_boosting.GBSregression import CBGBSRegressor
+from skpro.libs.cyclic_boosting.generic_loss import (
     CBAdditiveGenericRegressor,
     CBAdditiveQuantileRegressor,
-    CBClassifier,
-    CBExponential,
-    CBGBSRegressor,
     CBGenericClassifier,
-    CBLocationRegressor,
-    CBLocPoissonRegressor,
     CBMultiplicativeGenericRegressor,
     CBMultiplicativeQuantileRegressor,
-    CBNBinomC,
-    CBNBinomRegressor,
-    CBPoissonRegressor,
-    binning,
 )
+from skpro.libs.cyclic_boosting.location import (
+    CBLocationRegressor,
+    CBLocPoissonRegressor,
+)
+from skpro.libs.cyclic_boosting.nbinom import CBNBinomC
+from skpro.libs.cyclic_boosting.price import CBExponential
+from skpro.libs.cyclic_boosting.regression import CBNBinomRegressor, CBPoissonRegressor
 
 
 def pipeline_CB(

--- a/skpro/libs/cyclic_boosting/plots/_1dplots.py
+++ b/skpro/libs/cyclic_boosting/plots/_1dplots.py
@@ -1,0 +1,321 @@
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+from skpro.libs.cyclic_boosting import flags
+from skpro.libs.cyclic_boosting.link import IdentityLinkMixin, LogitLinkMixin, LogLinkMixin
+
+
+def _format_tick(tick, precision=1e-2):
+    """Returns a suitable string representation for a
+    factor, when it is given a tick position in linear space.
+
+    A "suitable" string reprentation is (in this order):
+
+    * an integer
+    * decimal numbers with precision 2
+    """
+    if tick - precision < np.round(tick) < tick + precision:
+        return "{:.0f}".format(tick)
+    return "{:.{prec}f}".format(tick, prec=2)
+
+
+def _get_x_axis(factors, bin_bounds, is_continuous):
+    """
+    Get x axis range and tick labels
+    """
+    if bin_bounds is not None:
+        if is_continuous:
+            labels = np.round((bin_bounds[:-1] + bin_bounds[1:]) / 2.0, 5)
+        else:
+            labels = bin_bounds[1:]
+    else:
+        labels = None
+    x_axis_range = np.arange(len(factors)).astype(np.float64)
+    return x_axis_range, labels
+
+
+def _get_optimal_number_of_ticks(distance):
+    """
+    Return optimal number of ticks given a distance of the upper and lower bound
+    First we scale the distance to the interval [1,20], afterwards we search
+    the smalest number out of {1,2,4,5,10,20} which leads to a total tick number in (10,20].
+    If we encounter something unexpected we just return 21
+    """
+    if distance < 1 or np.isinf(distance) or np.isnan(distance):
+        return 21
+    while distance > 20:
+        distance /= 10
+    for n in [20, 10, 5, 4, 2, 1]:
+        n_ticks = np.floor(distance * n)
+        if 10 < n_ticks <= 20:
+            return n_ticks + 1
+    return 21
+
+
+def _get_y_axis(factors, uncertainties=None):
+    """
+    Get y axis range and tick labels
+    """
+    if len(factors[:-1]) > 0:
+        if uncertainties is not None:
+            y_max_link = max(np.max(factors[:-1] + uncertainties[1][:-1]), factors[-1])
+            y_min_link = min(np.min(factors[:-1] - uncertainties[0][:-1]), factors[-1])
+        else:
+            y_max_link = np.max(factors)
+            y_min_link = np.min(factors)
+    else:
+        y_max_link = factors[-1] + 0.5
+        y_min_link = factors[-1] - 0.5
+
+    y_min_link_int = np.floor(y_min_link)
+    y_max_link_int = np.ceil(y_max_link)
+
+    distance_int = y_max_link_int - y_min_link_int
+    n_ticks = _get_optimal_number_of_ticks(distance_int)
+
+    linspace = np.linspace(y_min_link_int, y_max_link_int, int(n_ticks))
+
+    return linspace, list(map(_format_tick, linspace))
+
+
+def _ensure_tuple(x):
+    """
+    Ensures that given object is a tuple, if not wrap it in a tuple
+    """
+    return x if isinstance(x, tuple) else (x,)
+
+
+def _plot_factors(factors, x_axis_range, label, uncertainties=None):
+    """
+    Plot unsmoothed factors in given range with errobars if uncertainties are provided
+    """
+    if uncertainties is not None:
+        unsmoothed_style = dict(capsize=2.5, markersize=2, fmt="o", color="k", alpha=0.6)
+        unsmoothed_style["label"] = label
+        plt.errorbar(x_axis_range, factors, yerr=uncertainties, **unsmoothed_style)
+    else:
+        unsmoothed_style = dict(markersize=2, marker="o", color="k", alpha=0.6)
+        unsmoothed_style["label"] = label
+        plt.plot(x_axis_range, factors, **unsmoothed_style)
+
+
+def _plot_smoothed_factors(factors, x_axis_range, is_continuous, uncertainties=None):
+    """
+    Plot smoothed factors, plot style depends on is_continuous
+    """
+    if is_continuous:
+        smoothed_style = dict(linestyle="-", linewidth=1.0, color="r")
+        x_axis_range = (x_axis_range + np.append(x_axis_range, x_axis_range[-1] + 1)[1:]) / 2
+    else:
+        smoothed_style = dict(
+            marker="o",
+            markeredgecolor="r",
+            markersize=5.0,
+            linestyle="none",
+            fillstyle="none",
+            color="r",
+        )
+    smoothed_style["label"] = "smoothed factors"
+    if uncertainties is not None:
+        plt.errorbar(x_axis_range, factors, yerr=[uncertainties[0], uncertainties[1]], **smoothed_style)
+    else:
+        plt.plot(x_axis_range, factors, **smoothed_style)
+
+
+def _plot_missing_factor(factors, x_axis_range, y_axis_range):
+    """
+    Plot the factor which was calculated for missing values and mark the region in an orange color
+    """
+    # Factor which corresponds to missing value is the last one
+    missing_factor = factors[-1]
+    x_position = x_axis_range[-1]
+
+    # Plot single datapoint and shade the whole area around this point to mark it as "special"
+    nan_style = dict(
+        marker="p",
+        markeredgecolor="r",
+        markersize=5.0,
+        color="b",
+        linestyle="none",
+        fillstyle="none",
+    )
+    nan_style["label"] = "smoothed nan factor"
+    plt.plot([x_position], [missing_factor], **nan_style)
+    plt.fill_between(
+        [x_position - 0.5, x_position + 0.5],
+        min(y_axis_range),
+        max(y_axis_range),
+        color="#f7d208",
+        alpha=0.5,
+    )
+
+
+def _plot_axes(x_axis_range, x_axis_labels, y_axis_range, y_axis_labels, is_continuous):
+    """
+    Plot axes including limits, labels and ticks
+    """
+    # Set limits
+    plt.xlim(min(x_axis_range) - 0.5, max(x_axis_range) + 0.5)
+    plt.ylim(min(y_axis_range), max(y_axis_range))
+
+    # Shift x_axis to the left if continuous, because in this case the label correspond to the bin boundaries
+    if is_continuous:
+        x_axis_range -= 0.5
+    if x_axis_labels is not None:
+        if len(x_axis_range) - len(x_axis_labels) == 1:
+            x_axis_labels = np.append(x_axis_labels, "")
+        plt.xticks(x_axis_range, x_axis_labels, size="xx-small", rotation="vertical")
+    plt.yticks(y_axis_range, y_axis_labels)
+
+
+def plot_factor_1d(
+    feature,
+    bin_bounds=None,
+    with_errorbars=True,
+    ylimits_include_errors=True,
+    link_function=None,
+    plot_yp=True,
+):
+    """
+    Plots a single one dimensional factor plot.
+
+    Parameters
+    ----------
+    bin_bounds: list
+        Bin boundaries to label the bins.
+    feature: cyclic_boosting.base.Feature
+        Feature as it can be obtained from the plotting observers
+        ``features`` property.
+    link_function: cyclic_boosting.link.LinkFunction
+        Link function of the plotted feature
+    with_errorbars: bool
+        Option to switch errorbars on/off.
+    ylimits_include_errors: bool
+        Option to show the errorbars in the plot completely.
+    plot_yp: bool
+        Show deviation between truth and prediction in last iteration.
+    """
+    y = feature.y
+    if y is None:
+        plot_yp = False
+    p = feature.prediction
+
+    if plot_yp:
+        factors = feature.mean_dev
+    else:
+        factors = feature.unfitted_factors_link
+
+    smoothed_factors = feature.factors_link
+
+    if plot_yp:
+        uncertainties = np.abs(feature.unfitted_factors_link)
+        uncertainties = [uncertainties, uncertainties]
+    else:
+        uncertainties = [
+            feature.unfitted_uncertainties_link,
+            feature.unfitted_uncertainties_link,
+        ]
+
+    assert len(factors) == len(smoothed_factors) == len(uncertainties[0]) == len(uncertainties[1]) > 0
+    number_of_factors = len(factors)
+
+    if isinstance(link_function, IdentityLinkMixin):
+        plt.axhline(0, color="gray")
+        plt.ylabel("Summand")
+
+    elif isinstance(link_function, LogLinkMixin):
+        factors = link_function.unlink_func(factors)
+        smoothed_factors = link_function.unlink_func(smoothed_factors)
+        if plot_yp:
+            y = link_function.unlink_func(y)
+            p = link_function.unlink_func(p)
+        plt.axhline(1, color="gray")
+        plt.ylabel("Factor")
+
+    elif isinstance(link_function, LogitLinkMixin):
+        lower = np.abs(link_function.unlink_func(factors - uncertainties[0]) - link_function.unlink_func(factors))
+        upper = np.abs(link_function.unlink_func(factors + uncertainties[1]) - link_function.unlink_func(factors))
+        factors = link_function.unlink_func(factors)
+        smoothed_factors = link_function.unlink_func(smoothed_factors)
+        uncertainties = [
+            np.where(lower < 0.0, 0.0, lower),
+            np.where(upper > 1.0, 1.0, upper),
+        ]
+        if plot_yp:
+            # do not unlink for nbinom width mode
+            if ((link_function.unlink_func(y) >= 0).all()) and ((link_function.unlink_func(y) <= 1).all()):
+                y = link_function.unlink_func(y)
+            p = link_function.unlink_func(p)
+        plt.axhline(0.5, color="gray")
+        plt.ylabel("Probability")
+
+    else:
+        plt.ylabel("Unkown")
+
+    # Too many factors make the plot unreadable. Thus we resort to plotting a
+    # histogram of factors in these cases.
+    if number_of_factors > 400:
+        from skpro.libs.cyclic_boosting.plots import plot_factor_histogram
+
+        plot_factor_histogram(feature)
+        return
+
+    feature_property = _ensure_tuple(feature.feature_property)
+    is_continuous = flags.is_continuous_set(feature_property[0]) | flags.is_linear_set(feature_property[0])
+    if plot_yp:
+        minmax = np.r_[
+            np.min(np.r_[factors, smoothed_factors, y, p]),
+            np.max(np.r_[factors, smoothed_factors, y, p]),
+        ]
+    else:
+        minmax = np.r_[
+            np.min(np.r_[factors, smoothed_factors]),
+            np.max(np.r_[factors, smoothed_factors]),
+        ]
+    f = factors.copy()
+    if len(f) > 1:
+        f[:2] = minmax
+        u = uncertainties
+    else:
+        f = minmax
+        u = np.c_[uncertainties, uncertainties]
+
+    y_axis_range, y_axis_labels = _get_y_axis(f, u if ylimits_include_errors else None)
+    x_axis_range, x_axis_labels = _get_x_axis(factors, bin_bounds, is_continuous)
+
+    if "MISSING" in flags._convert_flags_to_string(feature.feature_property[0]):
+        _plot_missing_factor(smoothed_factors, x_axis_range, y_axis_range)
+    elif len(factors) > 1:
+        factors = factors[:-1]
+        uncertainties = [uncertainties[0][:-1], uncertainties[1][:-1]]
+        smoothed_factors = smoothed_factors[:-1]
+        x_axis_range = x_axis_range[:-1]
+    _plot_axes(x_axis_range, x_axis_labels, y_axis_range, y_axis_labels, is_continuous)
+
+    _plot_smoothed_factors(smoothed_factors, x_axis_range, is_continuous, None)
+
+    if not plot_yp:
+        label = "factors"
+        if is_continuous:
+            x_axis_range = (x_axis_range + np.append(x_axis_range, x_axis_range[-1] + 1)[1:]) / 2
+        _plot_factors(factors, x_axis_range, label, uncertainties if with_errorbars else None)
+
+    try:
+        if len(factors) > 1:
+            plt.plot(p[:-1], ".-", label="prediction", alpha=0.5)
+            plt.plot(y[:-1], ".-", label="truth", alpha=0.5)
+        else:
+            plt.plot(p, ".-", label="prediction", alpha=0.5)
+            plt.plot(y, ".-", label="truth", alpha=0.5)
+    except:
+        pass
+
+    from skpro.libs.cyclic_boosting.plots import _format_groupname_with_type
+
+    feature_group = _format_groupname_with_type(feature.feature_group, feature.feature_type)
+    plt.xlabel(feature_group)
+    plt.legend()
+
+
+__all__ = []

--- a/skpro/libs/cyclic_boosting/plots/_1dplots.py
+++ b/skpro/libs/cyclic_boosting/plots/_1dplots.py
@@ -1,9 +1,12 @@
 import matplotlib.pyplot as plt
 import numpy as np
 
-
 from skpro.libs.cyclic_boosting import flags
-from skpro.libs.cyclic_boosting.link import IdentityLinkMixin, LogitLinkMixin, LogLinkMixin
+from skpro.libs.cyclic_boosting.link import (
+    IdentityLinkMixin,
+    LogitLinkMixin,
+    LogLinkMixin,
+)
 
 
 def _format_tick(tick, precision=1e-2):
@@ -16,7 +19,7 @@ def _format_tick(tick, precision=1e-2):
     * decimal numbers with precision 2
     """
     if tick - precision < np.round(tick) < tick + precision:
-        return "{:.0f}".format(tick)
+        return f"{tick:.0f}"
     return "{:.{prec}f}".format(tick, prec=2)
 
 
@@ -91,7 +94,9 @@ def _plot_factors(factors, x_axis_range, label, uncertainties=None):
     Plot unsmoothed factors in given range with errobars if uncertainties are provided
     """
     if uncertainties is not None:
-        unsmoothed_style = dict(capsize=2.5, markersize=2, fmt="o", color="k", alpha=0.6)
+        unsmoothed_style = dict(
+            capsize=2.5, markersize=2, fmt="o", color="k", alpha=0.6
+        )
         unsmoothed_style["label"] = label
         plt.errorbar(x_axis_range, factors, yerr=uncertainties, **unsmoothed_style)
     else:
@@ -106,7 +111,9 @@ def _plot_smoothed_factors(factors, x_axis_range, is_continuous, uncertainties=N
     """
     if is_continuous:
         smoothed_style = dict(linestyle="-", linewidth=1.0, color="r")
-        x_axis_range = (x_axis_range + np.append(x_axis_range, x_axis_range[-1] + 1)[1:]) / 2
+        x_axis_range = (
+            x_axis_range + np.append(x_axis_range, x_axis_range[-1] + 1)[1:]
+        ) / 2
     else:
         smoothed_style = dict(
             marker="o",
@@ -118,7 +125,12 @@ def _plot_smoothed_factors(factors, x_axis_range, is_continuous, uncertainties=N
         )
     smoothed_style["label"] = "smoothed factors"
     if uncertainties is not None:
-        plt.errorbar(x_axis_range, factors, yerr=[uncertainties[0], uncertainties[1]], **smoothed_style)
+        plt.errorbar(
+            x_axis_range,
+            factors,
+            yerr=[uncertainties[0], uncertainties[1]],
+            **smoothed_style,
+        )
     else:
         plt.plot(x_axis_range, factors, **smoothed_style)
 
@@ -217,7 +229,13 @@ def plot_factor_1d(
             feature.unfitted_uncertainties_link,
         ]
 
-    assert len(factors) == len(smoothed_factors) == len(uncertainties[0]) == len(uncertainties[1]) > 0
+    assert (
+        len(factors)
+        == len(smoothed_factors)
+        == len(uncertainties[0])
+        == len(uncertainties[1])
+        > 0
+    )
     number_of_factors = len(factors)
 
     if isinstance(link_function, IdentityLinkMixin):
@@ -234,8 +252,14 @@ def plot_factor_1d(
         plt.ylabel("Factor")
 
     elif isinstance(link_function, LogitLinkMixin):
-        lower = np.abs(link_function.unlink_func(factors - uncertainties[0]) - link_function.unlink_func(factors))
-        upper = np.abs(link_function.unlink_func(factors + uncertainties[1]) - link_function.unlink_func(factors))
+        lower = np.abs(
+            link_function.unlink_func(factors - uncertainties[0])
+            - link_function.unlink_func(factors)
+        )
+        upper = np.abs(
+            link_function.unlink_func(factors + uncertainties[1])
+            - link_function.unlink_func(factors)
+        )
         factors = link_function.unlink_func(factors)
         smoothed_factors = link_function.unlink_func(smoothed_factors)
         uncertainties = [
@@ -244,7 +268,9 @@ def plot_factor_1d(
         ]
         if plot_yp:
             # do not unlink for nbinom width mode
-            if ((link_function.unlink_func(y) >= 0).all()) and ((link_function.unlink_func(y) <= 1).all()):
+            if ((link_function.unlink_func(y) >= 0).all()) and (
+                (link_function.unlink_func(y) <= 1).all()
+            ):
                 y = link_function.unlink_func(y)
             p = link_function.unlink_func(p)
         plt.axhline(0.5, color="gray")
@@ -262,7 +288,9 @@ def plot_factor_1d(
         return
 
     feature_property = _ensure_tuple(feature.feature_property)
-    is_continuous = flags.is_continuous_set(feature_property[0]) | flags.is_linear_set(feature_property[0])
+    is_continuous = flags.is_continuous_set(feature_property[0]) | flags.is_linear_set(
+        feature_property[0]
+    )
     if plot_yp:
         minmax = np.r_[
             np.min(np.r_[factors, smoothed_factors, y, p]),
@@ -298,8 +326,12 @@ def plot_factor_1d(
     if not plot_yp:
         label = "factors"
         if is_continuous:
-            x_axis_range = (x_axis_range + np.append(x_axis_range, x_axis_range[-1] + 1)[1:]) / 2
-        _plot_factors(factors, x_axis_range, label, uncertainties if with_errorbars else None)
+            x_axis_range = (
+                x_axis_range + np.append(x_axis_range, x_axis_range[-1] + 1)[1:]
+            ) / 2
+        _plot_factors(
+            factors, x_axis_range, label, uncertainties if with_errorbars else None
+        )
 
     try:
         if len(factors) > 1:
@@ -313,7 +345,9 @@ def plot_factor_1d(
 
     from skpro.libs.cyclic_boosting.plots import _format_groupname_with_type
 
-    feature_group = _format_groupname_with_type(feature.feature_group, feature.feature_type)
+    feature_group = _format_groupname_with_type(
+        feature.feature_group, feature.feature_type
+    )
     plt.xlabel(feature_group)
     plt.legend()
 

--- a/skpro/libs/cyclic_boosting/plots/_2dplots.py
+++ b/skpro/libs/cyclic_boosting/plots/_2dplots.py
@@ -1,0 +1,221 @@
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib import gridspec
+
+from skpro.libs.cyclic_boosting.plots._1dplots import _get_y_axis
+
+from .plot_utils import add_missing_values_box, blue_cyan_green_cmap, colorful_histogram
+
+
+_imshow_style = dict(aspect="auto", origin="lower", interpolation="nearest")
+_imshow_style_precisions = _imshow_style.copy()
+_imshow_style_precisions["cmap"] = plt.get_cmap("gray_r")
+_imshow_style_factors = _imshow_style.copy()
+_imshow_style_factors["cmap"] = blue_cyan_green_cmap()
+
+
+def _no_finite_samples(ax):
+    plt.text(
+        0.5,
+        0.5,
+        "No finite samples to plot",
+        horizontalalignment="center",
+        verticalalignment="center",
+        transform=ax.transAxes,
+    )
+
+
+def _imshow_factors_2d(ax, factors, nan_factor, nan_uncertainty, title, clim, feature, nan_count):
+    """Factor plots for unsmoothed and smoothed 2d factors.
+    Parameters
+    ----------
+    ax
+        Matplotlib axis where drawing takes place
+    factors
+        numpy ndarray (two-dimensional) with factor data
+    nan_Factor
+        factor value of the NaN-bin
+    nan_uncertainty
+        uncertainty of the factor in the NaN-bin, optionally None
+    title: str
+        the title of the plot
+    clim: tuple
+        limits for imshow
+    feature
+        Feature object for the feature that is shown
+    """
+    first_feature_name = feature.feature_group[0] + (feature.feature_type or "")
+    second_feature_name = feature.feature_group[1] + (feature.feature_type or "")
+
+    plt.sca(ax)
+    if len(factors) == 0:
+        _no_finite_samples(ax)
+    else:
+        img = ax.imshow(factors.T, **_imshow_style_factors)
+        img.set_clim(clim)
+        plt.colorbar(img)
+
+    ax.set_title(title, fontsize=9, loc="left")
+    plt.xlabel(first_feature_name)
+    plt.ylabel(second_feature_name)
+    if np.abs(nan_factor) > 0.0001:
+        add_missing_values_box(ax, nan_factor, nan_uncertainty, nan_count)
+
+
+def bin_boundaries_for_factor_histograms(n_factors, extremal_absolute_factor):
+    """Returns bin boundaries for a given factor array. The resulting bins are
+    uneven in number, so that the neutral factor is in the center of a bin."""
+    from skpro.libs.cyclic_boosting.plots import _guess_suitable_number_of_histogram_bins
+
+    n_bins = _guess_suitable_number_of_histogram_bins(n_factors)
+    if n_bins % 2 == 0:
+        n_bins += 1
+    return np.linspace(-extremal_absolute_factor, extremal_absolute_factor, n_bins + 1)
+
+
+def _plot_factors_histogram(ax, factors, extremal_absolute_factor):
+    plt.sca(ax)
+    bin_boundaries = bin_boundaries_for_factor_histograms(len(factors), extremal_absolute_factor)
+    freq, bin_borders = colorful_histogram(ax, factors, bin_boundaries=bin_boundaries, cmap=blue_cyan_green_cmap())
+    ax.set_title("histogram of smoothed factors")
+    plt.xlabel("Factor")
+    ticks = 0.5 * bin_borders[1:] + 0.5 * bin_borders[:-1]
+    plt.xticks(ticks, ["{:.1f}".format(x) for x in 2**ticks])
+
+
+def plot_factor_2d(n_bins_finite, feature, grid_item=None):
+    """
+    Plots a single two dimensional factor plot. For an example see the
+    :ref:`cyclic_boosting_analysis_plots`
+
+    Parameters
+    ----------
+    n_bins_finite: int
+        Number of finite bins
+    feature: cyclic_boosting.base.Feature
+        Feature as it can be obtained from the plotting observers
+        ``features`` property.
+    grid_item: :class:`matplotlib.gridspec.SubplotSpec`
+        If the plot should be imbedded into a larger grid.
+    """
+    from skpro.libs.cyclic_boosting.plots import _format_groupname_with_type
+
+    plot_yp = True
+    if feature.y is None:
+        plot_yp = False
+    if plot_yp:
+        y2d = feature.y
+        prediction2d = feature.prediction
+    if plot_yp:
+        factors = feature.mean_dev
+    else:
+        factors = feature.unfitted_factors_link
+
+    smoothed_factors = feature.factors_link
+    uncertainties = feature.unfitted_uncertainties_link
+    _ = _format_groupname_with_type(feature.feature_group, feature.feature_type)
+    weights = feature.bin_weightsums
+
+    nan_factor_unfitted = feature.unfitted_factor_link_nan_bin
+    nan_factor = feature.factor_link_nan_bin
+    nan_uncertainty = uncertainties[-1]
+
+    def extremal_factor(x):
+        return max(np.abs(np.max(x)), np.abs(np.min(x)))
+
+    factors2d = np.reshape(factors[:-1], n_bins_finite)
+    smoothed2d = np.reshape(smoothed_factors[:-1], n_bins_finite)
+    if plot_yp:
+        y2d = np.reshape(y2d[:-1], n_bins_finite)
+        prediction2d = np.reshape(prediction2d[:-1], n_bins_finite)
+
+    if np.prod(n_bins_finite) == 0:
+        extremal_absolute_factor = 1
+    else:
+        extremal_absolute_factor = extremal_factor(smoothed2d)
+
+    if grid_item is not None:
+        gs = gridspec.GridSpecFromSubplotSpec(2, 2, subplot_spec=grid_item)
+    else:
+        gs = gridspec.GridSpec(2, 2)
+
+    clim = (-extremal_absolute_factor, extremal_absolute_factor)
+
+    _imshow_factors_2d(
+        plt.subplot(gs[0, 0]),
+        factors2d,
+        nan_factor=nan_factor_unfitted,
+        nan_uncertainty=nan_uncertainty,
+        title="final deviation of predition and truth in link space",
+        clim=clim,
+        feature=feature,
+        nan_count=0 if len(feature.bin_weightsums) < 1 else feature.nan_bin_weightsum,
+    )
+
+    _imshow_factors_2d(
+        plt.subplot(gs[1, 0]),
+        smoothed2d,
+        nan_factor=nan_factor,
+        nan_uncertainty=None,
+        title="smoothed parameters in link space",
+        clim=clim,
+        feature=feature,
+        nan_count=0 if len(feature.bin_weightsums) < 1 else feature.nan_bin_weightsum,
+    )
+
+    def plot_marginal(axis):
+        w1 = np.reshape(weights[:-1], n_bins_finite)
+        w1[w1 == 0.0] = 1.0
+        w = np.sum(w1, axis=axis)
+
+        def f(x):
+            return np.log(np.sum(w1 * np.exp(x), axis=axis) / w)
+
+        marginal_smoothed = f(smoothed2d)
+        marginal_dev = f(factors2d)
+        if plot_yp:
+            marginal_y = f(y2d)
+            marginal_p = f(prediction2d)
+
+        plt.axhline(0, color="gray")
+        plt.plot(marginal_smoothed, "r.-", label="smoothed factors")
+        if plot_yp:
+            plt.plot(marginal_p, ".-", label="prediction", alpha=0.5)
+            plt.plot(marginal_y, ".-", label="truth", alpha=0.5)
+        else:
+            plt.plot(marginal_dev, ".-", label="prediction / truth")
+        if axis == 0:
+            plt.plot(smoothed2d.T, "b-", alpha=0.03)
+        else:
+            plt.plot(smoothed2d, "b-", alpha=0.03)
+        if plot_yp:
+            all_arrays = np.r_[
+                marginal_smoothed,
+                marginal_dev,
+                marginal_p,
+                marginal_y,
+                smoothed2d.flatten(),
+            ]
+        else:
+            all_arrays = np.r_[marginal_smoothed, marginal_dev, smoothed2d.flatten()]
+        minmax = np.r_[np.min(all_arrays), np.max(all_arrays)]
+        y_axis_range, y_axis_labels = _get_y_axis(np.r_[minmax, marginal_smoothed])
+        plt.yticks(y_axis_range, y_axis_labels)
+        plt.title("Marginal Distribution: {}".format(feature.feature_group[0 if axis == 1 else 1]))
+        plt.legend()
+
+    plt.sca(plt.subplot(gs[0, 1]))
+    if len(factors2d) == 0:
+        _no_finite_samples(plt.gca())
+    else:
+        plot_marginal(1)
+
+    plt.sca(plt.subplot(gs[1, 1]))
+    if len(factors2d) == 0:
+        _no_finite_samples(plt.gca())
+    else:
+        plot_marginal(0)
+
+
+__all__ = []

--- a/skpro/libs/cyclic_boosting/plots/_2dplots.py
+++ b/skpro/libs/cyclic_boosting/plots/_2dplots.py
@@ -1,4 +1,3 @@
-
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib import gridspec
@@ -6,7 +5,6 @@ from matplotlib import gridspec
 from skpro.libs.cyclic_boosting.plots._1dplots import _get_y_axis
 
 from .plot_utils import add_missing_values_box, blue_cyan_green_cmap, colorful_histogram
-
 
 _imshow_style = dict(aspect="auto", origin="lower", interpolation="nearest")
 _imshow_style_precisions = _imshow_style.copy()
@@ -26,7 +24,9 @@ def _no_finite_samples(ax):
     )
 
 
-def _imshow_factors_2d(ax, factors, nan_factor, nan_uncertainty, title, clim, feature, nan_count):
+def _imshow_factors_2d(
+    ax, factors, nan_factor, nan_uncertainty, title, clim, feature, nan_count
+):
     """Factor plots for unsmoothed and smoothed 2d factors.
     Parameters
     ----------
@@ -66,7 +66,9 @@ def _imshow_factors_2d(ax, factors, nan_factor, nan_uncertainty, title, clim, fe
 def bin_boundaries_for_factor_histograms(n_factors, extremal_absolute_factor):
     """Returns bin boundaries for a given factor array. The resulting bins are
     uneven in number, so that the neutral factor is in the center of a bin."""
-    from skpro.libs.cyclic_boosting.plots import _guess_suitable_number_of_histogram_bins
+    from skpro.libs.cyclic_boosting.plots import (
+        _guess_suitable_number_of_histogram_bins,
+    )
 
     n_bins = _guess_suitable_number_of_histogram_bins(n_factors)
     if n_bins % 2 == 0:
@@ -76,12 +78,16 @@ def bin_boundaries_for_factor_histograms(n_factors, extremal_absolute_factor):
 
 def _plot_factors_histogram(ax, factors, extremal_absolute_factor):
     plt.sca(ax)
-    bin_boundaries = bin_boundaries_for_factor_histograms(len(factors), extremal_absolute_factor)
-    freq, bin_borders = colorful_histogram(ax, factors, bin_boundaries=bin_boundaries, cmap=blue_cyan_green_cmap())
+    bin_boundaries = bin_boundaries_for_factor_histograms(
+        len(factors), extremal_absolute_factor
+    )
+    freq, bin_borders = colorful_histogram(
+        ax, factors, bin_boundaries=bin_boundaries, cmap=blue_cyan_green_cmap()
+    )
     ax.set_title("histogram of smoothed factors")
     plt.xlabel("Factor")
     ticks = 0.5 * bin_borders[1:] + 0.5 * bin_borders[:-1]
-    plt.xticks(ticks, ["{:.1f}".format(x) for x in 2**ticks])
+    plt.xticks(ticks, [f"{x:.1f}" for x in 2**ticks])
 
 
 def plot_factor_2d(n_bins_finite, feature, grid_item=None):
@@ -202,7 +208,9 @@ def plot_factor_2d(n_bins_finite, feature, grid_item=None):
         minmax = np.r_[np.min(all_arrays), np.max(all_arrays)]
         y_axis_range, y_axis_labels = _get_y_axis(np.r_[minmax, marginal_smoothed])
         plt.yticks(y_axis_range, y_axis_labels)
-        plt.title("Marginal Distribution: {}".format(feature.feature_group[0 if axis == 1 else 1]))
+        plt.title(
+            f"Marginal Distribution: {feature.feature_group[0 if axis == 1 else 1]}"
+        )
         plt.legend()
 
     plt.sca(plt.subplot(gs[0, 1]))

--- a/skpro/libs/cyclic_boosting/plots/__init__.py
+++ b/skpro/libs/cyclic_boosting/plots/__init__.py
@@ -1,0 +1,371 @@
+"""
+Plots for the Cyclic Boosting family
+"""
+
+import contextlib
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib import gridspec
+from matplotlib.backends.backend_pdf import PdfPages
+
+from skpro.libs.cyclic_boosting.features import create_feature_id
+from skpro.libs.cyclic_boosting.utils import get_bin_bounds
+from skpro.libs.cyclic_boosting import CBNBinomC
+
+from ._1dplots import plot_factor_1d
+from ._2dplots import plot_factor_2d
+from .plot_utils import append_extension, nbpy_style
+
+
+def _guess_suitable_number_of_histogram_bins(n):
+    """
+    Guesses a suitable number of histograms for a given number of samples.
+    """
+    sturges = int(np.ceil(np.log(n) / np.log(2) + 1))
+    return np.clip(sturges, 5, 30)
+
+
+def _factor_plots_y_limits(factor_arr, uncert_arr=None, percentage=0.05, ymin_for_zero=1e-3):
+    """
+    >>> y = np.array([0, 1e-5, 0.1, 0.5, 1, 2, 10, 100, 1e5])
+    >>> np.allclose(_factor_plots_y_limits(y), (-1e-3, 1e5 * 1.05))
+    True
+
+    >>> y = np.array([1e-5, 10])
+    >>> np.allclose(_factor_plots_y_limits(y), (1e-5 * 0.95, 10 * 1.05))
+    True
+    """
+    if uncert_arr is not None:
+        ymax = np.max(factor_arr + uncert_arr)
+        ymin = np.min(factor_arr - uncert_arr)
+    else:
+        ymax = np.max(factor_arr)
+        ymin = np.min(factor_arr)
+
+    if ymin == 0:
+        ymin = -ymin_for_zero
+    else:
+        ymin = ymin * (1 - percentage)
+
+    return ymin, ymax * (1 + percentage)
+
+
+@nbpy_style
+def plot_iteration_info(plot_observer):
+    """
+    Convenience method calling :func:`plot_loss` and
+    :func:`plot_factor_change`.
+
+    Parameters
+    ----------
+    plot_observer: :class:`~cyclic_boosting.observers.PlottingObserver`
+        A fitted plotting observer.
+    """
+    plt.subplot(211)
+    plot_loss(plot_observer)
+    plt.subplot(212)
+    plot_factor_change(plot_observer)
+
+
+@nbpy_style
+def plot_factor_change(plot_observer):
+    """
+    Plot the global factor changes for all iterations.
+
+    Parameters
+    ----------
+    plot_observer: :class:`~cyclic_boosting.observers.PlottingObserver`
+        A fitted plotting observer.
+    """
+    factor_changes = plot_observer.factor_change
+    n = len(factor_changes)
+    iterations = np.arange(1, n + 1)
+    plt.xlabel("Iterations")
+    plt.ylabel("Factor change of all features")
+    ymin, ymax = _factor_plots_y_limits(factor_changes)
+    plt.ylim(ymin, ymax)
+    plt.xlim(0.9, n + 0.1)
+    plt.plot(iterations, factor_changes, "ob-")
+    plt.grid(True)
+
+
+@nbpy_style
+def plot_loss(plot_observer):
+    """
+    Plot the change of the loss function between the in-sample y
+    and the predicted factors for all iterations.
+    For the zeroth iteration the mean of y is used as prediction.
+
+    Parameters
+    ----------
+    plot_observer: :class:`~cyclic_boosting.observers.PlottingObserver`
+        A fitted plotting observer.
+    """
+    loss = plot_observer.loss
+    n = len(loss)
+    iterations = np.arange(n)
+    plt.xlabel("Iterations")
+    plt.ylabel("Loss")
+    ymin, ymax = _factor_plots_y_limits(loss)
+    plt.ylim(ymin, ymax)
+    plt.xlim(-0.1, n + 0.1)
+    plt.plot(iterations, loss, "o-r")
+    plt.grid(True)
+
+
+@nbpy_style
+def plot_in_sample_diagonal_plot(plot_observer):
+    """
+    Plot the in sample diagonal plot for prediction and truth.
+
+    Parameters
+    ----------
+    plot_observer: :class:`~cyclic_boosting.observers.PlottingObserver`
+        A fitted plotting observer.
+    """
+    plot_observer.check_fitted()
+    means, bin_centers, errors, _ = plot_observer.histograms
+
+    plt.plot(bin_centers, means, "o", color="b")
+    ymin, ymax = plt.ylim()
+    if errors is not None:
+        plt.errorbar(
+            bin_centers,
+            means,
+            yerr=[-errors[0], errors[1]],
+            fmt="none",
+            ecolor="b",
+            capsize=2.5,
+        )
+    else:
+        plt.errorbar(
+            bin_centers,
+            means,
+            fmt="none",
+            ecolor="b",
+            capsize=2.5,
+        )
+    xmin, xmax = plt.xlim()
+    plt.ylim(min(xmin, ymin), max(xmax, ymax))
+    plt.xlim(xmin, xmax)
+    plt.plot([xmin, xmax], [xmin, xmax], "k", linewidth=0.4)
+    plt.xlabel("Prediction")
+    plt.ylabel("Truth")
+
+
+def plot_analysis(
+    plot_observer,
+    file_obj,
+    binners=None,
+    figsize=(11.69, 8.27),
+    use_tightlayout=True,
+    plot_yp=True,
+):
+    """
+    Plot factors as a multipage PDF, also include plots for Loss and
+    factor change behaviour and an insample diagonal plot.
+
+    Parameters
+    ----------
+    plot_observer: :class:`~cyclic_boosting.observers.PlottingObserver`
+        A fitted plotting observer.
+    file: string or file-like
+        If a string indicates the name of the file, to which the plots are
+        written. The ending '.pdf' is added if it is not present already.
+        You may also pass a file-like object.
+    binners: list
+        A list of binners. If binners are given the labels of the x-axis of
+        factor plots are better interpretable.
+    figsize: tuple
+        A tuple with length containing the width and height of the figures.
+    use_tightlayout: bool
+        If true the tightlayout option of matplotlib is used.
+    """
+    filepath_or_object = append_extension(file_obj, ".pdf")
+    dpi = 200
+    with contextlib.closing(PdfPages(filepath_or_object)) as pdf_pages:
+        plot_observer.check_fitted()
+
+        # do not show for nbinom width mode
+        if plot_observer.link_function.__class__ != CBNBinomC:
+            plt.figure(figsize=figsize)
+            plot_in_sample_diagonal_plot(plot_observer)
+            plt.savefig(pdf_pages, format="pdf", dpi=dpi)
+
+        for feature in plot_observer.features:
+            plt.figure(figsize=figsize)
+            grid = gridspec.GridSpec(1, 1)
+            _plot_one_feature_group(
+                plot_observer,
+                grid[0],
+                feature,
+                binners,
+                use_tightlayout,
+                plot_yp=plot_yp,
+            )
+            plt.savefig(pdf_pages, format="pdf", dpi=dpi)
+
+        # plt.figure(figsize=figsize)
+        # plot_factor_change(plot_observer)
+        # plt.savefig(pdf_pages, format="pdf", dpi=dpi)
+        plt.figure(figsize=figsize)
+        plot_loss(plot_observer)
+        plt.savefig(pdf_pages, format="pdf", dpi=dpi)
+        # for feature in plot_observer.features:
+        #     plt.figure(figsize=figsize)
+        #     f_sum = feature.factor_sum
+        #     # f_sum /= f_sum[-1]
+        #     plt.plot(f_sum)
+        #     plt.title(
+        #         "absolute factor sum for {} over iterations".format(
+        #             feature.feature_group
+        #         )
+        #     )
+        #     plt.savefig(pdf_pages, format="pdf", dpi=dpi)
+    plt.close("all")
+
+
+@nbpy_style
+def plot_factors(
+    plot_observer,
+    binners=None,
+    feature_groups_or_ids=None,
+    features_per_row=2,
+    use_tightlayout=True,
+    plot_yp=True,
+):
+    """
+    Create a matplotlib figure containing several factor plots (of a
+    possibly pre-defined subset of features) in a grid.
+
+    Parameters
+    ----------
+    plot_observer: :class:`~cyclic_boosting.observers.PlottingObserver`
+        A fitted plotting observer.
+    binners: list
+        A list of binners. If binners are given the labels of the x-axis of
+        factor plots are better interpretable.
+    feature_groups_or_ids: list
+        A list of feature group names or
+        :class:`cyclic_boosting.base.FeatureID`
+        for which the factors will be plotted.
+        Default is to plot the factors of all features.
+    features_per_row: int
+        The number of factor plots in one row.
+    use_tightlayout: bool
+        If true the tightlayout option of matplotlib is used.
+    """
+    plot_observer.check_fitted()
+    if feature_groups_or_ids is None:
+        features = plot_observer.features
+    else:
+        feature_ids = [create_feature_id(feature_group_or_id) for feature_group_or_id in feature_groups_or_ids]
+        features = [plot_observer.features[feature_id] for feature_id in feature_ids]
+
+    n_plots = len(features)
+    grid = gridspec.GridSpec(int(np.ceil(n_plots / features_per_row)), features_per_row)
+
+    for i, feature in enumerate(features):
+        _plot_one_feature_group(plot_observer, grid[i], feature, binners, use_tightlayout, plot_yp=plot_yp)
+
+
+def _format_groupname_with_type(feature_group, feature_type):
+    name = ", ".join(feature_group)
+    if feature_type is None:
+        return name
+    else:
+        return "{0} ({1})".format(name, feature_type)
+
+
+def _plot_one_feature_group(plot_observer, grid_item, feature, binners=None, use_tightlayout=True, plot_yp=True):
+    if len(feature.feature_group) == 1:
+        # treatment of one-dimensional features
+        # no bin occupancy plot for too many bins
+        if len(feature.factors_link) > 400:
+            plt.subplot(grid_item)
+            plot_factor_1d(
+                feature,
+                bin_bounds=get_bin_bounds(binners, feature.feature_group[0]),
+                link_function=plot_observer.link_function,
+                plot_yp=plot_yp,
+            )
+        else:
+            gs = gridspec.GridSpecFromSubplotSpec(2, 1, subplot_spec=grid_item, height_ratios=[2.5, 0.4])
+            factor_plot = plt.subplot(gs[0, 0])
+            plot_factor_1d(
+                feature,
+                bin_bounds=get_bin_bounds(binners, feature.feature_group[0]),
+                link_function=plot_observer.link_function,
+                plot_yp=plot_yp,
+            )
+            plt.subplot(gs[1, 0], sharex=factor_plot)
+            bin_occupancies = np.bincount(feature.lex_binned_data)
+            plt.plot(range(len(bin_occupancies)), bin_occupancies)
+            plt.xticks(size="xx-small", rotation="vertical")
+        plt.grid(True, which="both")
+
+    elif len(feature.feature_group) == 2:
+        # treatment of two-dimensional features
+        plot_factor_2d(
+            n_bins_finite=plot_observer.n_feature_bins[feature.feature_group],
+            feature=feature,
+            grid_item=grid_item,
+        )
+
+    else:
+        plt.subplot(grid_item)
+        plot_factor_high_dim(feature)
+
+    if use_tightlayout:
+        plt.tight_layout()
+
+
+def plot_factor_histogram(feature):
+    """
+    Plots a histogram of the given factors with a logarithmic y-axis.
+
+    Parameters
+    ----------
+    feature: cyclic_boosting.base.Feature
+        Feature object from as it can be obtained from a plotting
+        observer
+    """
+    factors = feature.unfitted_factors_link
+    smoothed_factors = feature.factors_link
+    feat_group = feature.feature_group
+    feature_type = feature.feature_type
+    feat_group = _format_groupname_with_type(feat_group, feature_type)
+    n_bins = _guess_suitable_number_of_histogram_bins(len(factors))
+
+    fig = plt.figure()
+    gs = gridspec.GridSpec(nrows=2, ncols=1, figure=fig)
+
+    fig.add_subplot(gs[0, 0])
+    plt.title("Unsmoothed-Factor Histogram for {0}".format(feat_group))
+    plt.xlabel("Factor")
+    plt.ylabel("Count")
+    plt.hist(factors, bins=n_bins, log=True)
+
+    fig.add_subplot(gs[1, 0])
+    dev = smoothed_factors - factors
+    plt.xlabel("smoothed_factors - factors")
+    plt.ylabel("Count")
+    plt.hist(dev, bins=100, log=True, color="red")
+
+
+plot_factor_high_dim = plot_factor_histogram
+
+
+__all__ = [
+    "plot_iteration_info",
+    "plot_factor_change",
+    "plot_loss",
+    "plot_in_sample_diagonal_plot",
+    "plot_analysis",
+    "plot_factors",
+    "plot_factor_1d",
+    "plot_factor_2d",
+    "plot_factor_high_dim",
+    "plot_factor_histogram",
+]

--- a/skpro/libs/cyclic_boosting/plots/__init__.py
+++ b/skpro/libs/cyclic_boosting/plots/__init__.py
@@ -9,9 +9,9 @@ import numpy as np
 from matplotlib import gridspec
 from matplotlib.backends.backend_pdf import PdfPages
 
+from skpro.libs.cyclic_boosting import CBNBinomC
 from skpro.libs.cyclic_boosting.features import create_feature_id
 from skpro.libs.cyclic_boosting.utils import get_bin_bounds
-from skpro.libs.cyclic_boosting import CBNBinomC
 
 from ._1dplots import plot_factor_1d
 from ._2dplots import plot_factor_2d
@@ -26,7 +26,9 @@ def _guess_suitable_number_of_histogram_bins(n):
     return np.clip(sturges, 5, 30)
 
 
-def _factor_plots_y_limits(factor_arr, uncert_arr=None, percentage=0.05, ymin_for_zero=1e-3):
+def _factor_plots_y_limits(
+    factor_arr, uncert_arr=None, percentage=0.05, ymin_for_zero=1e-3
+):
     """
     >>> y = np.array([0, 1e-5, 0.1, 0.5, 1, 2, 10, 100, 1e5])
     >>> np.allclose(_factor_plots_y_limits(y), (-1e-3, 1e5 * 1.05))
@@ -260,14 +262,19 @@ def plot_factors(
     if feature_groups_or_ids is None:
         features = plot_observer.features
     else:
-        feature_ids = [create_feature_id(feature_group_or_id) for feature_group_or_id in feature_groups_or_ids]
+        feature_ids = [
+            create_feature_id(feature_group_or_id)
+            for feature_group_or_id in feature_groups_or_ids
+        ]
         features = [plot_observer.features[feature_id] for feature_id in feature_ids]
 
     n_plots = len(features)
     grid = gridspec.GridSpec(int(np.ceil(n_plots / features_per_row)), features_per_row)
 
     for i, feature in enumerate(features):
-        _plot_one_feature_group(plot_observer, grid[i], feature, binners, use_tightlayout, plot_yp=plot_yp)
+        _plot_one_feature_group(
+            plot_observer, grid[i], feature, binners, use_tightlayout, plot_yp=plot_yp
+        )
 
 
 def _format_groupname_with_type(feature_group, feature_type):
@@ -275,10 +282,12 @@ def _format_groupname_with_type(feature_group, feature_type):
     if feature_type is None:
         return name
     else:
-        return "{0} ({1})".format(name, feature_type)
+        return f"{name} ({feature_type})"
 
 
-def _plot_one_feature_group(plot_observer, grid_item, feature, binners=None, use_tightlayout=True, plot_yp=True):
+def _plot_one_feature_group(
+    plot_observer, grid_item, feature, binners=None, use_tightlayout=True, plot_yp=True
+):
     if len(feature.feature_group) == 1:
         # treatment of one-dimensional features
         # no bin occupancy plot for too many bins
@@ -291,7 +300,9 @@ def _plot_one_feature_group(plot_observer, grid_item, feature, binners=None, use
                 plot_yp=plot_yp,
             )
         else:
-            gs = gridspec.GridSpecFromSubplotSpec(2, 1, subplot_spec=grid_item, height_ratios=[2.5, 0.4])
+            gs = gridspec.GridSpecFromSubplotSpec(
+                2, 1, subplot_spec=grid_item, height_ratios=[2.5, 0.4]
+            )
             factor_plot = plt.subplot(gs[0, 0])
             plot_factor_1d(
                 feature,
@@ -342,7 +353,7 @@ def plot_factor_histogram(feature):
     gs = gridspec.GridSpec(nrows=2, ncols=1, figure=fig)
 
     fig.add_subplot(gs[0, 0])
-    plt.title("Unsmoothed-Factor Histogram for {0}".format(feat_group))
+    plt.title(f"Unsmoothed-Factor Histogram for {feat_group}")
     plt.xlabel("Factor")
     plt.ylabel("Count")
     plt.hist(factors, bins=n_bins, log=True)

--- a/skpro/libs/cyclic_boosting/plots/plot_utils.py
+++ b/skpro/libs/cyclic_boosting/plots/plot_utils.py
@@ -1,0 +1,283 @@
+import contextlib
+
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+import numpy as np
+
+from matplotlib.cm import ScalarMappable
+from matplotlib.colors import Normalize
+
+from skpro.libs.cyclic_boosting import utils
+
+
+def add_missing_values_box(ax, nan_value=None, nan_uncert=None, nan_count=None):
+    r"""Adds a Neurobayes analysis-plot-style box to plot axes indicating the
+    corresponding value for NaN-data.
+
+    The function assumes that there is free space to the right of the plot.
+    It was originally designed to fit the NaN-box between a 2-D
+    :func:`matplotlib.pyplot.imshow` plot and its colorbar (see example below).
+
+    Parameters
+    ----------
+
+    ax : matplotlib.axes.Axes
+        The axes object corresponding to the plot to which the nan box should
+        be added
+
+    nan_value : float
+        A value to be displayed in the NaN box
+
+    nan_uncert : float
+        If not None, uncertainty that will be printed as plusminus deviation
+
+    Returns
+    -------
+
+    matplotlib.axes.Axes
+        axes object of the NaN-box
+    """
+    xmin, xmax = ax.get_xlim()
+    ymin, ymax = ax.get_ylim()
+
+    middle, right = fill_missing_values_box(ax, xmax, xmin, ymin, ymax)
+    ax.set_xlim(xmin, right)
+
+    if nan_value is None:
+        nan_text = r"NaN: -"
+    else:
+        nan_text = r"NaN: {value:.3f}"
+
+    if nan_uncert is not None:
+        nan_text += r" $\pm$ {uncert:.3f}"
+
+    if nan_count is not None:
+        nan_text += r", #: {count:.0f}"
+
+    ax.axvline(xmax)
+
+    ax.text(
+        middle,
+        sum(ax.get_ylim()) * 0.5,
+        nan_text.format(value=nan_value, uncert=nan_uncert, count=nan_count),
+        rotation="vertical",
+        fontsize=10,
+        verticalalignment="center",
+        horizontalalignment="center",
+        clip_on=True,
+    )
+
+
+def fill_missing_values_box(ax, xmax, xmin, ymin, ymax):
+    """Fill the yellow area and return x coordinates for
+    the missing values box.
+
+    Parameters
+    ----------
+
+    ax : matplotlib.axes.Axes
+        axes object into which the missing values box will be drawn
+
+    xmax : float
+        maximum x-limit of the axes
+
+    xmin : float
+        minimum x-limit of the axes
+
+    ymin : float
+        minimum y-limit of the axes
+
+    ymax : float
+        maximum y-limit of the axes
+
+    Note
+    ----
+
+    Be careful of the unintuitive order of the parameters.
+
+    Returns
+    -------
+     (float, float)
+        tuple of x-coordinates for the middle and the right edge of the box
+        (the left edge is already given by xmax)
+    """
+    middle, right = calc_extent_with_missing_values_box(xmin, xmax)
+    ax.fill_between([xmax, right], ymin, ymax, color="#f7d208", alpha=0.5)
+    return middle, right
+
+
+def calc_extent_with_missing_values_box(xmin, xmax):
+    """Calculates new extent of a plot when a missing values box is added
+
+    Parameters
+    ----------
+
+    xmin : float
+        minimum x-limit of the original plot
+
+    xmax : float
+        maximum x-limit of the original plot
+
+    Returns
+    -------
+
+    (float, float)
+        tuple of x-coordinates for the middle and the right edge of the box
+        (the left edge is already given by xmax)
+    """
+    step = (xmax - xmin) * 0.05
+    right = xmax + step
+    middle = xmax + 0.5 * step
+
+    return middle, right
+
+
+def colorful_histogram(ax, x, bin_boundaries, cmap):
+    """Plot a histogram on a given matplotlib axis `ax` for to-be-binned values
+    `x` with bin boundaries ``bin_boundaries`` (is passed to ``np.histogram``). Each bin
+    column is colored using the map provided by ``cmap``.
+    """
+    freq, bin_borders = np.histogram(x, bins=bin_boundaries)
+    color_norm = Normalize(vmin=np.min(bin_borders), vmax=np.max(bin_borders))
+    scalar_mappable = ScalarMappable(norm=color_norm, cmap=cmap)
+    bin_centers = 0.5 * bin_borders[:-1] + 0.5 * bin_borders[1:]
+
+    ax.bar(
+        bin_borders[:-1],
+        freq,
+        width=bin_borders[1] - bin_borders[0],
+        color=scalar_mappable.to_rgba(bin_centers),
+    )
+    return freq, bin_borders
+
+
+def blue_cyan_green_cmap():
+    """Colormap from blue over cyan to green
+
+    :rtype: :class:`matplotlib.colors.LinearSegmentedColormap`
+    """
+    return _colormap_gen(blue_red=False)
+
+
+def _colormap_gen(blue_red=True):
+    """Colormap from blue over magenta to red **or** blue over cyan to green
+
+    Parameters
+    ----------
+    blue_red: bool
+        If ``True`` blue-magenta-red colormap, else blue-cyan-green colormap is
+        build.
+
+    Returns
+    -------
+    matplotlib.colors.LinearSegmentedColormap
+        Color map
+    """
+    r1, g1, b1 = 0, 0, 1
+    r2, g2, b2 = 1, 0, 0
+    if blue_red:
+        color1 = "red"
+        color2 = "green"
+        name = "blue_magenta_red_cmap"
+    else:
+        color1 = "green"
+        color2 = "red"
+        name = "blue_cyan_green_cmap"
+
+    cdict = {
+        color1: ((0, r1, r1), (0.5, r2, r2), (1, r2, r2)),
+        color2: ((0, g1, g1), (1, g2, g2)),
+        "blue": ((0, b1, b1), (0.5, b1, b1), (1, b2, b2)),
+    }
+
+    cmap = mpl.colors.LinearSegmentedColormap(name, cdict)
+    if blue_red:
+        cmap.set_over((0.5, 0, 0))
+    else:
+        cmap.set_over((0, 0.5, 0))
+    cmap.set_under((0, 0, 0.5))
+    return cmap
+
+
+def _nbpy_style():
+    """Activate nbpy's Matplotlib style default settings locally."""
+    rcParams = {}
+    rcParams["grid.color"] = "#000000"
+    rcParams["grid.alpha"] = 0.1
+    rcParams["grid.linestyle"] = "-"
+    rcParams["lines.markersize"] = 3.0
+    rcParams["legend.numpoints"] = 1
+
+    # font sizes
+    rcParams["font.size"] = 20
+    rcParams["legend.fontsize"] = "small"
+    rcParams["axes.labelsize"] = "small"
+    rcParams["axes.titlesize"] = "medium"
+    rcParams["xtick.labelsize"] = "small"
+    rcParams["ytick.labelsize"] = "small"
+
+    rcParams["image.interpolation"] = "antialiased"
+
+    with mpl.rc_context(rcParams):
+        yield
+
+
+nbpy_style = utils.generator_to_decorator(_nbpy_style)
+nbpy_style_context = contextlib.contextmanager(_nbpy_style)
+
+
+@contextlib.contextmanager
+def _nbpy_style_figure(num=None, figsize=None):
+    """Contextmanager for providing a new plotting environment using the
+    nbpy plotting style.
+
+    Some plot functions create a new figure by default. To avoid this,
+    set the corresponding keyword argument, e.g. ``fignum`` in::
+
+        plt.matshow(matrix, fignum=False)
+
+    Note
+    ----
+    In earlier versions, this context closed all pre-existing figures.
+    This functionality has been removed. Please call plt.close("all") yourself,
+    if you need to remove figures before plotting.
+
+    Parameters
+    ----------
+    num: int
+        figure number, by default :obj:`None` which, the default of
+        :func:`~matplotlib.pyplot.figure` default.
+    figsize: tuple, float or None
+        Optional size of the new figure to create.
+    """
+    try:
+        plt.figure(num=num, figsize=figsize)
+        with nbpy_style_context():
+            yield
+    finally:
+        pass
+
+
+def append_extension(file, extension):
+    """Small helper method to append possibly missing extension to a
+    file name.
+
+    Only works on instances of basestring. Leaves all other objects
+    unchanged
+
+    Parameters
+    ----------
+
+    file : any object
+
+    extension : str
+        extension (including '.') to be appended to file
+
+    Returns
+    -------
+    result : object of same type as `file`
+    """
+    if isinstance(file, str):
+        if not file.endswith(extension):
+            file += extension
+    return file

--- a/skpro/libs/cyclic_boosting/plots/plot_utils.py
+++ b/skpro/libs/cyclic_boosting/plots/plot_utils.py
@@ -3,7 +3,6 @@ import contextlib
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
-
 from matplotlib.cm import ScalarMappable
 from matplotlib.colors import Normalize
 

--- a/skpro/libs/cyclic_boosting/price.py
+++ b/skpro/libs/cyclic_boosting/price.py
@@ -1,0 +1,474 @@
+# -*- coding: utf-8 -*-
+"""
+Cyclic boosting exponential price model estimator
+"""
+
+import logging
+
+import numpy as np
+import pandas as pd
+from numexpr import evaluate
+
+
+from skpro.libs.cyclic_boosting import CBNBinomRegressor
+from skpro.libs.cyclic_boosting.features import FeatureTypes, create_feature_id
+from skpro.libs.cyclic_boosting.base import UpdateMixin
+from skpro.libs.cyclic_boosting.regression import _calc_factors_and_uncertainties
+from skpro.libs.cyclic_boosting.utils import get_X_column
+
+_logger = logging.getLogger(__name__)
+
+
+def combine_lists_of_feature_groups(standard_feature_groups, external_feature_groups):
+    """Combine the ``feature_groups`` and ``external_feature_groups`` to
+    one list of feature_ids.
+    """
+    if standard_feature_groups is None:
+        raise ValueError("Pass at least one feature in `standard_feature_groups`.")
+    standard_feature_groups = [create_feature_id(fg) for fg in standard_feature_groups]
+    if external_feature_groups is not None:
+        external_feature_groups = [
+            create_feature_id(exfg, default_type=FeatureTypes.external) for exfg in external_feature_groups
+        ]
+        _check_feature_groups(standard_feature_groups, external_feature_groups)
+        return standard_feature_groups + external_feature_groups
+    else:
+        _check_feature_groups(standard_feature_groups, external_feature_groups)
+        return standard_feature_groups
+
+
+def _check_feature_groups(standard_feature_groups, external_feature_groups):
+    """Check if ``standard_feature_groups`` and ``external_feature_groups``
+    are correctly filled with the right
+    :class:`cyclic_boosting.base.FeatureID`.
+    """
+    for feature_id in standard_feature_groups:
+        if feature_id.feature_type is not None:
+            raise ValueError(
+                "There are none standard features in the "
+                "``standard_feature_groups`` present. Use "
+                "``external_feature_groups`` for those features."
+            )
+    if external_feature_groups is not None:
+        for feature_id in external_feature_groups:
+            if feature_id.feature_type is not FeatureTypes.external:
+                raise ValueError(
+                    "There are standard features in the "
+                    "``external_feature_groups`` present. Use "
+                    "``standard_feature_groups`` for those features."
+                )
+
+
+def _set_right_bound(x, args, valid):
+    bounds_to_small = True
+    max_iter = 10
+    i = 0
+    while bounds_to_small and (i < max_iter):
+        f = newton_step(x, *args, only_jac=True)
+        index = valid & (f < 0)
+        bounds_to_small = np.any(index)
+        if bounds_to_small:
+            x[index] *= 2
+        else:
+            break
+        i += 1
+    return x
+
+
+def newton_bisect(
+    newton_step,
+    args,
+    valid,
+    x_l,
+    x_r,
+    epsilon=0.001,
+    maximal_iterations=10,
+    start_values=None,
+):
+    """Combination of Newton's Method and Bisection
+    to find the root of the jacobian.
+
+    Every time Newton tries a step outside the bounding interval [x_l, x_r]
+    the bisection update is used.
+
+    Parameters
+    ----------
+    newton_step: callable
+       Calculate the parameter update, jacobian and hessian:
+
+       .. code-block:: python
+
+           def newton_step(l, *args):
+               ...
+               return l_new, jacobian, hessian
+
+    args: iterable
+       Parameters pass to `newton_step`
+    valid: np.ndarray
+       Boolean array encoding valid values
+    x_l: np.ndarray
+       Start values for the left bounds
+    x_r: np.ndarray
+       Start values for the right bounds
+    epsilon: float
+       Epsilon on the jacobian. Iteration stops if:
+
+       .. code-block:: python
+
+           np.all(np.abs(jacobian) < epsilon)
+
+    maximal_iterations: int
+       number of maximal iterations
+    start_values: np.ndarray or None
+       Start values on the parameters. If None, the middle of
+       the first bisection interval is used.
+
+    Returns
+    -------
+    tuple
+        (fitted parameters, variance of parameters,
+             left bounds, right bounds)
+    """
+    x_r = _set_right_bound(x_r, args, valid)
+    x_l_save, x_r_save = x_l.copy(), x_r.copy()
+
+    if start_values is None or np.any(start_values < x_l) or np.any(start_values > x_r):
+        l = (x_r + x_l) / 2.0
+    else:
+        l = start_values
+
+    for i in range(maximal_iterations):
+        l_new, jac, hess = newton_step(l, *args)
+        finite = np.isfinite(jac) & np.isfinite(hess) & np.isfinite(l_new)
+        valid = valid & finite
+        converged = (np.abs(jac) < epsilon) | (np.abs(l - x_l) < epsilon) | (np.abs(x_r - l) < epsilon) | (~valid)
+        if np.all(converged):
+            break
+        x_l[valid & (jac < 0)] = l[valid & (jac < 0)]
+        x_r[valid & (jac >= 0)] = l[valid & (jac >= 0)]
+
+        index = np.full_like(valid, False)
+        index[valid] = (l_new[valid] > x_r[valid]) | (l_new[valid] < x_l[valid])
+
+        l_new[index] = (x_l[index] + x_r[index]) / 2.0
+        l_new[~valid] = 1.0
+        hess[~valid] = 1.0
+        l = l_new
+
+    # Check for negative values in hessian -> not allowed because negative variance
+    hess_inv = np.full_like(hess, np.inf)
+    m_non_zero = hess != 0
+    hess_inv[m_non_zero] = 1.0 / hess[m_non_zero]
+
+    ind = hess_inv <= 0
+    hess_inv[ind] = 1.0
+
+    return l, hess_inv, x_l_save, x_r_save
+
+
+def newton_step(
+    l,
+    y,
+    p,
+    log_x,
+    k,
+    prior,
+    s,
+    log_k_prior,
+    var_l,
+    lex_binnumbers,
+    minlength,
+    only_jac=False,
+):
+    l1_ = np.c_[l, np.log(l)]  # noqa
+    l1_ = l1_[lex_binnumbers, :]  # noqa
+    l1 = l1_[:, 0]  # noqa
+    log_l1 = l1_[:, 1]  # noqa
+
+    mu = evaluate("p * exp((k * l1) * log_x)")  # noqa
+    w = k * log_x  # noqa
+
+    bin_counts = np.bincount(lex_binnumbers, minlength=minlength)[lex_binnumbers]  # noqa
+    # wolfram alpha: jacobian matrix ((y - p * x ** (l * k))^2 * s + ((l*k - c)^2 +
+    # (l - 1)^2 + log(l)^2 + log(l*k / c)^2) / v) with respect to (l)
+    jac_prior = evaluate("2 * (k * (k * l1 - prior) + l1 - 1 + (log_k_prior + 2 * log_l1) / l1) / var_l / bin_counts")
+
+    jac_data = evaluate("- (2 * w * mu * (y - mu)) * s")
+    jacobian = np.bincount(lex_binnumbers, weights=jac_data + jac_prior, minlength=minlength)
+
+    if only_jac:
+        return jacobian
+
+    # wolfram alpha: hessian matrix ((y - p * x ** (l * k))^2 * s + ((l*k - c)^2 +
+    # (l - 1)^2 + log(l)^2 + log(l*k / c)^2) / v) with respect to (l)
+    hess_prior = evaluate("2 * (k * k + 1 + (2 - (log_k_prior + 2 * log_l1) ) / l1 / l1) / var_l / bin_counts")
+
+    hess_data = evaluate("(2 * w * w * mu * mu) * s + w * jac_data")
+    hessian = np.bincount(lex_binnumbers, weights=hess_data + hess_prior, minlength=minlength)
+
+    lnew = np.full_like(l, np.nan)
+    m_non_zero = hessian != 0
+    lnew[m_non_zero] = l[m_non_zero] - jacobian[m_non_zero] / hessian[m_non_zero]
+
+    return lnew, jacobian, hessian
+
+
+class CBExponential(CBNBinomRegressor):
+    def __init__(
+        self,
+        external_colname,
+        standard_feature_groups,
+        external_feature_groups,
+        feature_properties=None,
+        weight_column=None,
+        prior_prediction_column=None,
+        minimal_loss_change=1e-3,
+        minimal_factor_change=1e-3,
+        maximal_iterations=20,
+        observers=None,
+        var_prior_exponent=0.1,
+        smoother_choice=None,
+        prior_exponent_colname=None,
+        output_column=None,
+        learn_rate=None,
+        a=1.0,
+        c=0.0,
+    ):
+        self.standard_feature_groups = standard_feature_groups
+        self.external_feature_groups = external_feature_groups
+        self.prior_exponent_colname = prior_exponent_colname
+
+        feature_id_list = combine_lists_of_feature_groups(standard_feature_groups, external_feature_groups)
+
+        self.external_colname = external_colname
+
+        CBNBinomRegressor.__init__(
+            self,
+            feature_groups=feature_id_list,
+            feature_properties=feature_properties,
+            weight_column=weight_column,
+            prior_prediction_column=prior_prediction_column,
+            minimal_loss_change=minimal_loss_change,
+            minimal_factor_change=minimal_factor_change,
+            maximal_iterations=maximal_iterations,
+            observers=observers,
+            smoother_choice=smoother_choice,
+            output_column=output_column,
+            learn_rate=learn_rate,
+            a=a,
+            c=c,
+        )
+
+        # Parameters which influence the exponent fits
+        # in each feature group bin
+        self.var_prior_exponent = var_prior_exponent
+        self.epsilon_jacobian = 0.01
+        self.starting_bound_bisect = 2
+
+    def required_columns(self):
+        required_columns = CBNBinomRegressor.required_columns(self)
+        required_columns.add(self.external_colname)
+        if self.prior_exponent_colname is not None:
+            required_columns.add(self.prior_exponent_colname)
+        return required_columns
+
+    def _init_external_column(self, X, is_fit):
+        """Init the external column.
+
+        Parameters
+        ----------
+
+        X: np.ndarray
+            samples features matrix
+        is_fit: bool
+           are we called in fit() ?
+
+        Raises
+        ------
+
+        ValueError
+            if any value in 'external_col' is smaller equal zero
+
+        """
+        self.external_col = get_X_column(X, self.external_colname) - 1
+        is_finite = np.isfinite(self.external_col)
+        self.external_col[~is_finite] = 0
+        if is_fit:
+            self.weights_external = np.asarray(is_finite, dtype=np.float64)
+            self.weights_external *= self.weights
+
+    def _get_prior_exponent(self, X):
+        if self.prior_exponent_colname is None:
+            return -1.0
+        else:
+            return get_X_column(X, self.prior_exponent_colname)
+
+    def calc_parameters(self, feature, y, pred, prefit_data):
+        """Calculates factors and uncertainties of the bins of a feature group
+        in the original space (not the link space) and transforms them to the
+        link space afterwards
+
+        The factors and uncertainties cannot be determined in link space, not
+        least because target values like 0 diverge in link spaces like `log`
+        or `logit`.
+
+        Parameters
+        ----------
+        feature: :class:`~.Feature`
+            feature information
+        y: np.ndarray
+            target, truth
+        prediction_link: np.ndarray
+            prediction in link space of all *other* features.
+        prefit_data
+            data returned by
+            :meth:`~cyclic_boosting.base.CyclicBoostingBase.precalc_parameters`
+            during fit
+
+        Returns
+        -------
+        tuple
+            This method must return a tuple of ``factors`` and
+            ``uncertainties`` in the **link space**.
+        """
+        if feature.feature_type == FeatureTypes.external:
+            _logger.debug("Price Feature {}".format(feature.feature_group))
+            expo, variance = self._calc_parameters_exponent(feature, y, pred)
+            return expo, variance
+        else:
+            _logger.debug("Demand Feature {}".format(feature.feature_group))
+            return CBNBinomRegressor.calc_parameters(self, feature, y, pred, None)
+
+    def _calc_parameters_exponent(self, feature, y, pred):
+        """Calculates exponents and uncertainties
+        for each bin of a feature group.
+
+        Parameters
+        ----------
+        feature: :class:`~.Feature`
+            feature information
+        y: np.ndarray
+            target, truth
+        prediction_link: np.ndarray
+            prediction in link space of all *other* features.
+
+
+        Returns
+        -------
+        tuple
+            ``exponents`` and ``uncertainties``.
+        """
+        lex_binnumbers = feature.lex_binned_data
+        pred_factors = self.unlink_func(pred.factors())
+        pred_expos = pred.exponents()
+        base = pred.base()
+        prior_exponents = pred.prior_exponents()
+
+        bounds_l = np.zeros(feature.n_bins, dtype=np.float64)
+        feature.bounds_r = self.starting_bound_bisect * np.ones(feature.n_bins, dtype=np.float64)
+        start_values = np.ones(feature.n_bins, dtype=np.float64)
+
+        p = self.unlink_func(pred.predict_link())
+
+        log_k_prior = evaluate("log(pred_expos / prior_exponents)")
+        a = self.a
+        c = self.c
+        variance = a * p + c * p * p
+
+        factors, variance_factors, feature.bounds_l, feature.bounds_r = newton_bisect(
+            newton_step,
+            (
+                y,
+                pred_factors,
+                base,
+                pred_expos,
+                prior_exponents,
+                self.weights_external / variance,
+                log_k_prior,
+                self.var_prior_exponent,
+                lex_binnumbers,
+                len(feature.bin_weightsums),
+            ),
+            feature.bin_weightsums > 0,
+            x_l=bounds_l,
+            x_r=feature.bounds_r,
+            epsilon=self.epsilon_jacobian,
+            start_values=start_values,
+        )
+        return gamma_momemt_matching(factors, variance_factors, self.link_func)
+
+    def predict(self, X, y=None):
+        pred = self.predict_extended(X, None)
+        return self.unlink_func(pred.predict_link())
+
+    def predict_extended(self, X, influence_categories):
+        self._check_fitted()
+        self._init_external_column(X, False)
+
+        prediction_link = self._get_prior_predictions(X)
+        pred = CBLinkPredictions(prediction_link, self._get_prior_exponent(X), self.external_col)
+
+        for feature in self.features:
+            feature_predictions = self._pred_feature(X, feature, is_fit=False)
+            pred.update_predictions(feature_predictions, feature, influence_categories)
+        return pred
+
+    def fit(self, X, y=None):
+        self._init_fit(X, y)
+        pred = CBLinkPredictions(
+            self._get_prior_predictions(X),
+            self._get_prior_exponent(X),
+            self.external_col,
+        )
+        _ = self._fit_main(X, y, pred)
+        del self.external_col
+        del self.weights_external
+
+        return self
+
+
+def gamma_momemt_matching(factors, variance_factors, link_func):
+    """ """
+    # Gamma distribution moment matching
+    beta = factors / variance_factors
+    alpha = beta * factors
+
+    # check finite of alpha, beta. If not finite
+    # -> set alpha=0, beta=0 -> then only the prior is used
+    # Non-finite values should not happen anymore since a
+    # prior is used in calc_factors_generic.
+    is_finite = np.isfinite(beta) & np.isfinite(alpha)
+    beta[~is_finite] = 0
+    alpha[~is_finite] = 0
+
+    return _calc_factors_and_uncertainties(alpha, beta, link_func)
+
+
+class CBLinkPredictions(UpdateMixin):
+    """Support for prediction of type log(p) = factors + base * exponents"""
+
+    def __init__(self, predictions, exponents, base):
+        self.df = pd.DataFrame(
+            {
+                "factors": predictions,
+                "prior_exponents": exponents,
+                "exponents": np.zeros_like(exponents, dtype=np.float64),
+                "base": base,
+            }
+        )
+
+    def predict_link(self):
+        return self.factors() + self.exponents() * self.base()
+
+    def factors(self):
+        return self.df["factors"].values
+
+    def exponents(self):
+        x = self.df["exponents"].values  # noqa
+        return self.df["prior_exponents"].values * evaluate("exp(x)")
+
+    def prior_exponents(self):
+        return self.df["prior_exponents"].values
+
+    def base(self):
+        return self.df["base"].values

--- a/skpro/libs/cyclic_boosting/price.py
+++ b/skpro/libs/cyclic_boosting/price.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Cyclic boosting exponential price model estimator
 """
@@ -9,10 +8,9 @@ import numpy as np
 import pandas as pd
 from numexpr import evaluate
 
-
 from skpro.libs.cyclic_boosting import CBNBinomRegressor
-from skpro.libs.cyclic_boosting.features import FeatureTypes, create_feature_id
 from skpro.libs.cyclic_boosting.base import UpdateMixin
+from skpro.libs.cyclic_boosting.features import FeatureTypes, create_feature_id
 from skpro.libs.cyclic_boosting.regression import _calc_factors_and_uncertainties
 from skpro.libs.cyclic_boosting.utils import get_X_column
 
@@ -28,7 +26,8 @@ def combine_lists_of_feature_groups(standard_feature_groups, external_feature_gr
     standard_feature_groups = [create_feature_id(fg) for fg in standard_feature_groups]
     if external_feature_groups is not None:
         external_feature_groups = [
-            create_feature_id(exfg, default_type=FeatureTypes.external) for exfg in external_feature_groups
+            create_feature_id(exfg, default_type=FeatureTypes.external)
+            for exfg in external_feature_groups
         ]
         _check_feature_groups(standard_feature_groups, external_feature_groups)
         return standard_feature_groups + external_feature_groups
@@ -141,7 +140,12 @@ def newton_bisect(
         l_new, jac, hess = newton_step(l, *args)
         finite = np.isfinite(jac) & np.isfinite(hess) & np.isfinite(l_new)
         valid = valid & finite
-        converged = (np.abs(jac) < epsilon) | (np.abs(l - x_l) < epsilon) | (np.abs(x_r - l) < epsilon) | (~valid)
+        converged = (
+            (np.abs(jac) < epsilon)
+            | (np.abs(l - x_l) < epsilon)
+            | (np.abs(x_r - l) < epsilon)
+            | (~valid)
+        )
         if np.all(converged):
             break
         x_l[valid & (jac < 0)] = l[valid & (jac < 0)]
@@ -188,23 +192,33 @@ def newton_step(
     mu = evaluate("p * exp((k * l1) * log_x)")  # noqa
     w = k * log_x  # noqa
 
-    bin_counts = np.bincount(lex_binnumbers, minlength=minlength)[lex_binnumbers]  # noqa
+    bin_counts = np.bincount(lex_binnumbers, minlength=minlength)[
+        lex_binnumbers
+    ]  # noqa
     # wolfram alpha: jacobian matrix ((y - p * x ** (l * k))^2 * s + ((l*k - c)^2 +
     # (l - 1)^2 + log(l)^2 + log(l*k / c)^2) / v) with respect to (l)
-    jac_prior = evaluate("2 * (k * (k * l1 - prior) + l1 - 1 + (log_k_prior + 2 * log_l1) / l1) / var_l / bin_counts")
+    jac_prior = evaluate(
+        "2 * (k * (k * l1 - prior) + l1 - 1 + (log_k_prior + 2 * log_l1) / l1) / var_l / bin_counts"
+    )
 
     jac_data = evaluate("- (2 * w * mu * (y - mu)) * s")
-    jacobian = np.bincount(lex_binnumbers, weights=jac_data + jac_prior, minlength=minlength)
+    jacobian = np.bincount(
+        lex_binnumbers, weights=jac_data + jac_prior, minlength=minlength
+    )
 
     if only_jac:
         return jacobian
 
     # wolfram alpha: hessian matrix ((y - p * x ** (l * k))^2 * s + ((l*k - c)^2 +
     # (l - 1)^2 + log(l)^2 + log(l*k / c)^2) / v) with respect to (l)
-    hess_prior = evaluate("2 * (k * k + 1 + (2 - (log_k_prior + 2 * log_l1) ) / l1 / l1) / var_l / bin_counts")
+    hess_prior = evaluate(
+        "2 * (k * k + 1 + (2 - (log_k_prior + 2 * log_l1) ) / l1 / l1) / var_l / bin_counts"
+    )
 
     hess_data = evaluate("(2 * w * w * mu * mu) * s + w * jac_data")
-    hessian = np.bincount(lex_binnumbers, weights=hess_data + hess_prior, minlength=minlength)
+    hessian = np.bincount(
+        lex_binnumbers, weights=hess_data + hess_prior, minlength=minlength
+    )
 
     lnew = np.full_like(l, np.nan)
     m_non_zero = hessian != 0
@@ -238,7 +252,9 @@ class CBExponential(CBNBinomRegressor):
         self.external_feature_groups = external_feature_groups
         self.prior_exponent_colname = prior_exponent_colname
 
-        feature_id_list = combine_lists_of_feature_groups(standard_feature_groups, external_feature_groups)
+        feature_id_list = combine_lists_of_feature_groups(
+            standard_feature_groups, external_feature_groups
+        )
 
         self.external_colname = external_colname
 
@@ -332,11 +348,11 @@ class CBExponential(CBNBinomRegressor):
             ``uncertainties`` in the **link space**.
         """
         if feature.feature_type == FeatureTypes.external:
-            _logger.debug("Price Feature {}".format(feature.feature_group))
+            _logger.debug(f"Price Feature {feature.feature_group}")
             expo, variance = self._calc_parameters_exponent(feature, y, pred)
             return expo, variance
         else:
-            _logger.debug("Demand Feature {}".format(feature.feature_group))
+            _logger.debug(f"Demand Feature {feature.feature_group}")
             return CBNBinomRegressor.calc_parameters(self, feature, y, pred, None)
 
     def _calc_parameters_exponent(self, feature, y, pred):
@@ -365,7 +381,9 @@ class CBExponential(CBNBinomRegressor):
         prior_exponents = pred.prior_exponents()
 
         bounds_l = np.zeros(feature.n_bins, dtype=np.float64)
-        feature.bounds_r = self.starting_bound_bisect * np.ones(feature.n_bins, dtype=np.float64)
+        feature.bounds_r = self.starting_bound_bisect * np.ones(
+            feature.n_bins, dtype=np.float64
+        )
         start_values = np.ones(feature.n_bins, dtype=np.float64)
 
         p = self.unlink_func(pred.predict_link())
@@ -406,7 +424,9 @@ class CBExponential(CBNBinomRegressor):
         self._init_external_column(X, False)
 
         prediction_link = self._get_prior_predictions(X)
-        pred = CBLinkPredictions(prediction_link, self._get_prior_exponent(X), self.external_col)
+        pred = CBLinkPredictions(
+            prediction_link, self._get_prior_exponent(X), self.external_col
+        )
 
         for feature in self.features:
             feature_predictions = self._pred_feature(X, feature, is_fit=False)

--- a/skpro/libs/cyclic_boosting/price.py
+++ b/skpro/libs/cyclic_boosting/price.py
@@ -8,10 +8,12 @@ import numpy as np
 import pandas as pd
 from numexpr import evaluate
 
-from skpro.libs.cyclic_boosting import CBNBinomRegressor
 from skpro.libs.cyclic_boosting.base import UpdateMixin
 from skpro.libs.cyclic_boosting.features import FeatureTypes, create_feature_id
-from skpro.libs.cyclic_boosting.regression import _calc_factors_and_uncertainties
+from skpro.libs.cyclic_boosting.regression import (
+    CBNBinomRegressor,
+    _calc_factors_and_uncertainties,
+)
 from skpro.libs.cyclic_boosting.utils import get_X_column
 
 _logger = logging.getLogger(__name__)

--- a/skpro/libs/cyclic_boosting/quantile_matching.py
+++ b/skpro/libs/cyclic_boosting/quantile_matching.py
@@ -1,0 +1,985 @@
+import numpy as np
+from numpy import exp, sinh, arcsinh, arccosh
+import pandas as pd
+from scipy.optimize import curve_fit, minimize_scalar
+from scipy.stats import norm, gamma, nbinom, logistic, mstats
+from scipy.interpolate import InterpolatedUnivariateSpline
+from sklearn.base import BaseEstimator
+
+from typing import Optional, Union, Tuple
+
+
+class J_QPD_S:
+    """
+    Implementation of the semi-bounded mode of Johnson Quantile-Parameterized
+    Distributions (J-QPD), see https://repositories.lib.utexas.edu/bitstream/handle/2152/63037/HADLOCK-DISSERTATION-2017.pdf
+    (Due to the Python keyword, the parameter lambda from this reference is named kappa below.).
+    A distribution is parameterized by a symmetric-percentile triplet (SPT).
+
+    Parameters
+    ----------
+    alpha : float
+        lower quantile of SPT (upper is ``1 - alpha``)
+    qv_low : np.ndarray
+        quantile function values of ``alpha``
+    qv_median : np.ndarray
+        quantile function values of quantile 0.5
+    qv_high : np.ndarray
+        quantile function values of quantile ``1 - alpha``
+    l : float
+        lower bound of semi-bounded range (default is 0)
+    version: str
+        options are ``normal`` (default) or ``logistic``
+    """
+
+    def __init__(
+        self,
+        alpha: float,
+        qv_low: Union[float, np.ndarray],
+        qv_median: Union[float, np.ndarray],
+        qv_high: Union[float, np.ndarray],
+        l: Optional[float] = 0,
+        version: Optional[str] = "normal",
+    ):
+        if version == "normal":
+            self.phi = norm()
+        elif version == "logistic":
+            self.phi = logistic()
+        else:
+            raise Exception("Invalid version.")
+
+        qv_low = np.asarray(qv_low)
+        qv_median = np.asarray(qv_median)
+        qv_high = np.asarray(qv_high)
+
+        if (qv_low > qv_median).any() or (qv_high < qv_median).any():
+            raise ValueError("The SPT values need to be monotonically increasing.")
+
+        self.l = l
+
+        self.c = self.phi.ppf(1 - alpha)
+
+        self.L = np.log(qv_low - l)
+        self.H = np.log(qv_high - l)
+        self.B = np.log(qv_median - l)
+
+        self.n = np.where(self.L + self.H - 2 * self.B > 0, 1, -1)
+        self.theta = np.where(self.L + self.H - 2 * self.B > 0, qv_low - l, qv_high - l)
+
+        self.n = np.where(self.L + self.H - 2 * self.B == 0, 0, self.n)
+        self.theta = np.where(self.L + self.H - 2 * self.B == 0, qv_median - l, self.theta)
+
+        self.delta = (
+            1.0
+            / self.c
+            * np.sinh(
+                np.arccosh(
+                    (self.H - self.L)
+                    / (2 * np.where((self.B - self.L) < (self.H - self.B), (self.B - self.L), (self.H - self.B)))
+                )
+            )
+        )
+
+        self.kappa = (
+            1.0
+            / (self.delta * self.c)
+            * np.where((self.H - self.B) < (self.B - self.L), (self.H - self.B), (self.B - self.L))
+        )
+
+    def ppf(self, x: Union[float, np.ndarray], inner=False) -> Union[float, np.ndarray]:
+        """
+        Percent point function (inverse of cdf).
+
+        Parameters
+        ----------
+        x : np.ndarray
+            quantiles to be calculated
+        inner : bool
+            flag to choose between inner (True) or outer (False) vector
+            multiplication of QPD distributions for a set of samples and
+            quantiles to be calculated, default (outer)
+
+        Returns
+        -------
+        np.ndarray
+            values according to the quantiles given
+        """
+        if inner:
+            ppf_value = self.l + self.theta * exp(
+                self.kappa
+                * np.sinh(np.arcsinh(self.phi.ppf(x) * self.delta) + np.arcsinh(self.n * self.c * self.delta))
+            )
+        else:
+            ppf_value = self.l + self.theta * exp(
+                self.kappa
+                * np.sinh(np.arcsinh(np.outer(self.phi.ppf(x), self.delta)) + np.arcsinh(self.n * self.c * self.delta))
+            )
+
+        if ppf_value.ndim == 0:
+            ppf_value = ppf_value.item()
+        ppf_value = np.squeeze(ppf_value)
+
+        return ppf_value
+
+    def cdf(self, x: Union[float, np.ndarray], inner=False) -> Union[float, np.ndarray]:
+        """
+        Cumulative distribution function.
+
+        Parameters
+        ----------
+        x : np.ndarray
+            values to be calculated
+        inner : bool
+            flag to choose between inner (True) or outer (False) vector
+            multiplication of QPD distributions for a set of samples and
+            values to be calculated, default (outer)
+
+        Returns
+        -------
+        np.ndarray
+            quantiles
+        """
+        if inner:
+            cdf_value = self.phi.cdf(
+                1.0
+                / self.delta
+                * np.sinh(
+                    np.arcsinh(1.0 / self.kappa * np.log((x - self.l) / self.theta))
+                    - np.arcsinh(self.n * self.c * self.delta)
+                )
+            )
+        else:
+            cdf_value = self.phi.cdf(
+                1.0
+                / self.delta
+                * np.sinh(
+                    np.arcsinh(1.0 / self.kappa * np.log(np.outer((x - self.l), 1.0 / self.theta)))
+                    - np.arcsinh(self.n * self.c * self.delta)
+                )
+            )
+
+        if cdf_value.ndim == 0:
+            cdf_value = cdf_value.item()
+        cdf_value = np.squeeze(cdf_value)
+
+        return cdf_value
+
+
+class J_QPD_B:
+    """
+    Implementation of the bounded mode of Johnson Quantile-Parameterized
+    Distributions (J-QPD), see https://repositories.lib.utexas.edu/bitstream/handle/2152/63037/HADLOCK-DISSERTATION-2017.pdf.
+    (Due to the Python keyword, the parameter lambda from this reference is named kappa below.)
+    A distribution is parameterized by a symmetric-percentile triplet (SPT).
+
+    Parameters
+    ----------
+    alpha : float
+        lower quantile of SPT (upper is ``1 - alpha``)
+    qv_low : np.ndarray
+        quantile function values of ``alpha``
+    qv_median : np.ndarray
+        quantile function values of quantile 0.5
+    qv_high : np.ndarray
+        quantile function values of quantile ``1 - alpha``
+    l : float
+        lower bound of supported range
+    u : float
+        upper bound of supported range
+    version: str
+        options are ``normal`` (default) or ``logistic``
+    """
+
+    def __init__(
+        self,
+        alpha: float,
+        qv_low: Union[float, np.ndarray],
+        qv_median: Union[float, np.ndarray],
+        qv_high: Union[float, np.ndarray],
+        l: float,
+        u: float,
+        version: Optional[str] = "normal",
+    ):
+        if version == "normal":
+            self.phi = norm()
+        elif version == "logistic":
+            self.phi = logistic()
+        else:
+            raise Exception("Invalid version.")
+
+        qv_low = np.asarray(qv_low)
+        qv_median = np.asarray(qv_median)
+        qv_high = np.asarray(qv_high)
+
+        if (qv_low > qv_median).any() or (qv_high < qv_median).any():
+            raise ValueError("The SPT values need to be monotonically increasing.")
+
+        self.l = l
+        self.u = u
+
+        self.c = self.phi.ppf(1 - alpha)
+
+        self.L = self.phi.ppf((qv_low - l) / (u - l))
+        self.H = self.phi.ppf((qv_high - l) / (u - l))
+        self.B = self.phi.ppf((qv_median - l) / (u - l))
+
+        self.n = np.where(self.L + self.H - 2 * self.B > 0, 1, -1)
+        self.xi = np.where(self.L + self.H - 2 * self.B > 0, self.L, self.H)
+
+        self.n = np.where(self.L + self.H - 2 * self.B == 0, 0, self.n)
+        self.xi = np.where(self.L + self.H - 2 * self.B == 0, self.B, self.xi)
+
+        self.delta = (
+            1.0
+            / self.c
+            * np.arccosh(
+                (self.H - self.L)
+                / (2 * np.where((self.B - self.L) < (self.H - self.B), self.B - self.L, self.H - self.B))
+            )
+        )
+
+        self.kappa = (self.H - self.L) / np.sinh(2 * self.delta * self.c)
+
+    def ppf(self, x: Union[float, np.ndarray], inner=False) -> Union[float, np.ndarray]:
+        if inner:
+            ppf_value = self.l + (self.u - self.l) * self.phi.cdf(
+                self.xi + self.kappa * np.sinh(self.delta * (self.phi.ppf(x) + self.n * self.c))
+            )
+        else:
+            if np.isscalar(x):
+                x = np.asarray([x])
+            ppf_value = self.l + (self.u - self.l) * self.phi.cdf(
+                self.xi + self.kappa * np.sinh(self.delta * (self.phi.ppf(x[:, np.newaxis]) + self.n * self.c))
+            )
+
+        if ppf_value.ndim == 0:
+            ppf_value = ppf_value.item()
+        ppf_value = np.squeeze(ppf_value)
+
+        return ppf_value
+
+    def cdf(self, x: Union[float, np.ndarray], inner=False) -> Union[float, np.ndarray]:
+        if inner:
+            cdf_value = self.phi.cdf(
+                1.0
+                / self.delta
+                * np.arcsinh(1.0 / self.kappa * (self.phi.ppf((x - self.l) / (self.u - self.l)) - self.xi))
+                - self.n * self.c
+            )
+        else:
+            if np.isscalar(x):
+                x = np.asarray([x])
+            cdf_value = self.phi.cdf(
+                1.0
+                / self.delta
+                * np.arcsinh(
+                    1.0 / self.kappa * (self.phi.ppf((x[:, np.newaxis] - self.l) / (self.u - self.l)) - self.xi)
+                )
+                - self.n * self.c
+            )
+
+        if cdf_value.ndim == 0:
+            cdf_value = cdf_value.item()
+        cdf_value = np.squeeze(cdf_value)
+
+        return cdf_value
+
+
+class SinhLogistic:
+    """
+    sinh/arcsinh-modified logistic distribution for smooth interpolation
+    between logistic and t2 distribution.
+
+    Parameters
+    ----------
+    shape: float
+        parameter modifying the logistic base distribution via
+        sinh/arcsinh-scaling
+    """
+
+    def __init__(self, shape: float):
+        self.shape = shape
+
+    def ppf(self, x: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
+        # ppf of natural logistic distribution
+        xlog = 0.25 * np.log(x / (1.0 - x))
+
+        # sinh or arcsinh scaling
+        if self.shape > 0:
+            x = np.arcsinh(self.shape * xlog) / self.shape
+        elif self.shape < 0:
+            x = np.sinh(self.shape * xlog) / self.shape
+        else:
+            x = xlog
+        return x
+
+    def cdf(self, x: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
+        # sinh or arcsinh scaling
+        if self.shape > 0:
+            xlog = np.sinh(self.shape * x) / self.shape
+        elif self.shape < 0:
+            xlog = np.arcsinh(self.shape * x) / self.shape
+        else:
+            xlog = x
+
+        # natural logistic cdf
+        return 1.0 / (1 + np.exp(-4 * xlog))
+
+    def pdf(self, x: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
+        if self.shape > 0:
+            return np.cosh(self.shape * x) / (np.cosh(2.0 / self.shape * np.sinh(self.shape * x))) ** 2
+        elif self.shape < 0:
+            return (
+                1.0 / np.sqrt((self.shape * x) ** 2 + 1) / (np.cosh(2.0 / self.shape * np.arcsinh(self.shape * x))) ** 2
+            )
+        else:
+            return 1.0 / (np.cosh(2 * x)) ** 2
+
+
+class BaseDist:
+    """
+    Scaling of base ppfs such that ppf(1 - alpha) = 1. A detailed description
+    can be found in the presentation JQPDregression.pdf in the docs folder of
+    this repository.
+    """
+
+    def __init__(self, dist, alpha: float):
+        self.dist = dist
+        self.alpha = alpha
+        self.width = self.dist.ppf(1 - self.alpha)
+
+    def ppf(self, x: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
+        return self.dist.ppf(x) / self.width
+
+    def cdf(self, x: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
+        return self.dist.cdf(x * self.width)
+
+    def pdf(self, x: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
+        return self.dist.pdf(x * self.width) * self.width
+
+
+def unconstrained_calc(L: float, B: float, H: float) -> Tuple[float, float, float, float]:
+    gamma = -np.sign(L + H - 2 * B)
+
+    if gamma == 0:
+        xi = B
+        kappa = H - B
+        delta = 1
+    else:
+        if gamma < 0:
+            xi = L
+            theta = (B - L) / (H - L)
+        else:
+            xi = H
+            theta = (H - B) / (H - L)
+        delta = 1.0 / arccosh(1 / (2.0 * theta))
+        kappa = (H - L) / sinh(2.0 / delta)
+
+    return gamma, xi, kappa, delta
+
+
+class J_QPD_extended_U:
+    """
+    Unbounded version of J-QPDs (see bounded and semi-bounded versions above),
+    including an additional shape parameter to enable flexible tail behavior.
+    Again, a distribution is parameterized by a symmetric-percentile triplet
+    (SPT).
+
+    Parameters
+    ----------
+    alpha : float
+        lower quantile of SPT (upper is ``1 - alpha``)
+    qv_low : float
+        quantile function value of ``alpha``
+    qv_median : float
+        quantile function value of quantile 0.5
+    qv_high : float
+        quantile function value of quantile ``1 - alpha``
+    version: str
+        options are ``normal`` (sinhlogistic), ``normal`, or ``logistic``
+    shape: float
+        parameter modifying the logistic base distribution via
+        sinh/arcsinh-scaling (only active in sinhlogistic version)
+    """
+
+    def __init__(
+        self,
+        alpha: float,
+        qv_low: float,
+        qv_median: float,
+        qv_high: float,
+        version: Optional[str] = "sinhlogistic",
+        shape: Optional[float] = 0,
+    ):
+        self.shape = shape
+        self.alpha = alpha
+
+        if version == "normal":
+            self.phi = norm()
+        elif version == "logistic":
+            self.phi = logistic()
+        elif version == "sinhlogistic":
+            self.phi = SinhLogistic(shape=self.shape)
+        else:
+            raise Exception("Invalid version.")
+
+        if (qv_low > qv_median) or (qv_high < qv_median):
+            raise ValueError("The SPT values need to be monotonically increasing.")
+
+        # identity transformation
+        self.gamma, self.xi, self.kappa, self.delta = unconstrained_calc(qv_low, qv_median, qv_high)
+
+    def ppf(self, x: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
+        basequantiles = BaseDist(self.phi, self.alpha).ppf(x)
+
+        # internal unconstrained quantiles from Johnson transform
+        # back transformatiaon into physical space (identity here)
+        return self.xi + self.kappa * sinh((basequantiles - self.gamma) / self.delta)
+
+    def cdf(self, x: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
+        # transform from physical to internal space (identity here)
+        # internal unconstrained quantiles from Johnson transform
+        basequantiles = self.gamma + self.delta * arcsinh((x - self.xi) / self.kappa)
+
+        # cdf of base distribution
+        return BaseDist(self.phi, self.alpha).cdf(basequantiles)
+
+
+class J_QPD_extended_S:
+    """
+    Semi-bounded version of J-QPDs, extended by a shape parameter to enable
+    flexible tail behavior. A distribution is parameterized by a
+    symmetric-percentile triplet (SPT).
+
+    Parameters
+    ----------
+    alpha : float
+        lower quantile of SPT (upper is ``1 - alpha``)
+    qv_low : float
+        quantile function value of ``alpha``
+    qv_median : float
+        quantile function value of quantile 0.5
+    qv_high : float
+        quantile function value of quantile ``1 - alpha``
+    l : float
+        lower bound of semi-bounded range (default is 0)
+    version: str
+        options are ``normal`` (sinhlogistic), ``normal`, or ``logistic``
+    shape: float
+        parameter modifying the logistic base distribution via
+        sinh/arcsinh-scaling (only active in sinhlogistic version)
+    """
+
+    def __init__(
+        self,
+        alpha: float,
+        qv_low: float,
+        qv_median: float,
+        qv_high: float,
+        l: Optional[float] = 0,
+        version: Optional[str] = "sinhlogistic",
+        shape: Optional[float] = 0,
+    ):
+        self.shape = shape
+        self.alpha = alpha
+
+        if version == "normal":
+            self.phi = norm()
+        elif version == "logistic":
+            self.phi = logistic()
+        elif version == "sinhlogistic":
+            self.phi = SinhLogistic(shape=self.shape)
+        else:
+            raise Exception("Invalid version.")
+
+        if (qv_low > qv_median) or (qv_high < qv_median):
+            raise ValueError("The SPT values need to be monotonically increasing.")
+
+        self.l = l
+
+        # transform input quantiles from semi-(lower-)bounded physical space to unconstrained internal space
+        self.L = transform_from_semibound_lower(qv_low, self.l)
+        self.H = transform_from_semibound_lower(qv_high, self.l)
+        self.B = transform_from_semibound_lower(qv_median, self.l)
+
+        # now handle like unconstrained
+        self.gamma, self.xi, self.kappa, self.delta = unconstrained_calc(self.L, self.B, self.H)
+
+    def ppf(self, x: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
+        basequantiles = BaseDist(self.phi, self.alpha).ppf(x)
+
+        # internal unconstrained quantiles from Johnson transform
+        z = self.xi + self.kappa * sinh((basequantiles - self.gamma) / self.delta)
+
+        # back transformation into physical space
+        return back_transform_in_semibound_lower(z, self.l)
+
+    def cdf(self, x: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
+        # transform from physical to internal space
+        z = transform_from_semibound_lower(x, self.l)
+
+        # internal unconstrained quantiles from Johnson transform
+        basequantiles = self.gamma + self.delta * arcsinh((z - self.xi) / self.kappa)
+
+        return BaseDist(self.phi, self.alpha).cdf(basequantiles)
+
+
+class J_QPD_extended_B:
+    """
+    Bounded version of J-QPDs, extended by a shape parameter to enable flexible
+    tail behavior. A distribution is parameterized by a symmetric-percentile
+    triplet (SPT).
+
+    Parameters
+    ----------
+    alpha : float
+        lower quantile of SPT (upper is ``1 - alpha``)
+    qv_low : float
+        quantile function value of ``alpha``
+    qv_median : float
+        quantile function value of quantile 0.5
+    qv_high : float
+        quantile function value of quantile ``1 - alpha``
+    l : float
+        lower bound of supported range
+    u : float
+        upper bound of supported range
+    version: str
+        options are ``normal`` (sinhlogistic), ``normal`, or ``logistic``
+    shape: float
+        parameter modifying the logistic base distribution via
+        sinh/arcsinh-scaling (only active in sinhlogistic version)
+    """
+
+    def __init__(
+        self,
+        alpha: float,
+        qv_low: float,
+        qv_median: float,
+        qv_high: float,
+        l: Optional[float] = 0,
+        u: Optional[float] = 1,
+        version: Optional[str] = "sinhlogistic",
+        shape: Optional[float] = 0,
+    ):
+        self.shape = shape
+        self.alpha = alpha
+
+        if version == "normal":
+            self.phi = norm()
+        elif version == "logistic":
+            self.phi = logistic()
+        elif version == "sinhlogistic":
+            self.phi = SinhLogistic(shape=self.shape)
+        else:
+            raise Exception("Invalid version.")
+
+        if (qv_low > qv_median) or (qv_high < qv_median):
+            raise ValueError("The SPT values need to be monotonically increasing.")
+
+        self.l = l
+        self.u = u
+
+        # transform input quantiles from bounded physical space to unconstrained internal space
+        self.L = transform_from_bounds(qv_low, self.l, self.u)
+        self.H = transform_from_bounds(qv_high, self.l, self.u)
+        self.B = transform_from_bounds(qv_median, self.l, self.u)
+
+        # now handle like unconstrained
+        self.gamma, self.xi, self.kappa, self.delta = unconstrained_calc(self.L, self.B, self.H)
+
+    def ppf(self, x: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
+        basequantiles = BaseDist(self.phi, self.alpha).ppf(x)
+
+        # internal unconstrained quantiles from Johnson transform
+        z = self.xi + self.kappa * sinh((basequantiles - self.gamma) / self.delta)
+
+        # back transformation into [l, u]
+        return back_transform_in_bounds(z, self.l, self.u)
+
+    def cdf(self, x: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
+        # transform from bounded physical space to unconstrained internal space
+        z = transform_from_bounds(x, self.l, self.u)
+
+        # internal unconstrained quantiles from Johnson transform
+        basequantiles = self.gamma + self.delta * arcsinh((z - self.xi) / self.kappa)
+
+        # cdf of base distribution
+        p = BaseDist(self.phi, self.alpha).cdf(basequantiles)
+
+        return p
+
+
+def transform_from_bounds(x: np.ndarray, l: float, u: float) -> np.ndarray:
+    # transform from bounded physical space to [0, 1]
+    z = (x - l) / (u - l)
+
+    # transfer to unconstrained internal space by logit
+    z = z / (1 - z)
+    z = np.where(z == 0, 1e-12, z)
+    return np.log(z)
+
+
+def back_transform_in_bounds(z: np.ndarray, l: float, u: float) -> np.ndarray:
+    # back transformation into [0, 1]
+    x = 1.0 / (1.0 + np.exp(-z))
+
+    # back transformation into [l, u]
+    return l + (u - l) * x
+
+
+def transform_from_semibound_lower(x: np.ndarray, l: float) -> np.ndarray:
+    z = x - l
+    z = np.where(z == 0, 1e-12, z)
+
+    # transfer to unconstrained internal space
+    return np.log(z)
+
+
+def back_transform_in_semibound_lower(z: np.ndarray, l: float) -> np.ndarray:
+    return l + np.exp(z)
+
+
+def transform_from_semibound_upper(x: np.ndarray, u: float) -> np.ndarray:
+    z = u - x
+    z = np.where(z == 0, 1e-12, z)
+
+    # transfer to unconstrained internal space
+    return np.log(z)
+
+
+def back_transform_in_semibound_upper(z: np.ndarray, u: float) -> np.ndarray:
+    return u - np.exp(z)
+
+
+def fit_sinhlogistic_shape(alpha: float, l: float, u: float, bound: str, y: np.ndarray) -> float:
+    """
+    Fit of the shape parameter of our extended versions of the J-QPD mechanism,
+    which modifies the logistic base distribution by sinh/arcsinh-scaling, on
+    the empirical quantile function of the observations.
+    """
+
+    if bound not in ["S", "B", "U"]:
+        raise Exception("Invalid version.")
+
+    qlowincl = np.quantile(y, alpha)
+    qmedincl = np.quantile(y, 0.5)
+    qhighincl = np.quantile(y, 1 - alpha)
+
+    if bound == "S":
+        jqpd_inclusive = J_QPD_extended_S(alpha, qlowincl, qmedincl, qhighincl, l)
+    elif bound == "B":
+        jqpd_inclusive = J_QPD_extended_B(alpha, qlowincl, qmedincl, qhighincl, l, u)
+    else:
+        jqpd_inclusive = J_QPD_extended_U(alpha, qlowincl, qmedincl, qhighincl)
+
+    def fit_shape(shape, p, q):
+        jqpd_inclusive.shape = shape
+        jqpd_inclusive.phi = SinhLogistic(shape=jqpd_inclusive.shape)
+
+        q_fit = jqpd_inclusive.ppf(p)
+
+        emd = (np.abs(q - q_fit)).mean()
+        return emd
+
+    stepsize = 0.001
+    p = np.arange(stepsize / 2.0, 1 - stepsize / 2.0, stepsize)
+    q = mstats.mquantiles(y, p)
+    param = minimize_scalar(fit_shape, args=(p, q))
+    return param.x
+
+
+class QPD_RegressorChain(BaseEstimator):
+    """
+    Constrained conditional density estimation by means of quantile regression
+    and quantile-parameterized distributions (QPD).
+
+    The training chain consists of several steps:
+
+    First, the median is trained and predicted in-sample by means of an
+    arbitrary method (e.g., an ML regressor using a pinball loss, like Cyclic
+    Boosting). External (and also internal ones, see below) constraints on the
+    target range can be taken into account by non-linear transformations,
+    exploiting the bijectivity of quantile transformations (Quantile of
+    transformed variable equals transformation of quantile of original
+    variable.).
+
+    Next, the lower quantile of the QPD symmetric-percentile triplet (SPT) is
+    trained and predicted in-sample by means of an arbitrary method (again
+    taking into account external constraints on the target range), which is
+    independent, and therefore can be completely different, to the median model
+    above. Due to the internal constraint to train only on samples with target
+    value lower than the in-sample-predicted median, the quantile that must
+    actually be used in the quantile regression method is ``2 * alpha``.
+
+    Next, the upper quantile of the QPD SPT triplet is trained by means of an
+    arbitrary method (again taking into account external constraints on the
+    target range), which is independent, and therefore can be completely
+    different, to the median and lower quantile models above. Due to the
+    internal constraint to train only on samples with target value higher than
+    the in-sample-predicted median, the quantile that must actually be used in
+    the quantile regression method is ``2 * (1 - alpha) - 1``.
+
+    The prediction chain is then executed accordingly, and finally, a QPD is
+    calculated for each sample by means of the predicted SPT. For this,
+    extended versions of the J-QPD mechanism are used, which include a shape
+    parameter modifying the logistic base distribution by sinh/arcsinh-scaling.
+    This shape parameter is independently fitted on the empirical quantile
+    function of the training targets.
+
+    Parameters
+    ----------
+    est_median : BaseEstimator
+        estimator to be used predict the median
+    est_lowq : BaseEstimator
+        estimator to be used predict the lower quantile ``alpha`` (must be
+        trained with quantile ``2 * alpha``, e.g., median for ``alpha = 0.25``)
+    est_highq : BaseEstimator
+        estimator to be used predict the upper quantile ``1 - alpha`` (must be
+        trained with quantile ``2 * (1 - alpha) - 1``, e.g., median for
+        ``alpha = 0.25``)
+    bound: str
+        Different modes defined by supported target range, options are ``S``
+        (semi-bound) and ``B`` (bound).
+    alpha : float
+        lower quantile of SPT (upper is ``1 - alpha``)
+    l : float
+        lower bound of supported range
+    u : float
+        upper bound of supported range (only active for bound mode)
+    """
+
+    def __init__(
+        self,
+        est_median: BaseEstimator,
+        est_lowq: BaseEstimator,
+        est_highq: BaseEstimator,
+        bound: str,
+        alpha: Optional[float] = 0.25,
+        l: Optional[float] = 0,
+        u: Optional[float] = 1,
+    ):
+        self.est_median = est_median
+        self.est_lowq = est_lowq
+        self.est_highq = est_highq  # trained with quantile 2 * (1 - alpha) - 1 (e.g., median for 0.75)
+
+        self.alpha = alpha
+
+        self.l = l
+        self.u = u
+
+        self.bound = bound
+        if self.bound not in ["S", "B"]:
+            raise Exception("Invalid version.")
+
+    def fit(self, X: Union[pd.DataFrame, np.ndarray], y: np.ndarray) -> BaseEstimator:
+        # median model
+        if self.bound == "S":
+            y_trans = transform_from_semibound_lower(y, self.l)
+        elif self.bound == "B":
+            y_trans = transform_from_bounds(y, self.l, self.u)
+        self.est_median.fit(X, y_trans)
+        z = self.est_median.predict(X)
+        if self.bound == "S":
+            pred_median = back_transform_in_semibound_lower(z, self.l)
+        elif self.bound == "B":
+            pred_median = back_transform_in_bounds(z, self.l, self.u)
+
+        # lower quantile model
+        y_trans = y / pred_median
+        mask = y_trans < 1
+        y_trans = y_trans[mask]
+        y_trans = transform_from_bounds(y_trans, self.l / pred_median[mask], 1)
+        self.est_lowq.fit(X[mask], y_trans)
+        z = self.est_lowq.predict(X)
+        pred_lowq = back_transform_in_bounds(z, self.l, pred_median)
+
+        # upper quantile model
+        y_trans = (y - pred_median) / (pred_median - pred_lowq)
+        mask = y_trans > 0
+        y_trans = y_trans[mask]
+        if self.bound == "S":
+            y_trans = transform_from_semibound_lower(y_trans, 0)
+        elif self.bound == "B":
+            y_trans = transform_from_bounds(y_trans, 0, (self.u - pred_median) / (pred_median - pred_lowq))
+        self.est_highq.fit(X[mask], y_trans)
+
+        return self
+
+    def predict(self, X: Union[pd.DataFrame, np.ndarray]) -> tuple:
+        if self.bound == "S":
+            pred_median = back_transform_in_semibound_lower(self.est_median.predict(X), self.l)
+            pred_lowq = back_transform_in_bounds(self.est_lowq.predict(X), self.l, pred_median)
+            pred_highq = back_transform_in_semibound_lower(self.est_highq.predict(X), pred_median)
+        elif self.bound == "B":
+            pred_median = back_transform_in_bounds(self.est_median.predict(X), self.l, self.u)
+            pred_lowq = back_transform_in_bounds(self.est_lowq.predict(X), self.l, pred_median)
+            pred_highq = back_transform_in_bounds(self.est_highq.predict(X), pred_median, self.u)
+
+        if self.bound == "S":
+            qpd = J_QPD_S(self.alpha, pred_lowq, pred_median, pred_highq, self.l)
+        elif self.bound == "B":
+            qpd = J_QPD_B(self.alpha, pred_lowq, pred_median, pred_highq, self.l, self.u)
+
+        return pred_lowq, pred_median, pred_highq, qpd
+
+
+def quantile_fit_gaussian(quantiles: np.ndarray, quantile_values: np.ndarray, mode: Optional[str] = "ppf") -> callable:
+    """
+    Interpolation of a quantile function (with quantiles estimated, e.g., by
+    means of quantile regression) according to a Gaussian distribution as
+    assumed PDF.
+
+    Parameters
+    ----------
+    quantiles : np.ndarray
+        quantiles (x values of quantile function)
+    quantile_values : np.ndarray
+        quantile values (y values of quantile function)
+    mode : str
+        decides about kind of returned callable, possible values are:
+
+            - ``ppf``: quantile function (default)
+            - ``dist``: fitted Gaussian function (scipy function)
+            - ``cdf``: CDF function
+
+    Returns
+    -------
+    callable
+        fitted Gaussian function (see mode)
+    """
+
+    def f(x, mu, sigma):
+        return norm(loc=mu, scale=sigma).ppf(x)
+
+    mu, sigma = curve_fit(f, quantiles, quantile_values)[0]
+    if mode == "ppf":
+        return norm(mu, sigma).ppf
+    elif mode == "dist":
+        return norm(mu, sigma)
+    elif mode == "cdf":
+        return norm(mu, sigma).cdf
+    else:
+        raise Exception("Invalid mode.")
+
+
+def quantile_fit_gamma(quantiles: np.ndarray, quantile_values: np.ndarray, mode: Optional[str] = "ppf") -> callable:
+    """
+    Interpolation of a quantile function (with quantiles estimated, e.g., by
+    means of quantile regression) according to a Gamma distribution as assumed
+    PDF (i.e., continuous, non-negative target values).
+
+    Parameters
+    ----------
+    quantiles : np.ndarray
+        quantiles (x values of quantile function)
+    quantile_values : np.ndarray
+        quantile values (y values of quantile function)
+    mode : str
+        decides about kind of returned callable, possible values are:
+
+            - ``ppf``: quantile function (default)
+            - ``dist``: fitted Gamma function (scipy function)
+            - ``cdf``: CDF function
+
+    Returns
+    -------
+    callable
+        fitted Gamma function (see mode)
+    """
+
+    def f(x, alpha, beta):
+        return gamma(alpha, scale=1 / beta).ppf(x)
+
+    alpha, beta = curve_fit(f, quantiles, quantile_values, p0=[2.0, 0.9])[0]
+    if mode == "ppf":
+        return gamma(alpha, scale=1 / beta).ppf
+    elif mode == "dist":
+        return gamma(alpha, scale=1 / beta)
+    elif mode == "cdf":
+        return gamma(alpha, scale=1 / beta).cdf
+    else:
+        raise Exception("Invalid mode.")
+
+
+def _nbinom_cdf_mu_var(x: float, mu: float, var: float) -> callable:
+    """
+    Calculation of negative binomial parameters n and p from given mean and
+    variance, and subsequent call of its cumulative distribution function.
+
+    Parameters
+    ----------
+    x : float
+        value of random variable following negative binomial distribution
+    mu : float
+        mean of negative binomial distribution
+    var : float
+        variance of negative binomial distribution
+
+    Returns
+    -------
+    callable
+        negative binomial cumulative distribution function
+    """
+    n = mu * mu / (var - mu)
+    p = mu / var
+    return nbinom(n, p).cdf(x)
+
+
+def quantile_fit_nbinom(quantiles: np.ndarray, quantile_values: np.ndarray, mode: Optional[str] = "ppf") -> callable:
+    """
+    Interpolation of a quantile function (with quantiles estimated, e.g., by
+    means of quantile regression) according to a negative binomial distribution
+    as assumed PDF (i.e., discrete, non-negative target values).
+
+    Parameters
+    ----------
+    quantiles : np.ndarray
+        quantiles (x values of quantile function)
+    quantile_values : np.ndarray
+        quantile values (y values of quantile function)
+    mode : str
+        decides about kind of returned callable, possible values are:
+
+            - ``ppf``: quantile function (default)
+            - ``dist``: fitted negative binomial function (scipy function)
+            - ``cdf``: CDF function
+
+    Returns
+    -------
+    callable
+        fitted negative binomial function (see mode)
+    """
+    mu, var = curve_fit(_nbinom_cdf_mu_var, quantile_values, quantiles, p0=[2.2, 2.4])[0]
+    n = mu * mu / (var - mu)
+    p = mu / var
+    if mode == "ppf":
+        return nbinom(n, p).ppf
+    elif mode == "dist":
+        return nbinom(n, p)
+    elif mode == "cdf":
+        return nbinom(n, p).cdf
+    else:
+        raise Exception("Invalid mode.")
+
+
+def quantile_fit_spline(quantiles: np.ndarray, quantile_values: np.ndarray) -> callable:
+    """
+    Interpolation of a quantile function (with quantiles estimated, e.g., by
+    means of quantile regression) according to a smoothing spline (i.e.,
+    arbitrary target distribution).
+
+    Parameters
+    ----------
+    quantiles : np.ndarray
+        quantiles (x values of quantile function)
+    quantile_values : np.ndarray
+        quantile values (y values of quantile function)
+
+    Returns
+    -------
+    callable
+        spline fitted to quantile function
+    """
+    spl = InterpolatedUnivariateSpline(quantiles, quantile_values, k=3, bbox=[0, 1], ext=3)
+    return spl

--- a/skpro/libs/cyclic_boosting/quantile_matching.py
+++ b/skpro/libs/cyclic_boosting/quantile_matching.py
@@ -1,12 +1,12 @@
-import numpy as np
-from numpy import exp, sinh, arcsinh, arccosh
-import pandas as pd
-from scipy.optimize import curve_fit, minimize_scalar
-from scipy.stats import norm, gamma, nbinom, logistic, mstats
-from scipy.interpolate import InterpolatedUnivariateSpline
-from sklearn.base import BaseEstimator
+from typing import Optional, Tuple, Union
 
-from typing import Optional, Union, Tuple
+import numpy as np
+import pandas as pd
+from numpy import arccosh, arcsinh, exp, sinh
+from scipy.interpolate import InterpolatedUnivariateSpline
+from scipy.optimize import curve_fit, minimize_scalar
+from scipy.stats import gamma, logistic, mstats, nbinom, norm
+from sklearn.base import BaseEstimator
 
 
 class J_QPD_S:
@@ -67,7 +67,9 @@ class J_QPD_S:
         self.theta = np.where(self.L + self.H - 2 * self.B > 0, qv_low - l, qv_high - l)
 
         self.n = np.where(self.L + self.H - 2 * self.B == 0, 0, self.n)
-        self.theta = np.where(self.L + self.H - 2 * self.B == 0, qv_median - l, self.theta)
+        self.theta = np.where(
+            self.L + self.H - 2 * self.B == 0, qv_median - l, self.theta
+        )
 
         self.delta = (
             1.0
@@ -75,7 +77,14 @@ class J_QPD_S:
             * np.sinh(
                 np.arccosh(
                     (self.H - self.L)
-                    / (2 * np.where((self.B - self.L) < (self.H - self.B), (self.B - self.L), (self.H - self.B)))
+                    / (
+                        2
+                        * np.where(
+                            (self.B - self.L) < (self.H - self.B),
+                            (self.B - self.L),
+                            (self.H - self.B),
+                        )
+                    )
                 )
             )
         )
@@ -83,7 +92,11 @@ class J_QPD_S:
         self.kappa = (
             1.0
             / (self.delta * self.c)
-            * np.where((self.H - self.B) < (self.B - self.L), (self.H - self.B), (self.B - self.L))
+            * np.where(
+                (self.H - self.B) < (self.B - self.L),
+                (self.H - self.B),
+                (self.B - self.L),
+            )
         )
 
     def ppf(self, x: Union[float, np.ndarray], inner=False) -> Union[float, np.ndarray]:
@@ -107,12 +120,18 @@ class J_QPD_S:
         if inner:
             ppf_value = self.l + self.theta * exp(
                 self.kappa
-                * np.sinh(np.arcsinh(self.phi.ppf(x) * self.delta) + np.arcsinh(self.n * self.c * self.delta))
+                * np.sinh(
+                    np.arcsinh(self.phi.ppf(x) * self.delta)
+                    + np.arcsinh(self.n * self.c * self.delta)
+                )
             )
         else:
             ppf_value = self.l + self.theta * exp(
                 self.kappa
-                * np.sinh(np.arcsinh(np.outer(self.phi.ppf(x), self.delta)) + np.arcsinh(self.n * self.c * self.delta))
+                * np.sinh(
+                    np.arcsinh(np.outer(self.phi.ppf(x), self.delta))
+                    + np.arcsinh(self.n * self.c * self.delta)
+                )
             )
 
         if ppf_value.ndim == 0:
@@ -153,7 +172,11 @@ class J_QPD_S:
                 1.0
                 / self.delta
                 * np.sinh(
-                    np.arcsinh(1.0 / self.kappa * np.log(np.outer((x - self.l), 1.0 / self.theta)))
+                    np.arcsinh(
+                        1.0
+                        / self.kappa
+                        * np.log(np.outer((x - self.l), 1.0 / self.theta))
+                    )
                     - np.arcsinh(self.n * self.c * self.delta)
                 )
             )
@@ -234,7 +257,14 @@ class J_QPD_B:
             / self.c
             * np.arccosh(
                 (self.H - self.L)
-                / (2 * np.where((self.B - self.L) < (self.H - self.B), self.B - self.L, self.H - self.B))
+                / (
+                    2
+                    * np.where(
+                        (self.B - self.L) < (self.H - self.B),
+                        self.B - self.L,
+                        self.H - self.B,
+                    )
+                )
             )
         )
 
@@ -243,13 +273,18 @@ class J_QPD_B:
     def ppf(self, x: Union[float, np.ndarray], inner=False) -> Union[float, np.ndarray]:
         if inner:
             ppf_value = self.l + (self.u - self.l) * self.phi.cdf(
-                self.xi + self.kappa * np.sinh(self.delta * (self.phi.ppf(x) + self.n * self.c))
+                self.xi
+                + self.kappa * np.sinh(self.delta * (self.phi.ppf(x) + self.n * self.c))
             )
         else:
             if np.isscalar(x):
                 x = np.asarray([x])
             ppf_value = self.l + (self.u - self.l) * self.phi.cdf(
-                self.xi + self.kappa * np.sinh(self.delta * (self.phi.ppf(x[:, np.newaxis]) + self.n * self.c))
+                self.xi
+                + self.kappa
+                * np.sinh(
+                    self.delta * (self.phi.ppf(x[:, np.newaxis]) + self.n * self.c)
+                )
             )
 
         if ppf_value.ndim == 0:
@@ -263,7 +298,11 @@ class J_QPD_B:
             cdf_value = self.phi.cdf(
                 1.0
                 / self.delta
-                * np.arcsinh(1.0 / self.kappa * (self.phi.ppf((x - self.l) / (self.u - self.l)) - self.xi))
+                * np.arcsinh(
+                    1.0
+                    / self.kappa
+                    * (self.phi.ppf((x - self.l) / (self.u - self.l)) - self.xi)
+                )
                 - self.n * self.c
             )
         else:
@@ -273,7 +312,12 @@ class J_QPD_B:
                 1.0
                 / self.delta
                 * np.arcsinh(
-                    1.0 / self.kappa * (self.phi.ppf((x[:, np.newaxis] - self.l) / (self.u - self.l)) - self.xi)
+                    1.0
+                    / self.kappa
+                    * (
+                        self.phi.ppf((x[:, np.newaxis] - self.l) / (self.u - self.l))
+                        - self.xi
+                    )
                 )
                 - self.n * self.c
             )
@@ -327,10 +371,15 @@ class SinhLogistic:
 
     def pdf(self, x: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
         if self.shape > 0:
-            return np.cosh(self.shape * x) / (np.cosh(2.0 / self.shape * np.sinh(self.shape * x))) ** 2
+            return (
+                np.cosh(self.shape * x)
+                / (np.cosh(2.0 / self.shape * np.sinh(self.shape * x))) ** 2
+            )
         elif self.shape < 0:
             return (
-                1.0 / np.sqrt((self.shape * x) ** 2 + 1) / (np.cosh(2.0 / self.shape * np.arcsinh(self.shape * x))) ** 2
+                1.0
+                / np.sqrt((self.shape * x) ** 2 + 1)
+                / (np.cosh(2.0 / self.shape * np.arcsinh(self.shape * x))) ** 2
             )
         else:
             return 1.0 / (np.cosh(2 * x)) ** 2
@@ -358,7 +407,9 @@ class BaseDist:
         return self.dist.pdf(x * self.width) * self.width
 
 
-def unconstrained_calc(L: float, B: float, H: float) -> Tuple[float, float, float, float]:
+def unconstrained_calc(
+    L: float, B: float, H: float
+) -> Tuple[float, float, float, float]:
     gamma = -np.sign(L + H - 2 * B)
 
     if gamma == 0:
@@ -427,7 +478,9 @@ class J_QPD_extended_U:
             raise ValueError("The SPT values need to be monotonically increasing.")
 
         # identity transformation
-        self.gamma, self.xi, self.kappa, self.delta = unconstrained_calc(qv_low, qv_median, qv_high)
+        self.gamma, self.xi, self.kappa, self.delta = unconstrained_calc(
+            qv_low, qv_median, qv_high
+        )
 
     def ppf(self, x: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
         basequantiles = BaseDist(self.phi, self.alpha).ppf(x)
@@ -503,7 +556,9 @@ class J_QPD_extended_S:
         self.B = transform_from_semibound_lower(qv_median, self.l)
 
         # now handle like unconstrained
-        self.gamma, self.xi, self.kappa, self.delta = unconstrained_calc(self.L, self.B, self.H)
+        self.gamma, self.xi, self.kappa, self.delta = unconstrained_calc(
+            self.L, self.B, self.H
+        )
 
     def ppf(self, x: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
         basequantiles = BaseDist(self.phi, self.alpha).ppf(x)
@@ -586,7 +641,9 @@ class J_QPD_extended_B:
         self.B = transform_from_bounds(qv_median, self.l, self.u)
 
         # now handle like unconstrained
-        self.gamma, self.xi, self.kappa, self.delta = unconstrained_calc(self.L, self.B, self.H)
+        self.gamma, self.xi, self.kappa, self.delta = unconstrained_calc(
+            self.L, self.B, self.H
+        )
 
     def ppf(self, x: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
         basequantiles = BaseDist(self.phi, self.alpha).ppf(x)
@@ -652,7 +709,9 @@ def back_transform_in_semibound_upper(z: np.ndarray, u: float) -> np.ndarray:
     return u - np.exp(z)
 
 
-def fit_sinhlogistic_shape(alpha: float, l: float, u: float, bound: str, y: np.ndarray) -> float:
+def fit_sinhlogistic_shape(
+    alpha: float, l: float, u: float, bound: str, y: np.ndarray
+) -> float:
     """
     Fit of the shape parameter of our extended versions of the J-QPD mechanism,
     which modifies the logistic base distribution by sinh/arcsinh-scaling, on
@@ -801,30 +860,48 @@ class QPD_RegressorChain(BaseEstimator):
         if self.bound == "S":
             y_trans = transform_from_semibound_lower(y_trans, 0)
         elif self.bound == "B":
-            y_trans = transform_from_bounds(y_trans, 0, (self.u - pred_median) / (pred_median - pred_lowq))
+            y_trans = transform_from_bounds(
+                y_trans, 0, (self.u - pred_median) / (pred_median - pred_lowq)
+            )
         self.est_highq.fit(X[mask], y_trans)
 
         return self
 
     def predict(self, X: Union[pd.DataFrame, np.ndarray]) -> tuple:
         if self.bound == "S":
-            pred_median = back_transform_in_semibound_lower(self.est_median.predict(X), self.l)
-            pred_lowq = back_transform_in_bounds(self.est_lowq.predict(X), self.l, pred_median)
-            pred_highq = back_transform_in_semibound_lower(self.est_highq.predict(X), pred_median)
+            pred_median = back_transform_in_semibound_lower(
+                self.est_median.predict(X), self.l
+            )
+            pred_lowq = back_transform_in_bounds(
+                self.est_lowq.predict(X), self.l, pred_median
+            )
+            pred_highq = back_transform_in_semibound_lower(
+                self.est_highq.predict(X), pred_median
+            )
         elif self.bound == "B":
-            pred_median = back_transform_in_bounds(self.est_median.predict(X), self.l, self.u)
-            pred_lowq = back_transform_in_bounds(self.est_lowq.predict(X), self.l, pred_median)
-            pred_highq = back_transform_in_bounds(self.est_highq.predict(X), pred_median, self.u)
+            pred_median = back_transform_in_bounds(
+                self.est_median.predict(X), self.l, self.u
+            )
+            pred_lowq = back_transform_in_bounds(
+                self.est_lowq.predict(X), self.l, pred_median
+            )
+            pred_highq = back_transform_in_bounds(
+                self.est_highq.predict(X), pred_median, self.u
+            )
 
         if self.bound == "S":
             qpd = J_QPD_S(self.alpha, pred_lowq, pred_median, pred_highq, self.l)
         elif self.bound == "B":
-            qpd = J_QPD_B(self.alpha, pred_lowq, pred_median, pred_highq, self.l, self.u)
+            qpd = J_QPD_B(
+                self.alpha, pred_lowq, pred_median, pred_highq, self.l, self.u
+            )
 
         return pred_lowq, pred_median, pred_highq, qpd
 
 
-def quantile_fit_gaussian(quantiles: np.ndarray, quantile_values: np.ndarray, mode: Optional[str] = "ppf") -> callable:
+def quantile_fit_gaussian(
+    quantiles: np.ndarray, quantile_values: np.ndarray, mode: Optional[str] = "ppf"
+) -> callable:
     """
     Interpolation of a quantile function (with quantiles estimated, e.g., by
     means of quantile regression) according to a Gaussian distribution as
@@ -863,7 +940,9 @@ def quantile_fit_gaussian(quantiles: np.ndarray, quantile_values: np.ndarray, mo
         raise Exception("Invalid mode.")
 
 
-def quantile_fit_gamma(quantiles: np.ndarray, quantile_values: np.ndarray, mode: Optional[str] = "ppf") -> callable:
+def quantile_fit_gamma(
+    quantiles: np.ndarray, quantile_values: np.ndarray, mode: Optional[str] = "ppf"
+) -> callable:
     """
     Interpolation of a quantile function (with quantiles estimated, e.g., by
     means of quantile regression) according to a Gamma distribution as assumed
@@ -926,7 +1005,9 @@ def _nbinom_cdf_mu_var(x: float, mu: float, var: float) -> callable:
     return nbinom(n, p).cdf(x)
 
 
-def quantile_fit_nbinom(quantiles: np.ndarray, quantile_values: np.ndarray, mode: Optional[str] = "ppf") -> callable:
+def quantile_fit_nbinom(
+    quantiles: np.ndarray, quantile_values: np.ndarray, mode: Optional[str] = "ppf"
+) -> callable:
     """
     Interpolation of a quantile function (with quantiles estimated, e.g., by
     means of quantile regression) according to a negative binomial distribution
@@ -950,7 +1031,9 @@ def quantile_fit_nbinom(quantiles: np.ndarray, quantile_values: np.ndarray, mode
     callable
         fitted negative binomial function (see mode)
     """
-    mu, var = curve_fit(_nbinom_cdf_mu_var, quantile_values, quantiles, p0=[2.2, 2.4])[0]
+    mu, var = curve_fit(_nbinom_cdf_mu_var, quantile_values, quantiles, p0=[2.2, 2.4])[
+        0
+    ]
     n = mu * mu / (var - mu)
     p = mu / var
     if mode == "ppf":
@@ -981,5 +1064,7 @@ def quantile_fit_spline(quantiles: np.ndarray, quantile_values: np.ndarray) -> c
     callable
         spline fitted to quantile function
     """
-    spl = InterpolatedUnivariateSpline(quantiles, quantile_values, k=3, bbox=[0, 1], ext=3)
+    spl = InterpolatedUnivariateSpline(
+        quantiles, quantile_values, k=3, bbox=[0, 1], ext=3
+    )
     return spl

--- a/skpro/libs/cyclic_boosting/regression.py
+++ b/skpro/libs/cyclic_boosting/regression.py
@@ -1,0 +1,189 @@
+
+import abc
+import logging
+
+import numexpr
+import numpy as np
+
+import sklearn.base
+import scipy.special
+
+from skpro.libs.cyclic_boosting.base import CyclicBoostingBase, CBLinkPredictionsFactors
+from skpro.libs.cyclic_boosting.features import Feature
+from skpro.libs.cyclic_boosting.link import LogLinkMixin
+
+from typing import Tuple
+
+_logger = logging.getLogger(__name__)
+
+
+def _calc_factors_from_posterior(alpha_posterior: np.ndarray, beta_posterior: np.ndarray) -> np.ndarray:
+    # The posterior distribution of f_j (factor in bin j)
+    # follows a Gamma distribution. We want to use the median as estimate
+    # because it is more stable against the log transformation. But calculating
+    # the median is much more expensive for large values of alpha_posterior and
+    # beta_posterior. Therefore we omit calculating the median and take the
+    # mean instead (since mean -> median for large values of alpha_posterior
+    # and beta_posterior).
+
+    noncritical_posterior = (alpha_posterior <= 1e12) & (beta_posterior <= 1e12)
+    # Median of the gamma distribution
+    posterior_gamma = (
+        scipy.special.gammaincinv(alpha_posterior[noncritical_posterior], 0.5) / beta_posterior[noncritical_posterior]
+    )
+
+    factors = alpha_posterior / beta_posterior
+    factors[noncritical_posterior] = posterior_gamma
+    return np.log(factors)
+
+
+def _calc_factors_and_uncertainties(alpha: np.ndarray, beta: np.ndarray, link_func: np.ndarray) -> Tuple[np.ndarray]:
+    alpha_prior, beta_prior = get_gamma_priors()
+    alpha_posterior = alpha + alpha_prior
+    beta_posterior = beta + beta_prior
+
+    factors = _calc_factors_from_posterior(alpha_posterior, beta_posterior)
+    # factor_uncertainties:
+    # The variance used here was calculated by matching the first two moments
+    # of the Gamma posterior with a log-normal distribution.
+    uncertainties = np.sqrt(link_func(1 + alpha_posterior) - link_func(alpha_posterior))
+
+    return factors, uncertainties
+
+
+def get_gamma_priors() -> Tuple[int, float]:
+    """prior values for Gamma distribution with median 1"""
+    alpha_prior = 2
+    beta_prior = 1.67834
+    return alpha_prior, beta_prior
+
+
+
+class CBBaseRegressor(CyclicBoostingBase, sklearn.base.RegressorMixin, LogLinkMixin, metaclass=abc.ABCMeta):
+    r"""This is the base regressor for all Cyclic Boosting regression problems.
+    It implements :class:`cyclic_boosting.link.LogLinkMixin` and is usable
+    for regression problems with a target range of: :math:`0 \leq y < \infty`.
+    """
+
+    def _check_y(self, y: np.ndarray) -> None:
+        """Check that y has no negative values."""
+        if not (y >= 0.0).all():
+            raise ValueError(
+                "The target y must be positive semi-definite " "and not NAN. y[~(y>=0)] = {0}".format(y[~(y >= 0)])
+            )
+
+    @abc.abstractmethod
+    def calc_parameters(self, feature: Feature, y: np.ndarray, pred: CBLinkPredictionsFactors, prefit_data):
+        raise NotImplementedError("implement in subclass")
+
+    @abc.abstractmethod
+    def precalc_parameters(self, feature: Feature, y: np.ndarray, pred: CBLinkPredictionsFactors) -> None:
+        return None
+
+
+class CBNBinomRegressor(CBBaseRegressor):
+    r"""This regressor minimizes the mean squared error. It is usable for
+    regressions of target-values :math:`0 \leq y < \infty`.
+
+    This Cyclic Boosting mode assumes an underlying negative binomial (or
+    Gamma-Poisson) distribution as conditional distribution of the target. The
+    prior values for the Gamma distribution :math:`\alpha = 2.0` and
+    :math:`\beta = 1.67834` are chosen such that its median is
+    :math:`\Gamma_{\text{median}}(\alpha, \beta) =1`, which is the neutral
+    element of multiplication (Cyclic Boosting in this mode is a multiplicative
+    model). The estimate for each factor is the median of the Gamma
+    distribution with the measured values of :math:`\alpha` and :math:`\beta`.
+    To determine the uncertainties of the factors, the variance is estimated
+    from a log-normal distribution that is approximated using the first two
+    moments of the Gamma distribution.
+
+    In the default case of parameter settings :math:`a = 1.0` and
+    :math:`c = 0.0`, this regressor corresponds to the special case of a
+    Poisson regressor, as implemented in :class:`~.CBPoissonRegressor`.
+    """
+
+    def __init__(
+        self,
+        feature_groups=None,
+        hierarchical_feature_groups=None,
+        feature_properties=None,
+        weight_column=None,
+        prior_prediction_column=None,
+        minimal_loss_change=1e-3,
+        minimal_factor_change=1e-3,
+        maximal_iterations=10,
+        observers=None,
+        smoother_choice=None,
+        output_column=None,
+        learn_rate=None,
+        a=1.0,
+        c=0.0,
+        aggregate=True,
+    ):
+        CyclicBoostingBase.__init__(
+            self,
+            feature_groups=feature_groups,
+            hierarchical_feature_groups=hierarchical_feature_groups,
+            feature_properties=feature_properties,
+            weight_column=weight_column,
+            prior_prediction_column=prior_prediction_column,
+            minimal_loss_change=minimal_loss_change,
+            minimal_factor_change=minimal_factor_change,
+            maximal_iterations=maximal_iterations,
+            observers=observers,
+            smoother_choice=smoother_choice,
+            output_column=output_column,
+            learn_rate=learn_rate,
+            aggregate=aggregate,
+        )
+        self.a = a  # TODO: a and c as variable names are too vague
+        self.c = c
+
+    def precalc_parameters(self, feature: Feature, y: np.ndarray, pred: CBLinkPredictionsFactors):
+        pass
+
+    def calc_parameters(
+        self, feature: Feature, y: np.ndarray, pred: CBLinkPredictionsFactors, prefit_data
+    ) -> Tuple[np.ndarray]:
+        a = self.a  # noqa: F841
+        c = self.c  # noqa: F841
+        weights = self.weights  # noqa: F841
+        prediction_link = pred.predict_link()
+        prediction = self.unlink_func(prediction_link)  # noqa: F841
+
+        alpha_w = numexpr.evaluate("weights * y / (a + c * prediction)")
+        beta_w = numexpr.evaluate("weights * prediction / (a + c * prediction)")
+
+        lex_binnumbers = feature.lex_binned_data
+        minlength = feature.n_bins
+        alpha, beta = (np.bincount(lex_binnumbers, weights=w, minlength=minlength) for w in [alpha_w, beta_w])
+        link_func = self.link_func
+
+        return _calc_factors_and_uncertainties(alpha, beta, link_func)
+
+
+class CBPoissonRegressor(CBBaseRegressor):
+    r"""This regressor minimizes the mean squared error. It is usable for
+    regressions of target-values :math:`0 \leq y < \infty`.
+
+    As Poisson regressor, it is a special case of the more general negative
+    binomial regressor :class:`~.CBNBinomRegressor`, assuming *purely*
+    Poisson-distributed target values.
+    """
+
+    def precalc_parameters(self, feature: Feature, y: np.ndarray, pred: CBLinkPredictionsFactors):
+        return np.bincount(feature.lex_binned_data, weights=y * self.weights, minlength=feature.n_bins)
+
+    def calc_parameters(self, feature: Feature, y: np.ndarray, pred: CBLinkPredictionsFactors, prefit_data):
+        prediction = self.unlink_func(pred.predict_link())
+
+        prediction_sum_of_bins = np.bincount(
+            feature.lex_binned_data,
+            weights=self.weights * prediction,
+            minlength=feature.n_bins,
+        )
+
+        return _calc_factors_and_uncertainties(alpha=prefit_data, beta=prediction_sum_of_bins, link_func=self.link_func)
+
+
+__all__ = ["get_gamma_priors", "CBPoissonRegressor", "CBNBinomRegressor"]

--- a/skpro/libs/cyclic_boosting/regression.py
+++ b/skpro/libs/cyclic_boosting/regression.py
@@ -1,23 +1,22 @@
-
 import abc
 import logging
+from typing import Tuple
 
 import numexpr
 import numpy as np
-
-import sklearn.base
 import scipy.special
+import sklearn.base
 
-from skpro.libs.cyclic_boosting.base import CyclicBoostingBase, CBLinkPredictionsFactors
+from skpro.libs.cyclic_boosting.base import CBLinkPredictionsFactors, CyclicBoostingBase
 from skpro.libs.cyclic_boosting.features import Feature
 from skpro.libs.cyclic_boosting.link import LogLinkMixin
-
-from typing import Tuple
 
 _logger = logging.getLogger(__name__)
 
 
-def _calc_factors_from_posterior(alpha_posterior: np.ndarray, beta_posterior: np.ndarray) -> np.ndarray:
+def _calc_factors_from_posterior(
+    alpha_posterior: np.ndarray, beta_posterior: np.ndarray
+) -> np.ndarray:
     # The posterior distribution of f_j (factor in bin j)
     # follows a Gamma distribution. We want to use the median as estimate
     # because it is more stable against the log transformation. But calculating
@@ -29,7 +28,8 @@ def _calc_factors_from_posterior(alpha_posterior: np.ndarray, beta_posterior: np
     noncritical_posterior = (alpha_posterior <= 1e12) & (beta_posterior <= 1e12)
     # Median of the gamma distribution
     posterior_gamma = (
-        scipy.special.gammaincinv(alpha_posterior[noncritical_posterior], 0.5) / beta_posterior[noncritical_posterior]
+        scipy.special.gammaincinv(alpha_posterior[noncritical_posterior], 0.5)
+        / beta_posterior[noncritical_posterior]
     )
 
     factors = alpha_posterior / beta_posterior
@@ -37,7 +37,9 @@ def _calc_factors_from_posterior(alpha_posterior: np.ndarray, beta_posterior: np
     return np.log(factors)
 
 
-def _calc_factors_and_uncertainties(alpha: np.ndarray, beta: np.ndarray, link_func: np.ndarray) -> Tuple[np.ndarray]:
+def _calc_factors_and_uncertainties(
+    alpha: np.ndarray, beta: np.ndarray, link_func: np.ndarray
+) -> Tuple[np.ndarray]:
     alpha_prior, beta_prior = get_gamma_priors()
     alpha_posterior = alpha + alpha_prior
     beta_posterior = beta + beta_prior
@@ -58,8 +60,9 @@ def get_gamma_priors() -> Tuple[int, float]:
     return alpha_prior, beta_prior
 
 
-
-class CBBaseRegressor(CyclicBoostingBase, sklearn.base.RegressorMixin, LogLinkMixin, metaclass=abc.ABCMeta):
+class CBBaseRegressor(
+    CyclicBoostingBase, sklearn.base.RegressorMixin, LogLinkMixin, metaclass=abc.ABCMeta
+):
     r"""This is the base regressor for all Cyclic Boosting regression problems.
     It implements :class:`cyclic_boosting.link.LogLinkMixin` and is usable
     for regression problems with a target range of: :math:`0 \leq y < \infty`.
@@ -69,15 +72,24 @@ class CBBaseRegressor(CyclicBoostingBase, sklearn.base.RegressorMixin, LogLinkMi
         """Check that y has no negative values."""
         if not (y >= 0.0).all():
             raise ValueError(
-                "The target y must be positive semi-definite " "and not NAN. y[~(y>=0)] = {0}".format(y[~(y >= 0)])
+                "The target y must be positive semi-definite "
+                "and not NAN. y[~(y>=0)] = {}".format(y[~(y >= 0)])
             )
 
     @abc.abstractmethod
-    def calc_parameters(self, feature: Feature, y: np.ndarray, pred: CBLinkPredictionsFactors, prefit_data):
+    def calc_parameters(
+        self,
+        feature: Feature,
+        y: np.ndarray,
+        pred: CBLinkPredictionsFactors,
+        prefit_data,
+    ):
         raise NotImplementedError("implement in subclass")
 
     @abc.abstractmethod
-    def precalc_parameters(self, feature: Feature, y: np.ndarray, pred: CBLinkPredictionsFactors) -> None:
+    def precalc_parameters(
+        self, feature: Feature, y: np.ndarray, pred: CBLinkPredictionsFactors
+    ) -> None:
         return None
 
 
@@ -139,11 +151,17 @@ class CBNBinomRegressor(CBBaseRegressor):
         self.a = a  # TODO: a and c as variable names are too vague
         self.c = c
 
-    def precalc_parameters(self, feature: Feature, y: np.ndarray, pred: CBLinkPredictionsFactors):
+    def precalc_parameters(
+        self, feature: Feature, y: np.ndarray, pred: CBLinkPredictionsFactors
+    ):
         pass
 
     def calc_parameters(
-        self, feature: Feature, y: np.ndarray, pred: CBLinkPredictionsFactors, prefit_data
+        self,
+        feature: Feature,
+        y: np.ndarray,
+        pred: CBLinkPredictionsFactors,
+        prefit_data,
     ) -> Tuple[np.ndarray]:
         a = self.a  # noqa: F841
         c = self.c  # noqa: F841
@@ -156,7 +174,10 @@ class CBNBinomRegressor(CBBaseRegressor):
 
         lex_binnumbers = feature.lex_binned_data
         minlength = feature.n_bins
-        alpha, beta = (np.bincount(lex_binnumbers, weights=w, minlength=minlength) for w in [alpha_w, beta_w])
+        alpha, beta = (
+            np.bincount(lex_binnumbers, weights=w, minlength=minlength)
+            for w in [alpha_w, beta_w]
+        )
         link_func = self.link_func
 
         return _calc_factors_and_uncertainties(alpha, beta, link_func)
@@ -171,10 +192,20 @@ class CBPoissonRegressor(CBBaseRegressor):
     Poisson-distributed target values.
     """
 
-    def precalc_parameters(self, feature: Feature, y: np.ndarray, pred: CBLinkPredictionsFactors):
-        return np.bincount(feature.lex_binned_data, weights=y * self.weights, minlength=feature.n_bins)
+    def precalc_parameters(
+        self, feature: Feature, y: np.ndarray, pred: CBLinkPredictionsFactors
+    ):
+        return np.bincount(
+            feature.lex_binned_data, weights=y * self.weights, minlength=feature.n_bins
+        )
 
-    def calc_parameters(self, feature: Feature, y: np.ndarray, pred: CBLinkPredictionsFactors, prefit_data):
+    def calc_parameters(
+        self,
+        feature: Feature,
+        y: np.ndarray,
+        pred: CBLinkPredictionsFactors,
+        prefit_data,
+    ):
         prediction = self.unlink_func(pred.predict_link())
 
         prediction_sum_of_bins = np.bincount(
@@ -183,7 +214,9 @@ class CBPoissonRegressor(CBBaseRegressor):
             minlength=feature.n_bins,
         )
 
-        return _calc_factors_and_uncertainties(alpha=prefit_data, beta=prediction_sum_of_bins, link_func=self.link_func)
+        return _calc_factors_and_uncertainties(
+            alpha=prefit_data, beta=prediction_sum_of_bins, link_func=self.link_func
+        )
 
 
 __all__ = ["get_gamma_priors", "CBPoissonRegressor", "CBNBinomRegressor"]

--- a/skpro/libs/cyclic_boosting/smoothing/__init__.py
+++ b/skpro/libs/cyclic_boosting/smoothing/__init__.py
@@ -1,0 +1,20 @@
+"""
+Smoothers of target profiles and factor profiles or for the regularization of
+plots.
+"""
+
+from skpro.libs.cyclic_boosting.smoothing.meta_smoother import RegressionType
+
+
+from skpro.libs.cyclic_boosting.smoothing import extrapolate
+from skpro.libs.cyclic_boosting.smoothing import meta_smoother
+from skpro.libs.cyclic_boosting.smoothing import multidim
+from skpro.libs.cyclic_boosting.smoothing import onedim
+
+__all__ = [
+    "RegressionType",
+    "extrapolate",
+    "meta_smoother",
+    "multidim",
+    "onedim",
+]

--- a/skpro/libs/cyclic_boosting/smoothing/__init__.py
+++ b/skpro/libs/cyclic_boosting/smoothing/__init__.py
@@ -3,13 +3,13 @@ Smoothers of target profiles and factor profiles or for the regularization of
 plots.
 """
 
+from skpro.libs.cyclic_boosting.smoothing import (
+    extrapolate,
+    meta_smoother,
+    multidim,
+    onedim,
+)
 from skpro.libs.cyclic_boosting.smoothing.meta_smoother import RegressionType
-
-
-from skpro.libs.cyclic_boosting.smoothing import extrapolate
-from skpro.libs.cyclic_boosting.smoothing import meta_smoother
-from skpro.libs.cyclic_boosting.smoothing import multidim
-from skpro.libs.cyclic_boosting.smoothing import onedim
 
 __all__ = [
     "RegressionType",

--- a/skpro/libs/cyclic_boosting/smoothing/base.py
+++ b/skpro/libs/cyclic_boosting/smoothing/base.py
@@ -1,0 +1,40 @@
+"""
+Base classes for smoothers
+"""
+
+import numpy as np
+import sklearn.base as sklearnb
+
+from skpro.libs.cyclic_boosting.utils import bin_steps
+
+
+class AbstractBinSmoother(sklearnb.BaseEstimator, sklearnb.RegressorMixin):
+    """**Abstract base class** for smoothers acting on bins.
+
+    Please implement the methods ``fit`` and ``predict``.
+    """
+
+    inc_fitting = False
+    supports_pandas = False
+
+
+class SetNBinsMixin(object):
+    """Mixin class for smoothers working on bins that saves binning
+    information in ``fit`` to be available in ``predict``.
+    """
+
+    def set_n_bins(self, X_for_smoother):
+        ndim = X_for_smoother.shape[1] - 2
+        if ndim < 1:
+            raise ValueError("Smoothers need at least three columns!")
+
+        self.ndim_ = ndim
+        self.bin_weights_ = X_for_smoother[:, -2]
+        self.n_bins_ = np.max(X_for_smoother[:, : self.ndim_], axis=0)
+        self.n_bins_ = np.round(self.n_bins_)
+        self.n_bins_ = np.asarray(self.n_bins_, dtype=int) + 1
+        if ndim > 1:
+            self._bin_steps = bin_steps(self.n_bins_)
+
+
+__all__ = ["AbstractBinSmoother", "SetNBinsMixin"]

--- a/skpro/libs/cyclic_boosting/smoothing/base.py
+++ b/skpro/libs/cyclic_boosting/smoothing/base.py
@@ -18,7 +18,7 @@ class AbstractBinSmoother(sklearnb.BaseEstimator, sklearnb.RegressorMixin):
     supports_pandas = False
 
 
-class SetNBinsMixin(object):
+class SetNBinsMixin:
     """Mixin class for smoothers working on bins that saves binning
     information in ``fit`` to be available in ``predict``.
     """

--- a/skpro/libs/cyclic_boosting/smoothing/extrapolate.py
+++ b/skpro/libs/cyclic_boosting/smoothing/extrapolate.py
@@ -1,0 +1,139 @@
+"""
+Smoothers capable of extrapolating beyond the range seen in the training
+
+The most common example is extrapolating a target profile or factor profile
+into the future, i.e. the smoother can be used to extend the profile beyond the
+time range seen in the training. In this case, the smoother operates on the
+feature `time`.
+
+.. note::
+    Using these components requires **regular retraining**, because the
+    extrapolation originates at the end of the training interval and will
+    become more and more uncertain over time.
+
+    don't use
+
+    * :class:`cyclic_boosting.binning.ECdfTransformer`
+    * :class:`cyclic_boosting.binning.BinNumberTransformer`
+    * :class:`cyclic_boosting.binning.FractionalBinNumberTransformer`
+
+    on features these smoothers operate on, because they just assign the
+    largest bin number to feature values beyond the upper bound seen in the
+    training which prevents any extrapolation.
+
+    For the `time` feature, :class:`LinearBinner` is usually sufficient,
+    because the amount of samples per time interval usually doesn't vary that
+    much over time.
+
+    Extrapolation is **not** needed for times within some period, e.g. for
+    the weekday, the month day or the day number in the year. Please use normal
+    smoothers for that.
+"""
+
+import numpy as np
+
+from skpro.libs.cyclic_boosting.smoothing import onedim
+from skpro.libs.cyclic_boosting.utils import linear_regression
+
+
+class LinearExtrapolator(onedim.AbstractBinSmoother):
+    r"""Smoother of one-dimensional bins that applies a linear regression
+    to fit the bin values of y (as received from the profile function in
+    the fit) and applies a linear interpolation in predict.
+
+    The :func:`math_utils.linear_regression` is used for the regression.
+    The uncertainties :math:`\sigma_i` of `y` are transformed to the
+    weights :math:`w_i = \frac{1}{(\sigma_i)^2 + \epsilon}` needed by
+    :func:`~math_utils.linear_regression` in the fit method. An epsilon
+    value is added to avoid zero division.
+
+    :param epsilon: Epsilon value to avoid zero division when transforming
+        the uncertainties to the weights.
+    :type epsilon: float
+
+    **Required columns** in the ``X_for_smoother`` passed to :meth:`fit`:
+
+    * column 0: ...
+    * column 1: ignored
+    * column 2: uncertainty of the average ``y`` in each bin
+
+    These are provided by the following **profile functions**:
+
+    * :class:`BetaMeanSigmaProfile`
+
+    **Used column** in the :meth:`predict`:
+
+    * column 0: ...
+
+    **Estimated parameters**
+
+    :param `alpha_`: axis interception
+    :type `alpha_`: :obj:`float`
+
+    :param `beta_`: slope
+    :type `beta_`: :obj:`float`
+
+    **Small data example**
+
+    >>> np.random.seed(4)
+    >>> n = 5
+    >>> x = np.arange(n)
+    >>> alpha = 3.0
+    >>> beta = 0.5
+    >>> y = alpha + beta * x
+    >>> y
+    array([ 3. ,  3.5,  4. ,  4.5,  5. ])
+    >>> y_err = np.array([np.mean(np.random.randn(n)) for i in range(n)])
+    >>> y_smeared = y + y_err
+    >>> y_smeared
+    array([ 2.96598022,  3.01021291,  4.02623841,  4.91211327,  5.04914922])
+
+    >>> X = np.c_[x, np.ones(n), y_err]
+
+    >>> from skpro.libs.cyclic_boosting.smoothing.extrapolate import LinearExtrapolator
+    >>> est = LinearExtrapolator()
+    >>> est = est.fit(X, y_smeared)
+
+    >>> from decimal import Decimal
+    >>> Decimal(est.alpha_).quantize(Decimal("1.000"))
+    Decimal('2.971')
+    >>> Decimal(est.beta_).quantize(Decimal("1.000"))
+    Decimal('0.523')
+
+    >>> x1 = np.array([-7, -5, -3, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9., 20.])
+    >>> X1 = np.c_[x1]
+    >>> est.predict(X1)
+    array([ -0.69276543,   0.354095  ,   1.40095542,   2.44781584,
+             2.97124605,   3.49467626,   4.01810647,   4.54153668,
+             5.06496689,   5.5883971 ,   6.11182731,   6.63525752,
+             7.15868773,   7.68211794,  13.43985026])
+    """
+
+    def __init__(self, epsilon=1e-4):
+        self.epsilon = epsilon
+        self.alpha_ = None
+        self.beta_ = None
+
+    def _check_fitted(self):
+        """Check if a fit was performed."""
+        if self.alpha_ is None or self.beta_ is None:
+            raise ValueError("You have to call fit before predict.")
+
+    def fit(self, X_for_smoother, y):
+        weights = 1.0 / (np.square(np.asarray(X_for_smoother[:, 2])) + self.epsilon)
+        self.alpha_, self.beta_ = linear_regression(
+            np.asarray(X_for_smoother[:, 0], dtype=np.float64),
+            np.asarray(y, dtype=np.float64),
+            weights,
+        )
+        return self
+
+    def predict(self, X):
+        self._check_fitted()
+        y = self.alpha_ + np.asarray(X[:, 0], dtype=np.float64) * self.beta_
+        return y
+
+
+__all__ = [
+    "LinearExtrapolator",
+]

--- a/skpro/libs/cyclic_boosting/smoothing/meta_smoother.py
+++ b/skpro/libs/cyclic_boosting/smoothing/meta_smoother.py
@@ -1,0 +1,305 @@
+"""
+base module for abstract smoothers
+"""
+
+import logging
+from enum import Enum
+
+import numpy as np
+
+
+from skpro.libs.cyclic_boosting import utils
+from skpro.libs.cyclic_boosting.smoothing.base import AbstractBinSmoother, SetNBinsMixin
+
+_logger = logging.getLogger(__name__)
+
+
+class RegressionType(Enum):
+    """Type of regression that is supported by the smoother.
+
+    Three variants are supported:
+
+    * discontinuous: It cannot be interpolated between the values seen
+       by the smoother (e.g. the values are unordered labels).
+       Therefore all values in predict are set to nan that are out of the
+       bin boundries in the fit or where no fit events have been seen.
+    * interpolating: Interpolation is possible between the values seen by
+       the smoother. So only values above or below the bin boundries are
+       critical. Therefore all values in predict are set to nan that
+       are out of the bin boundries in the fit.
+    * extrapolating: Extrapolation allows arbitrary values independent of
+       the values seen in the fit. Therefore no restrictions apply.
+    """
+
+    discontinuous = "discontinuous"
+    interpolating = "interpolating"
+    extrapolating = "extrapolating"
+
+
+def check_reg_type(reg_type):
+    if (
+        (reg_type == RegressionType.discontinuous)
+        or (reg_type == RegressionType.interpolating)
+        or (reg_type == RegressionType.extrapolating)
+    ):
+        return reg_type
+    else:
+        raise KeyError(
+            "Only the following regression types are allowed:"
+            "{}, {}, {}".format(
+                RegressionType.discontinuous,
+                RegressionType.interpolating,
+                RegressionType.extrapolating,
+            )
+        )
+
+
+def not_interpolating(reg_type):
+    return check_reg_type(reg_type) == RegressionType.discontinuous
+
+
+def not_extrapolating(reg_type):
+    return check_reg_type(reg_type) != RegressionType.extrapolating
+
+
+class NormalizationSmoother(AbstractBinSmoother):
+    """Meta-smoother that normalizes the values for its subestimator.
+
+    Parameters
+    ----------
+
+    smoother: :class:`AbstractBinSmoother`
+        smoother used to fit and predict on the `normalized` data points.
+    """
+
+    def __init__(self, smoother):
+        self.smoother = smoother
+
+    def calc_norm(self, X_for_smoother, y):
+        """Calculate the weighted mean of the target y that can
+        then be used to give the subestimator a normalized
+        distribution.
+
+        Parameters
+        ----------
+
+        X_for_smoother: :class:`numpy.ndarray`
+            Multidimensional array with at least three columns.
+            For a k-dimensional feature the first k columns contain
+            the x-values for the smoothing.
+            The ``k + 1`` column are the weights of these x-values, while
+            the ``k + 2`` column contains the uncertainties.
+
+        smoothed_y: :class:`numpy.ndarray`
+             Array that contains the original target values.
+        """
+        w = X_for_smoother[:, -2]
+        weightsum = np.sum(w)
+        if weightsum > 0:
+            self.norm_ = np.sum(y * w) / weightsum
+        else:
+            self.norm_ = 0
+
+        if not np.isfinite(self.norm_):
+            _logger.info(
+                "The norm in smoother {0} is not finite: "
+                "norm= {1}; weights= {2}; target= {3}".format(self.__class__.__name__, self.norm_, X_for_smoother, y)
+            )
+            self.norm_ = 0.0
+
+    def fit(self, X_for_smoother, y):
+        self.calc_norm(X_for_smoother, y)
+        self.smoother.fit(X_for_smoother, y - self.norm_)
+
+    def predict(self, X_for_smoother):
+        smoothed_y = self.smoother.predict(X_for_smoother)
+        return smoothed_y + self.norm_
+
+
+def _selected_events_interpolating(X_for_smoother, ndim, nbins):
+    selected_events = np.min(X_for_smoother[:, :ndim], axis=1) < 0.0
+    for dim in range(ndim):
+        selected_events |= X_for_smoother[:, dim] > (nbins[dim] - 0.5)
+    return selected_events
+
+
+class RegressionTypeSmoother(AbstractBinSmoother, SetNBinsMixin):
+    """Meta-smoother to constrain all values according to their
+    :class:`~cyclic_boosting.smoothing.RegressionType` from the ``predict`` method
+    of the subsmoother.
+
+    Parameters
+    ----------
+
+    smoother: :class:`AbstractBinSmoother`
+        smoother used to fit and predict on the `normalized` data points.
+
+    reg_type: :class:`RegressionType`
+        defines the regression type that is used to constrain the values.
+
+    Regression Types
+    ----------------
+
+    * discontinuous: Set all values in predict to nan that are out of the bin
+           boundries in the fit or where no fit events have been seen.
+    * interpolating: Set all values in predict to nan that are out of the bin
+           boundries in the fit.
+    * extrapolating: No restrictions for values in predict.
+    """
+
+    def __init__(self, smoother, reg_type):
+        self.smoother = smoother
+        self.reg_type = check_reg_type(reg_type)
+
+    def apply_cut(self, X_for_smoother, smoothed_y):
+        """Constrain all values in smoothed_y according to their
+        :class:`RegressionType`.
+
+        Parameters
+        ----------
+
+        X_for_smoother: :class:`numpy.ndarray`
+            Multidimensional array with at least three columns.
+            For a k-dimensional feature the first k columns contain
+            the x-values for the smoothing.
+            The ``k + 1`` column are the weights of these x-values, while
+            the ``k + 2`` column contains the uncertainties.
+
+        smoothed_y: :class:`numpy.ndarray`
+             Array that contains the result of the subsmoother.
+        """
+        if not_interpolating(self.reg_type):
+            selected_events = utils.not_seen_events(X_for_smoother[:, : self.ndim_], self.bin_weights_, self.n_bins_)
+        elif not_extrapolating(self.reg_type):
+            selected_events = _selected_events_interpolating(X_for_smoother, self.ndim_, self.n_bins_)
+        else:
+            return smoothed_y
+
+        smoothed_y = np.asarray(smoothed_y, dtype=np.float64)
+        smoothed_y[selected_events] = np.nan
+        return smoothed_y
+
+    def fit(self, X_for_smoother, y):
+        self.set_n_bins(X_for_smoother)
+        self.smoother.fit(X_for_smoother, y)
+
+    def predict(self, X_for_smoother):
+        smoothed_y = self.smoother.predict(X_for_smoother)
+        return self.apply_cut(X_for_smoother, smoothed_y)
+
+
+class NormalizationRegressionTypeSmoother(NormalizationSmoother, RegressionTypeSmoother):
+    """Meta-smoother to constrain all values according to their
+    :class:`~cyclic_boosting.smoothing.RegressionType` from the ``predict`` method
+    of the subsmoother.
+
+    Parameters
+    ----------
+
+    smoother: :class:`AbstractBinSmoother`
+        smoother used to fit and predict on the `normalized` data points.
+
+    reg_type: :class:`RegressionType`
+        defines the regression type that is used to constrain the values.
+
+    Regression Types
+    ----------------
+
+    * discontinuous: Set all values in predict to nan that are out of the bin
+           boundries in the fit or where no fit events have been seen.
+    * interpolating: Set all values in predict to nan that are out of the bin
+           boundries in the fit.
+    * extrapolating: No restrictions for values in predict.
+    """
+
+    def __init__(self, smoother, reg_type):
+        self.smoother = smoother
+        self.reg_type = check_reg_type(reg_type)
+
+    def fit(self, X_for_smoother, y):
+        self.set_n_bins(X_for_smoother)
+        self.calc_norm(X_for_smoother, y)
+        self.smoother.fit(X_for_smoother, y - self.norm_)
+
+    def predict(self, X_for_smoother):
+        smoothed_y = self.smoother.predict(X_for_smoother) + self.norm_
+        return self.apply_cut(X_for_smoother, smoothed_y)
+
+
+class SectionSmoother(AbstractBinSmoother):
+    """Meta-smoother that splits the fitted data into two parts which are
+    fitted by different subsmoothers.
+
+    Parameters
+    ----------
+
+    split_point : float
+        value of x to split the data :math:`x_{below} <= C_{split} < x_{above}`
+
+    smoother_lower: :class:`AbstractBinSmoother`
+        smoother used to fit and predict on the data points below and including
+        the split_point
+
+    smoother_upper: :class:`AbstractBinSmoother`
+        smoother used to fit and predict on the data points above the split_point
+
+    nan_representation: float
+        optional argument to define ``not a number values`` (default = ``np.nan``).
+
+    epsilon: float
+        Floating point accuracy when comparing with the ``split_point``.
+        (E.g. :math:`x_{below} <= C_{split} + /epsilon`)
+    """
+
+    def __init__(
+        self,
+        split_point,
+        smoother_lower,
+        smoother_upper,
+        nan_representation=np.nan,
+        epsilon=0.001,
+    ):
+        self.split_point = split_point
+        self.smoother_lower = smoother_lower
+        self.smoother_upper = smoother_upper
+        self.nan_representation = np.nan
+        self.epsilon = epsilon
+        self._reset_smoother_status()
+
+    def _reset_smoother_status(self):
+        self.smoother_lower_fitted = False
+        self.smoother_upper_fitted = False
+
+    def _split_condition(self, X_for_smoother):
+        return X_for_smoother[:, 0] <= self.split_point + self.epsilon
+
+    def fit(self, X_for_smoother, y):
+        self._reset_smoother_status()
+        cond_lower = self._split_condition(X_for_smoother)
+        if np.sum(cond_lower) > 0:
+            self.smoother_lower.fit(X_for_smoother[cond_lower], y[cond_lower])
+            self.smoother_lower_fitted = True
+        if np.sum(~cond_lower) > 0:
+            self.smoother_upper.fit(X_for_smoother[~cond_lower], y[~cond_lower])
+            self.smoother_upper_fitted = True
+        assert self.smoother_upper_fitted or self.smoother_lower_fitted
+
+    def predict(self, X_for_smoother):
+        if not self.smoother_upper_fitted and not self.smoother_lower_fitted:
+            raise ValueError("The {} has not been fitted!".format(self.__class__.__name__))
+
+        cond_lower = self._split_condition(X_for_smoother)
+        pred = np.ones(len(X_for_smoother)) * self.nan_representation
+        if self.smoother_lower_fitted and np.sum(cond_lower) > 0:
+            pred[cond_lower] = self.smoother_lower.predict(X_for_smoother[cond_lower])
+        if self.smoother_upper_fitted and np.sum(~cond_lower) > 0:
+            pred[~cond_lower] = self.smoother_upper.predict(X_for_smoother[~cond_lower])
+        return pred
+
+
+__all__ = [
+    "NormalizationSmoother",
+    "RegressionTypeSmoother",
+    "NormalizationRegressionTypeSmoother",
+    "SectionSmoother",
+]

--- a/skpro/libs/cyclic_boosting/smoothing/meta_smoother.py
+++ b/skpro/libs/cyclic_boosting/smoothing/meta_smoother.py
@@ -7,7 +7,6 @@ from enum import Enum
 
 import numpy as np
 
-
 from skpro.libs.cyclic_boosting import utils
 from skpro.libs.cyclic_boosting.smoothing.base import AbstractBinSmoother, SetNBinsMixin
 
@@ -102,8 +101,10 @@ class NormalizationSmoother(AbstractBinSmoother):
 
         if not np.isfinite(self.norm_):
             _logger.info(
-                "The norm in smoother {0} is not finite: "
-                "norm= {1}; weights= {2}; target= {3}".format(self.__class__.__name__, self.norm_, X_for_smoother, y)
+                "The norm in smoother {} is not finite: "
+                "norm= {}; weights= {}; target= {}".format(
+                    self.__class__.__name__, self.norm_, X_for_smoother, y
+                )
             )
             self.norm_ = 0.0
 
@@ -169,9 +170,13 @@ class RegressionTypeSmoother(AbstractBinSmoother, SetNBinsMixin):
              Array that contains the result of the subsmoother.
         """
         if not_interpolating(self.reg_type):
-            selected_events = utils.not_seen_events(X_for_smoother[:, : self.ndim_], self.bin_weights_, self.n_bins_)
+            selected_events = utils.not_seen_events(
+                X_for_smoother[:, : self.ndim_], self.bin_weights_, self.n_bins_
+            )
         elif not_extrapolating(self.reg_type):
-            selected_events = _selected_events_interpolating(X_for_smoother, self.ndim_, self.n_bins_)
+            selected_events = _selected_events_interpolating(
+                X_for_smoother, self.ndim_, self.n_bins_
+            )
         else:
             return smoothed_y
 
@@ -188,7 +193,9 @@ class RegressionTypeSmoother(AbstractBinSmoother, SetNBinsMixin):
         return self.apply_cut(X_for_smoother, smoothed_y)
 
 
-class NormalizationRegressionTypeSmoother(NormalizationSmoother, RegressionTypeSmoother):
+class NormalizationRegressionTypeSmoother(
+    NormalizationSmoother, RegressionTypeSmoother
+):
     """Meta-smoother to constrain all values according to their
     :class:`~cyclic_boosting.smoothing.RegressionType` from the ``predict`` method
     of the subsmoother.
@@ -286,7 +293,7 @@ class SectionSmoother(AbstractBinSmoother):
 
     def predict(self, X_for_smoother):
         if not self.smoother_upper_fitted and not self.smoother_lower_fitted:
-            raise ValueError("The {} has not been fitted!".format(self.__class__.__name__))
+            raise ValueError(f"The {self.__class__.__name__} has not been fitted!")
 
         cond_lower = self._split_condition(X_for_smoother)
         pred = np.ones(len(X_for_smoother)) * self.nan_representation

--- a/skpro/libs/cyclic_boosting/smoothing/multidim.py
+++ b/skpro/libs/cyclic_boosting/smoothing/multidim.py
@@ -1,0 +1,397 @@
+"""
+Multidimensional smoothers
+"""
+
+import numpy as np
+import pandas as pd
+from scipy import sparse
+
+from skpro.libs.cyclic_boosting import utils
+from skpro.libs.cyclic_boosting.smoothing.base import AbstractBinSmoother, SetNBinsMixin
+
+
+class PredictingBinValueMixin(SetNBinsMixin):
+    """Mixin for smoothers of multidimensional bins with
+    :meth:`predict` returning the corresponding entry in the estimated parameter
+    ``smoothed_y_`` which must have been calculated in :meth:`fit`.
+
+    Please create the array ``smoothed_y_`` in your :meth:`fit` method.
+
+    **Estimated parameters**
+
+    :param `smoothed_y_`: the bin values for ``y`` (as received from the profile
+        function in the fit) after some smoothing; a pseudobin
+        for the missing values is not supported; the values are indexed in
+        lexicographical ordering using the
+    :type `smoothed_y_`: :class:`numpy.ndarray` (float64, shape `(n_bins,)`)
+
+    :param `n_bins_`: number of bins in each dimension; it is permitted to
+        append additional entries to this array. They are ignored in
+        :meth:`predict` anyway.
+
+        Please use :meth:`set_n_bins`
+        to initialize this estimated parameter in your implementation of
+        :meth:`fit`.
+    :type `n_bins_`: :class:`numpy.ndarray` (int64, shape `(n_dims + x,)`)
+
+    For examples, see the subclass :class:`BinValuesSmoother`.
+    """
+
+    def predict(self, X):
+        if not hasattr(self, "n_bins_"):
+            raise ValueError('Please call the method "fit" before "predict" and ' '"set_n_bins" in your "fit" method')
+
+        if self._bin_steps is None:
+            self.n_bins_ = self.n_bins_[: X.shape[1]]
+            self._bin_steps = utils.bin_steps(self.n_bins_)
+
+        binnos = X
+        binnos_round = np.asarray(np.floor(X), dtype=int)
+        is_valid = np.all(
+            np.isfinite(binnos) & (binnos >= 0) & (binnos_round < (self.n_bins_[None, :])),
+            axis=1,
+        )
+
+        pred = utils.nans(len(binnos))
+        pred[is_valid] = self.smoothed_y_[np.dot(binnos_round[is_valid], self._bin_steps[1:])]
+
+        return pred
+
+
+class BinValuesSmoother(AbstractBinSmoother, PredictingBinValueMixin):
+    """Smoother of multidimensional bins that outputs the saved bin values of
+    y (as received from the profile function in the fit) as the prediction.
+
+    This smoother only considers the first ``n_dim`` columns of
+    ``X_for_smoother`` passed by the **profile function**. These columns are
+    supposed to contain all the coordinates of the ``n_dim``-dimensional bin
+    centers.
+
+    **Estimated parameters**
+
+    :param `smoothed_y_`: the bin values for ``y`` (as received from the
+        profile function in the fit), in this case without any smoothing;
+        a pseudobin for the missing values is not supported
+    :type `smoothed_y_`: :class:`numpy.ndarray` (float64, shape `(n_bins,)`)
+
+    :param `n_bins_`: see :class:`PredictingBinValueMixin`
+
+    >>> from skpro.libs.cyclic_boosting import smoothing
+    >>> X =    np.c_[[0., 0,  1,  1],
+    ...              [0,  1,  0,  1],
+    ...              [1,  1,  1,  1]]  # ignored
+    >>> y = np.array([90, 80, 50, 40])
+
+    >>> reg = smoothing.multidim.BinValuesSmoother()
+    >>> assert reg.fit(X, y) is reg
+    >>> assert np.allclose(reg.smoothed_y_, y)
+    >>> X = np.c_[[1.1, 0.4, 0.0, 0.1, 2.],
+    ...           [1.2, 1.1, 0.4, 0.4, 0.]]
+    >>> reg.predict(X)
+    array([ 40.,  80.,  90.,  90.,  nan])
+    """
+
+    elems = ["smoothed_y_", "bin_weights_"]
+
+    def fit(self, X_for_smoother, y):
+        self.set_n_bins(X_for_smoother)
+        self.smoothed_y_ = y
+        return self
+
+    def __getstate__(self):
+        """Return state values to be pickled."""
+        state = self.__dict__.copy()
+        for elem in self.elems:
+            if elem in state and state[elem] is not None:
+                state[elem] = sparse.csr_matrix(state[elem])
+        return state
+
+    def __setstate__(self, state):
+        """Restore state from the unpickled state values."""
+        for elem in self.elems:
+            if elem in state and state[elem] is not None:
+                state[elem] = state[elem].toarray()[0, :]
+        self.__dict__.update(state)
+
+
+class RegularizeToPriorExpectationSmoother(AbstractBinSmoother, PredictingBinValueMixin):
+    r"""Smoother of multidimensional bins regularizing values with uncertainties
+    to a prior expectation.
+
+    For details, see :func:`cyclic_boosting.utils.regularize_to_prior_expectation`.
+
+    :param prior_expectation: The prior dominate the regularized value if the
+        uncertainties are large.
+    :type prior_expectation: :class:`numpy.ndarray` (float64, dim=1) or float
+
+    :param threshold: Threshold in terms of sigma. If the significance of a
+        value:
+
+        .. math::
+
+            \text{sig}(x_i) = \frac{x_i - \text{prior\_expectation}_i}
+            {\text{uncertainty}_i}
+
+        is below the threshold, the prior expectation replaces the value.
+    :type threshold: float
+
+    **Required columns** in the ``X_for_smoother`` passed to :meth:`fit`:
+
+    * columns 0 to``n_dim - 1``: coordinates of the bin centers (ignored here)
+    * column ``n_dim``: ignored
+    * column ``n_dim + 1``, which must be the last: uncertainty of the average
+      ``y`` in each bin
+
+    **Doctests**
+
+    >>> from skpro.libs.cyclic_boosting import smoothing
+    >>> y = np.array([0, 1, 2, 3])
+    >>> X = np.c_[
+    ...     [0, 0, 1, 1],
+    ...     [0, 1, 0, 1],
+    ...     [1]*4,
+    ...     [0.1]*4]
+    >>> est = smoothing.multidim.RegularizeToPriorExpectationSmoother(1.)
+    >>> assert est.fit(X, y) is est
+    >>> y_smoothed = est.predict(X[:, :2])
+    >>> y_smoothed
+    array([ 0.03175416,  1.        ,  1.96824584,  2.98431348])
+    >>> np.allclose(1 - np.sqrt(((y[0] - 1) / 0.1)**2 - 2.5**2) * 0.1,
+    ...     y_smoothed[0])
+    True
+    >>> np.allclose(1 + np.sqrt(((y[-1] - 1) / 0.1)**2 - 2.5**2) * 0.1,
+    ...     y_smoothed[-1])
+    True
+    """
+
+    def __init__(self, prior_expectation, threshold=2.5):
+        self.prior_expectation = prior_expectation
+        self.threshold = threshold
+
+    def fit(self, X_for_smoother, y):
+        self.set_n_bins(X_for_smoother)
+        self.smoothed_y_ = utils.regularize_to_prior_expectation(
+            y, X_for_smoother[:, -1], self.prior_expectation, threshold=self.threshold
+        )
+        return self
+
+
+class RegularizeToOneSmoother(RegularizeToPriorExpectationSmoother):
+    """Smoother for multidimensional bins regularizing values with
+    uncertainties to the prior expectation 1.
+
+    For details, see the superclass
+    :class:`RegularizeToPriorExpectationSmoother` and the
+    underlying function
+    :func:`cyclic_boosting.utils.regularize_to_prior_expectation`.
+
+    :param threshold: threshold in terms of sigma.
+        If the significance of a factor
+        is below the threshold, the global measurement replaces the factor.
+        Internally :func:`cyclic_boosting.utils.regularize_to_prior_expectation`
+        is used.
+    :type threshold: float
+    """
+
+    def __init__(self, threshold=2.5):
+        RegularizeToPriorExpectationSmoother.__init__(self, prior_expectation=1, threshold=threshold)
+
+
+class WeightedMeanSmoother(AbstractBinSmoother, PredictingBinValueMixin):
+    r"""Smoother for multidimensional bins regularizing values with
+    uncertainties to the weighted mean.
+
+    For details see :func:`cyclic_boosting.utils.regularize_to_error_weighted_mean`.
+
+    :param prior_prediction: If the `prior_prediction` is specified, all values
+        are regularized with it and not with the error weighted mean.
+    :type prior_prediction: float
+
+    >>> from skpro.libs.cyclic_boosting import smoothing
+    >>> y_for_smoother = np.array([0.9, 0.9, 0.9, 1.8, 1.8, 0.4, 0.4])
+    >>> X_for_smoother = np.c_[
+    ...     [1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0],
+    ...     [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0],
+    ...     [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+    ...     [0.05, 0.05, 0.05, 0.05, 0.15, 0.15, 0.05]]
+    >>> smoother = smoothing.multidim.WeightedMeanSmoother()
+    >>> smoother.fit(X_for_smoother, y_for_smoother)
+    >>> smoother.smoothed_y_
+    array([ 0.90096366,  0.90096366,  0.90096366,  1.79077293,  1.723854  ,
+            0.45467402,  0.40662518])
+
+    """
+
+    def __init__(self, prior_prediction=None):
+        self.prior_prediction = prior_prediction
+
+    def fit(self, X_for_smoother, y):
+        self.set_n_bins(X_for_smoother)
+        self.smoothed_y_ = utils.regularize_to_error_weighted_mean(y, X_for_smoother[:, -1], self.prior_prediction)
+
+
+class PriorExpectationMetaSmoother(AbstractBinSmoother, PredictingBinValueMixin):
+    """Meta-Smoother that takes another multi-dimensional smoother which
+    results are addionally smoothed using
+    :func:`cyclic_boosting.utils.regularize_to_prior_expectation`.
+
+    :param prior_expectation: The prior dominate the regularized value if the
+        uncertainties are large.
+    :type prior_expectation: :class:`numpy.ndarray` (float64, dim=1) or float
+
+    :param threshold: Threshold in terms of sigma. If the significance of a
+        value:
+
+        .. math::
+
+            \text{sig}(x_i) = \frac{x_i - \text{prior_{expectation}_i}}
+            {\text{uncertainty}_i}
+
+        is below the threshold, the prior expectation replaces the value.
+    :type threshold: float
+    """
+
+    def __init__(self, est, prior_expectation, threshold=2.5):
+        self.est = est
+        self.prior_expectation = prior_expectation
+        self.threshold = threshold
+
+    def fit(self, X_for_smoother, y):
+        """ """
+        d = X_for_smoother.shape[1] - 2
+        if d < 2:
+            raise ValueError("You need at least 4 columns for multidim smoothing.")
+        self.est.fit(X_for_smoother.copy(), y)
+
+        self.set_n_bins(X_for_smoother)
+        self.smoothed_y_ = utils.regularize_to_prior_expectation(
+            self.est.predict(X_for_smoother[:, :d]),
+            X_for_smoother[:, -1],
+            self.prior_expectation,
+            threshold=self.threshold,
+        )
+        return self
+
+
+def _fit_est_on_group(X, n_group_columns, est):
+    est = utils.clone(est)
+    est.fit(X.iloc[:, n_group_columns:-1].values, X.iloc[:, -1].values)
+    return est
+
+
+def _predict_groups(x, gb, n_group_columns):
+    try:
+        est = gb.loc(axis=0)[x.name]
+    except KeyError:
+        p = np.nan
+    else:
+        p = est.predict(np.c_[x.values])
+    return p
+
+
+class GroupBySmoother(AbstractBinSmoother):
+    """Multidimensional smoother that groups on the *first* k-1 columns
+    of a k dimensional feature and smoothes a clone of the specified 1-dimensional
+    smoother on each group.
+
+    Parameters
+    ----------
+
+    est: :class:`AbstractBinSmoother`
+        One-dimensional smoother whose clones are fitted on the grouped columns
+
+    ndim: int
+        Number of dimensions of the feature.
+
+    index_weight_col: int
+       Index of weight column. If specified, rows with zero weight are removed.
+       If `None`, no rows are dropped.
+    """
+
+    @property
+    def n_group_columns(self):
+        return self.n_dim - 1
+
+    def __init__(self, est, n_dim, index_weight_col=None):
+        self.est = est
+        self.n_dim = n_dim
+        self.index_weight_col = index_weight_col
+
+    def fit(self, X_for_smoother, y):
+        if self.index_weight_col is not None:
+            Xp = pd.DataFrame(X_for_smoother)
+            gb_cols = list(range(self.n_dim - 1))
+            gb = Xp.groupby(gb_cols)[self.n_dim].sum()
+            Xp = Xp[gb_cols].merge(gb.reset_index(), how="left", on=gb_cols)
+            mask = Xp[self.n_dim].values > 0
+            X_for_smoother = X_for_smoother[mask]
+            y = y[mask]
+        X = pd.DataFrame(np.c_[X_for_smoother, y])
+        self.group_cols = list(range(self.n_group_columns))
+        self.gb = X.groupby(self.group_cols, sort=False).apply(_fit_est_on_group, self.n_group_columns, self.est)
+
+    def predict(self, X):
+        X = pd.DataFrame(X)
+        pred = X.groupby(self.group_cols, sort=False)[X.columns[-1]].transform(
+            _predict_groups, self.gb, self.n_group_columns
+        )
+        return pred.values
+
+
+class GroupBySmootherCB(GroupBySmoother):
+    """GroupBySmoother for cyclic boosting.
+    Samples with zero weights are dropped to save memory.
+    """
+
+    def __init__(self, est, n_dim):
+        GroupBySmoother.__init__(self, est, n_dim, -2)
+
+
+class Neutralize2DMetaSmoother(AbstractBinSmoother, PredictingBinValueMixin):
+    """Meta-Smoother that takes another multi-dimensional smoother which
+    inputs are smoothed by neutralize_one_dim_influence.
+
+    This means, the influence of one-dimensional features on two-dimensional features
+    is removed by iteratively projecting the two-dimensional factor matrix onto one dimension
+    and substract this weighted by the uncertainties from the matrix.
+
+    In a cyclic boosting model this prevents two-dimensional features to include the effect which
+    should be learned by the one-dimension features.
+
+    :func:`cyclic_boosting.utils.neutralize_one_dim_influence`.
+    """
+
+    def __init__(self, est):
+        self.est = est
+
+    def fit(self, X_for_smoother, y):
+        """Fit the transformer to training samples."""
+        d = X_for_smoother.shape[1] - 2
+        if d < 2:
+            raise ValueError("You need at least 4 columns for multidim smoothing.")
+
+        # We get the y values as 1d array, hence we have to reshape it into
+        # the correct 2d array
+        new_shape = np.max(X_for_smoother[:, :2], axis=0).astype(np.int64) + 1
+        values = np.reshape(y, new_shape)
+        uncertainties = np.reshape(X_for_smoother[:, -1], new_shape)
+        neutralized_values = utils.neutralize_one_dim_influence(values, uncertainties)
+
+        y = np.reshape(neutralized_values, np.prod(new_shape))
+        self.est.fit(X_for_smoother.copy(), y)
+
+        self.set_n_bins(X_for_smoother)
+        self.smoothed_y_ = self.est.predict(X_for_smoother[:, :d])
+        return self
+
+
+__all__ = [
+    "PredictingBinValueMixin",
+    "BinValuesSmoother",
+    "RegularizeToPriorExpectationSmoother",
+    "RegularizeToOneSmoother",
+    "WeightedMeanSmoother",
+    "Neutralize2DMetaSmoother",
+    "GroupBySmoother",
+    "GroupBySmootherCB",
+]

--- a/skpro/libs/cyclic_boosting/smoothing/multidim.py
+++ b/skpro/libs/cyclic_boosting/smoothing/multidim.py
@@ -39,7 +39,10 @@ class PredictingBinValueMixin(SetNBinsMixin):
 
     def predict(self, X):
         if not hasattr(self, "n_bins_"):
-            raise ValueError('Please call the method "fit" before "predict" and ' '"set_n_bins" in your "fit" method')
+            raise ValueError(
+                'Please call the method "fit" before "predict" and '
+                '"set_n_bins" in your "fit" method'
+            )
 
         if self._bin_steps is None:
             self.n_bins_ = self.n_bins_[: X.shape[1]]
@@ -48,12 +51,16 @@ class PredictingBinValueMixin(SetNBinsMixin):
         binnos = X
         binnos_round = np.asarray(np.floor(X), dtype=int)
         is_valid = np.all(
-            np.isfinite(binnos) & (binnos >= 0) & (binnos_round < (self.n_bins_[None, :])),
+            np.isfinite(binnos)
+            & (binnos >= 0)
+            & (binnos_round < (self.n_bins_[None, :])),
             axis=1,
         )
 
         pred = utils.nans(len(binnos))
-        pred[is_valid] = self.smoothed_y_[np.dot(binnos_round[is_valid], self._bin_steps[1:])]
+        pred[is_valid] = self.smoothed_y_[
+            np.dot(binnos_round[is_valid], self._bin_steps[1:])
+        ]
 
         return pred
 
@@ -114,7 +121,9 @@ class BinValuesSmoother(AbstractBinSmoother, PredictingBinValueMixin):
         self.__dict__.update(state)
 
 
-class RegularizeToPriorExpectationSmoother(AbstractBinSmoother, PredictingBinValueMixin):
+class RegularizeToPriorExpectationSmoother(
+    AbstractBinSmoother, PredictingBinValueMixin
+):
     r"""Smoother of multidimensional bins regularizing values with uncertainties
     to a prior expectation.
 
@@ -194,7 +203,9 @@ class RegularizeToOneSmoother(RegularizeToPriorExpectationSmoother):
     """
 
     def __init__(self, threshold=2.5):
-        RegularizeToPriorExpectationSmoother.__init__(self, prior_expectation=1, threshold=threshold)
+        RegularizeToPriorExpectationSmoother.__init__(
+            self, prior_expectation=1, threshold=threshold
+        )
 
 
 class WeightedMeanSmoother(AbstractBinSmoother, PredictingBinValueMixin):
@@ -227,7 +238,9 @@ class WeightedMeanSmoother(AbstractBinSmoother, PredictingBinValueMixin):
 
     def fit(self, X_for_smoother, y):
         self.set_n_bins(X_for_smoother)
-        self.smoothed_y_ = utils.regularize_to_error_weighted_mean(y, X_for_smoother[:, -1], self.prior_prediction)
+        self.smoothed_y_ = utils.regularize_to_error_weighted_mean(
+            y, X_for_smoother[:, -1], self.prior_prediction
+        )
 
 
 class PriorExpectationMetaSmoother(AbstractBinSmoother, PredictingBinValueMixin):
@@ -328,7 +341,9 @@ class GroupBySmoother(AbstractBinSmoother):
             y = y[mask]
         X = pd.DataFrame(np.c_[X_for_smoother, y])
         self.group_cols = list(range(self.n_group_columns))
-        self.gb = X.groupby(self.group_cols, sort=False).apply(_fit_est_on_group, self.n_group_columns, self.est)
+        self.gb = X.groupby(self.group_cols, sort=False).apply(
+            _fit_est_on_group, self.n_group_columns, self.est
+        )
 
     def predict(self, X):
         X = pd.DataFrame(X)

--- a/skpro/libs/cyclic_boosting/smoothing/onedim.py
+++ b/skpro/libs/cyclic_boosting/smoothing/onedim.py
@@ -1,0 +1,777 @@
+"""
+One-dimensional smoothers
+"""
+
+import warnings
+
+import numpy as np
+import scipy.interpolate
+import scipy.optimize
+import sklearn.isotonic
+from scipy import sparse
+from sklearn.linear_model import LassoLarsIC
+
+from skpro.libs.cyclic_boosting import utils
+from skpro.libs.cyclic_boosting.smoothing.base import AbstractBinSmoother
+from skpro.libs.cyclic_boosting.smoothing.orthofit import (
+    cy_apply_orthogonal_poly_fit_equidistant,
+    cy_orthogonal_poly_fit_equidistant,
+)
+
+
+class PredictingBinValueMixin(object):
+    """Mixin for smoothers of one-dimensional bins with :meth:`predict`
+    returning the corresponding entry in the estimated parameter
+    ``smoothed_y_`` which must have been calculated in :meth:`fit`.
+
+    Please create the array ``smoothed_y_`` in your :meth:`fit` method.
+
+    **Estimated parameters**
+
+    :param `smoothed_y_`: the bin values for ``y``
+        (as received from the profile function in the fit)
+        after some smoothing.
+        a pseudobin for the missing values is not supported
+    :type `smoothed_y_`: :class:`numpy.ndarray` (float64, shape `(n_bins,)`)
+
+    For examples, see the subclasses :class:`BinValuesSmoother` and
+    :class:`BinKernelSmoother`.
+    """
+
+    def predict(self, X):
+        if not hasattr(self, "smoothed_y_"):
+            raise ValueError("The {} has not been fitted!".format(self.__class__.__name__))
+        binnos = X[:, 0]
+        binnos_round = np.asarray(np.rint(binnos), dtype=np.int64)
+        is_valid = np.isfinite(binnos) & (binnos >= 0) & (binnos_round < (len(self.smoothed_y_)))
+
+        pred = utils.nans(len(binnos))
+        pred[is_valid] = self.smoothed_y_[binnos_round[is_valid]]
+        return pred
+
+
+class BinValuesSmoother(AbstractBinSmoother, PredictingBinValueMixin):
+    """Smoother that does not perform any smoothing (the identity smoother so
+    to speak).
+
+    Smoother of one-dimensional bins that outputs the saved bin values of y (as
+    received from the profile function in the fit) as the prediction.  This
+    smoother has **no requirements** on ``X_for_smoother`` passed by the
+    **profile function**, because it just saves the target values ``y`` and
+    ignores ``X_for_smoother`` completely.
+
+    **Estimated parameters**
+
+    :param `smoothed_y_`: the bin values for ``y``
+        (as received from the profile function in the fit)
+        after some smoothing.
+        a pseudobin for the missing values is not supported
+    :type `smoothed_y_`: :class:`numpy.ndarray` (float64, shape `(n_bins,)`)
+
+    >>> X = np.c_[[0., 1, 2, 3],
+    ...           [1, 1, 1, 1]]
+    >>> y = np.array([90, 80, 50, 40])
+
+    >>> from skpro.libs.cyclic_boosting.smoothing.onedim import BinValuesSmoother
+    >>> reg = BinValuesSmoother()
+    >>> assert reg.fit(X, y) is reg
+    >>> assert np.allclose(reg.smoothed_y_, y)
+    >>> X = np.c_[[3.1, 0.4, 1, 2.9, 3.4, 4.5]]
+    >>> reg.predict(X)
+    array([ 40.,  90.,  80.,  40.,  40.,  nan])
+    """
+
+    elem = "smoothed_y_"
+
+    def fit(self, X_for_smoother, y):
+        self.smoothed_y_ = y
+        return self
+
+    def __getstate__(self):
+        """Return state values to be pickled."""
+        state = self.__dict__.copy()
+        if self.elem in state and state[self.elem] is not None:
+            state[self.elem] = sparse.csr_matrix(state[self.elem])
+        return state
+
+    def __setstate__(self, state):
+        """Restore state from the unpickled state values."""
+        if self.elem in state and state[self.elem] is not None:
+            state[self.elem] = state[self.elem].toarray()[0, :]
+        self.__dict__.update(state)
+
+
+class RegularizeToPriorExpectationSmoother(AbstractBinSmoother, PredictingBinValueMixin):
+    r"""Smoother of one-dimensional bins regularizing values with uncertainties
+    to a prior expectation.
+
+    :param prior_expectation: The prior dominate the regularized value if the
+        uncertainties are large.
+    :type prior_expectation: :class:`numpy.ndarray` (float64, dim=1) or float
+
+    :param threshold: Threshold in terms of sigma. If the significance of a
+        value:
+
+        .. math::
+
+            \text{sig}(x_i) = \frac{x_i - \text{prior\_expectation}_i}
+            {\text{uncertainty}_i}
+
+        is below the threshold, the prior expectation replaces the value.
+    :type threshold: float
+
+    **Required columns** in the ``X_for_smoother`` passed to :meth:`fit`:
+
+    * column 0: ...
+    * column 1: ignored
+    * column 2: uncertainty of the average ``y`` in each bin
+
+    **Doctests**
+
+    >>> y = np.array([0, 1, 2, 3])
+    >>> X = np.c_[
+    ...     [0, 1, 2, 3],
+    ...     [1]*4,
+    ...     [0.1]*4]
+    >>> from skpro.libs.cyclic_boosting.smoothing.onedim import RegularizeToPriorExpectationSmoother
+    >>> est = RegularizeToPriorExpectationSmoother(1.)
+    >>> assert est.fit(X, y) is est
+    >>> y_smoothed = est.predict(X[:, [0]])
+    >>> y_smoothed
+    array([ 0.03175416,  1.        ,  1.96824584,  2.98431348])
+    >>> np.allclose(1 - np.sqrt(((y[0] - 1) / 0.1)**2 - 2.5**2) * 0.1,
+    ...     y_smoothed[0])
+    True
+    >>> np.allclose(1 + np.sqrt(((y[-1] - 1) / 0.1)**2 - 2.5**2) * 0.1,
+    ...     y_smoothed[-1])
+    True
+    """
+
+    def __init__(self, prior_expectation, threshold=2.5):
+        self.prior_expectation = prior_expectation
+        self.threshold = threshold
+
+    def fit(self, X_for_smoother, y):
+        self.smoothed_y_ = utils.regularize_to_prior_expectation(
+            y, X_for_smoother[:, 2], self.prior_expectation, threshold=self.threshold
+        )
+        return self
+
+
+class RegularizeToOneSmoother(RegularizeToPriorExpectationSmoother):
+    """Smoother for one-dimensional bins regularizing values with uncertainties
+    to the mean of the values.
+
+    :param threshold: threshold in terms of sigma.
+        If the significance of a factor is below the threshold, the global
+        measurement replaces the factor.
+    :type threshold: float
+    """
+
+    def __init__(self, threshold=2.5):
+        RegularizeToPriorExpectationSmoother.__init__(self, prior_expectation=1, threshold=threshold)
+
+
+class WeightedMeanSmoother(AbstractBinSmoother, PredictingBinValueMixin):
+    r"""Smoother for one-dimensional bins regularizing values with
+    uncertainties to the weighted mean or a user defined value.
+
+    :param prior_prediction: If the `prior_prediction` is specified, all values
+        are regularized with it and not with the error weighted mean.
+    :type prior_prediction: float
+
+    >>> y_for_smoother = np.array([0.9, 0.9, 0.9, 1.8, 1.8, 0.4, 0.4])
+    >>> X_for_smoother = np.c_[
+    ...     [1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0],
+    ...     [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+    ...     [0.05, 0.05, 0.05, 0.05, 0.15, 0.15, 0.05]]
+    >>> from skpro.libs.cyclic_boosting.smoothing.onedim import WeightedMeanSmoother
+    >>> smoother = WeightedMeanSmoother()
+    >>> smoother.fit(X_for_smoother, y_for_smoother)
+    >>> smoother.smoothed_y_
+    array([ 0.90096366,  0.90096366,  0.90096366,  1.79077293,  1.723854  ,
+            0.45467402,  0.40662518])
+
+    >>> y_for_smoother = np.array([-0.70710678, -0.70710678])
+    >>> X_for_smoother = np.c_[[0., 1.], [0.012]*2, [9.12870929]*2]
+    >>> smoother = WeightedMeanSmoother()
+    >>> smoother.fit(X_for_smoother, y_for_smoother)
+    >>> smoother.smoothed_y_
+    array([-0.70710678, -0.70710678])
+
+    >>> y_for_smoother = np.array([-1, -1, -1, 1, 1])
+    >>> X_for_smoother = np.c_[
+    ...     [1.0, 1.0, 1.0, 0.0, 0.0],
+    ...     [0.0, 0.0, 0.0, 0.0, 0.0],
+    ...     [0.5, 0.5, 0.5, 0.5, 0.5]]
+    >>> smoother = WeightedMeanSmoother(prior_prediction=0)
+    >>> smoother.fit(X_for_smoother, y_for_smoother)
+    >>> smoothed_abs = (4. * 1 + 1 * 0) / (4 + 1)
+    >>> np.testing.assert_allclose(smoother.smoothed_y_,
+    ...     y_for_smoother * smoothed_abs)
+
+    """
+
+    def __init__(self, prior_prediction=None):
+        self.prior_prediction = prior_prediction
+
+    def fit(self, X_for_smoother, y):
+        self.smoothed_y_ = utils.regularize_to_error_weighted_mean(y, X_for_smoother[:, 2], self.prior_prediction)
+
+
+class WeightedMeanSmootherNeighbors(AbstractBinSmoother, PredictingBinValueMixin):
+    """
+    Smoother for regularizing one-dimensional bin values with uncertainties to
+    the weighted mean of a window including only its left and right neigboring
+    bins.
+    """
+
+    def fit(self, X_for_smoother, y):
+        if len(y) < 3:
+            self.smoothed_y_ = utils.regularize_to_error_weighted_mean(y, X_for_smoother[:, 2])
+        else:
+            self.smoothed_y_ = utils.regularize_to_error_weighted_mean_neighbors(y, X_for_smoother[:, 2], window_size=3)
+
+
+class OrthogonalPolynomialSmoother(AbstractBinSmoother):
+    """A polynomial fit that uses orthogonal polynomials as basis functions.
+
+    Ansatz, see Blobel (http://www.desy.de/~blobel/eBuch.pdf)
+    """
+
+    def fit(self, X_for_smoother, y):
+        x = np.ascontiguousarray(X_for_smoother[:, 0], dtype=np.float64)
+
+        self.minimal_x = np.nanmin(x)
+        self.maximal_x = np.nanmax(x)
+        self.pp_, self.n_degrees_ = cy_orthogonal_poly_fit_equidistant(
+            x,
+            np.ascontiguousarray(y, dtype=np.float64),
+            np.ascontiguousarray(X_for_smoother[:, 2], dtype=np.float64),
+        )
+
+        return self
+
+    def predict(self, X):
+        assert X.ndim == 2
+        if not hasattr(self, "pp_"):
+            raise ValueError("The {} has not been fitted!".format(self.__class__.__name__))
+        x = np.ascontiguousarray(X[:, 0], dtype=np.float64)
+        x[x < self.minimal_x] = self.minimal_x
+        x[x > self.maximal_x] = self.maximal_x
+        y = cy_apply_orthogonal_poly_fit_equidistant(x, self.pp_, self.n_degrees_)
+        return y
+
+
+def _choose_default_fit_function(order):
+    if order == 1:
+        return _seasonality_first_order
+    elif order == 2:
+        return _seasonality_second_order
+    elif order == 3:
+        return _seasonality_third_order
+    else:
+        raise ValueError(
+            "The order parameter of the SeasonalSmoother "
+            "has to be 1, 2 or 3. If this is not sufficient "
+            "you can specify a `custom_fit_function`."
+        )
+
+
+def _seasonality_first_order(x, c_const, c_sin, c_cos):
+    return c_const + c_sin * np.sin(x) + c_cos * np.cos(x)
+
+
+def _seasonality_second_order(x, c_const, c_sin_1x, c_cos_1x, c_sin_2x, c_cos_2x):
+    return c_const + c_sin_1x * np.sin(x) + c_cos_1x * np.cos(x) + c_sin_2x * np.sin(2 * x) + c_cos_2x * np.cos(2 * x)
+
+
+def _seasonality_third_order(x, c_const, c_sin_1x, c_cos_1x, c_sin_2x, c_cos_2x, c_sin_3x, c_cos_3x):
+    return (
+        c_const
+        + c_sin_1x * np.sin(x)
+        + c_cos_1x * np.cos(x)
+        + c_sin_2x * np.sin(2 * x)
+        + c_cos_2x * np.cos(2 * x)
+        + c_sin_3x * np.sin(3 * x)
+        + c_cos_3x * np.cos(3 * x)
+    )
+
+
+class SeasonalSmoother(AbstractBinSmoother):
+    """Seasonal Smoother of one-dimensional bins that applies an sinus/cosinus
+    fit to smooth the bin values of y (as received from the profile function in
+    the fit) and returns the polynomial values as the prediction.
+
+    By default, SeasonalSmoother uses the the function  ``f(x) = c_const +
+    c_sin * np.sin(x) + c_cos * np.cos(x)`` for the fit. The constant offset
+    ``c_const`` is ignored if ``offset_tozero`` is set ot ``True`` (default).
+    With higher ``order``, terms with frequency ``2*x`` and possibly ``3*x``
+    are added.
+
+    Instead of specifying an order, a custom fit-function can be supplied via
+    the ``custom_fit_function`` argument.
+
+    Parameters
+    ----------
+    offset_tozero : bool
+        If ``True`` sets the constant offset to zero (default=True)
+
+    order : int
+        Order k of the series sin(k * x) + cos(k * x). Per default this
+        is 1 and supported for order 2 and 3.
+
+    custom_fit_function : function
+        User defined function to define a custom fit function for the
+        seasonal smoother. In this case the order parameter is ignored.
+
+    fallback_value: float
+        User defined parameter that is used when the fit does not converge
+    Notes
+    -----
+    .. code::
+
+        def my_custom_fit_function(x, *params):
+            return ...
+
+    **Required columns** in the ``X_for_smoother`` passed to :meth:`fit`:
+
+    * column 0: ...
+    * column 1: ignored
+    * column 2: uncertainty of the average ``y`` in each bin
+
+    These are provided by the following **profile functions**:
+
+    * :class:`BetaMeanSigmaProfile`
+    * :class:`MeanProfile`
+
+    Attributes
+    ----------
+
+    frequency_: float
+        Frequency calculated from the maximum binnumber.
+
+    par_: numpy.ndarray
+        Parameters from the fit.
+    """
+
+    def __init__(self, offset_tozero=True, order=1, custom_fit_function=None, fallback_value=0.0):
+        self.offset_tozero = offset_tozero
+        self.order = order
+        self.custom_fit_function = custom_fit_function
+        if custom_fit_function is None:
+            self.fit_function = _choose_default_fit_function(order)
+        else:
+            self.fit_function = custom_fit_function
+            if order != 1:
+                warnings.warn("You specified a `custom_fit_function` thus " "the `order` parameter will be ignored!")
+        self.converged = None
+        self.fallback_value = fallback_value
+
+    def transform_X(self, X):
+        return 2 * np.pi * X[:, 0] * self.frequency_
+
+    def fit(self, X_for_smoother, y):
+        self.frequency_ = 1.0 / len(X_for_smoother)
+        xdata = self.transform_X(X_for_smoother)
+        try:
+            self.par_, _ = scipy.optimize.curve_fit(self.fit_function, xdata=xdata, ydata=y, sigma=X_for_smoother[:, 2])
+            if self.offset_tozero:
+                self.par_[0] = 0.0
+        except TypeError:
+            warnings.warn("Seasonal Smoother did not converge. Fallback value is used")
+            self.converged = False
+        else:
+            self.converged = True
+
+        return self
+
+    def predict(self, X):
+        if self.converged or self.converged is None:
+            if not hasattr(self, "par_"):
+                raise ValueError("The {} has not been fitted!".format(self.__class__.__name__))
+            return self.fit_function(self.transform_X(X), *self.par_)
+        else:
+            return np.ones(len(X), dtype=np.float64) * self.fallback_value
+
+
+class SeasonalLassoSmoother(AbstractBinSmoother):
+    """
+    Seasonal Smoother of one-dimensional bins that applies a first order sine/cosine
+    fit to smooth the bin values of y and returns the smoothed values as the prediction.
+
+    Lasso Regularization is used to reduce the influence of outliers.
+
+    If the number of days in the year where data is available remains below the configured
+    threshold, the fallback value 0 is returned.
+
+    Parameters
+    ----------
+    min_days : int
+        The smoother is only fitted if more than `min_days` bins of data are available.
+        Otherwise, it is set to fallback_mode and no smoothing is done. (default=300)
+
+    Notes
+    -----
+
+    **Required columns** in the ``X_for_smoother`` passed to :meth:`fit`:
+
+    * column 0: ...
+    * column 1: The number of samples in the bin
+    * column 2: uncertainty of the average ``y`` in each bin (ignored)
+
+    Attributes
+    ----------
+
+    est: sklearn.estimator
+        The fitted sklearn.LassoLarsIC estimator
+
+    """
+
+    def __init__(self, min_days=300):
+        self.min_days = min_days
+        self.max_bin = None
+        self.est = None
+        self.fallback_mode = None
+
+    def prepare_X(self, x):
+        x1 = 2 * np.pi * x / self.max_bin
+        X = np.c_[
+            np.sin(x1),
+            np.cos(x1),
+            -np.sin(x1),
+            -np.cos(x1),
+        ]
+        return X
+
+    def _fallback_predict(self, X):
+        return np.zeros(len(X), dtype=np.float64)
+
+    def predict(self, X):
+        if not self.fallback_mode:
+            if not self.est:
+                raise ValueError("The {} has not been fitted!".format(self.__class__.__name__))
+            Xt = self.prepare_X(X[:, 0])
+            return self.est.predict(Xt)
+        else:
+            return self._fallback_predict(X)
+
+    def fit(self, X_for_smoother, y):
+        self.max_bin = X_for_smoother[-1, 0]
+        days_with_samples = X_for_smoother[:, 1] > 0
+        X_for_smoother = X_for_smoother[days_with_samples, :]
+        y = y[days_with_samples]
+
+        if len(y) < self.min_days:
+            self.fallback_mode = True
+        else:
+            self.fallback_mode = False
+            X = self.prepare_X(X_for_smoother[:, 0].copy())
+            self.est = LassoLarsIC(positive=True, fit_intercept=False)
+            self.est.fit(X, y)
+        return self
+
+
+class PriorExpectationMetaSmoother(AbstractBinSmoother, PredictingBinValueMixin):
+    """Meta-Smoother that takes another one-dimensional smoother which
+    results are additionally smoothed using
+    :func:`cyclic_boosting.utils.regularize_to_prior_expectation`.
+
+    :param prior_expectation: The prior dominate the regularized value if the
+        uncertainties are large.
+    :type prior_expectation: :class:`numpy.ndarray` (float64, dim=1) or float
+
+    :param threshold: Threshold in terms of sigma. If the significance of a
+        value:
+
+        .. math::
+
+            \text{sig}(x_i) = \frac{x_i - \text{prior_{expectation}_i}
+            {\text{uncertainty}_i}
+
+        is below the threshold, the prior expectation replaces the value.
+    :type threshold: float
+    """
+
+    def __init__(self, est, prior_expectation, threshold=2.5):
+        self.est = est
+        self.prior_expectation = prior_expectation
+        self.threshold = threshold
+
+    def fit(self, X_for_smoother, y):
+        self.est.fit(X_for_smoother.copy(), y)
+        self.smoothed_y_ = utils.regularize_to_prior_expectation(
+            self.est.predict(X_for_smoother.copy()),
+            X_for_smoother[:, 2],
+            self.prior_expectation,
+            threshold=self.threshold,
+        )
+        return self
+
+
+class UnivariateSplineSmoother(AbstractBinSmoother):
+    r"""Smoother of one-dimensional bins that applies a univariate spline fit to
+    smooth the bin values of y (as received from the profile function in the
+    fit) and returns the spline values as the prediction.
+
+    This class delegates to :class:`scipy.interpolate.UnivariateSpline`.
+
+    **Required columns** in the ``X_for_smoother`` passed to :meth:`fit`:
+
+    * column 0: ...
+    * column 1: weight sum in each bin
+
+    These are provided by the following **profile functions**:
+
+    * :class:`MeanProfile`
+    * :class:`BetaMeanSigmaProfile`
+
+    :param k: Degree of the smoothing spline, must be ``<= 5``. The number of
+        the data points must be larger than the spline degree.
+    :type k: int
+
+    :param s: Positive smoothing factor used to choose the number of knots.
+        The number of knots will be increased until the smoothing condition is
+        satisfied:
+
+        .. math::
+
+            \sum_i w_i \cdot (y_i - s(x_i))^2 \le s
+
+        If `None` (default), ``s = len(w)`` is taken which should be a good
+        value if ``1 / w[i]`` is an estimate of the standard deviation of
+        ``y[i]``. If 0, the spline will interpolate through all data points.
+
+        See :class:`scipy.interpolate.UnivariateSpline`.
+    :type s: :obj:`float` or `None`
+
+    **Estimated parameters**
+
+    :param `spline_`: spline function that can be applied to ``x`` values
+    :type `spline_`: :class:`scipy.interpolate.UnivariateSpline`
+    """
+
+    def __init__(self, k=3, s=None):
+        self.k = k
+        self.s = s
+
+    def fit(self, X_for_smoother, y):
+        self.spline_ = scipy.interpolate.UnivariateSpline(
+            np.asarray(X_for_smoother[:, 0], dtype=np.float64),
+            np.asarray(y, dtype=np.float64),
+            w=np.asarray(X_for_smoother[:, 1], dtype=np.float64),
+            k=self.k,
+            s=self.s,
+        )
+
+        return self
+
+    def predict(self, X):
+        if not hasattr(self, "spline_"):
+            raise ValueError("The {} has not been fitted!".format(self.__class__.__name__))
+        return self.spline_(np.asarray(X[:, 0], dtype=np.float64))
+
+
+class PolynomialSmoother(AbstractBinSmoother):
+    r"""Least squares polynomial fit.
+
+    Fit a polynomial ``p(x) = p[0] * x**deg + ... + p[deg]`` of degree `deg`
+    to points `(x, y)`. Returns a vector of coefficients `p` that minimises
+    the squared error.
+
+    This class delegates to :class:`numpy.polyfit`.
+
+    **Required columns** in the ``X_for_smoother`` passed to :meth:`fit`:
+
+    * column 0: ...
+    * column 1: ignored
+    * column 2: uncertainty of the average ``y`` in each bin
+
+    These are provided by the following **profile functions**:
+
+    * :class:`MeanProfile`
+    * :class:`BetaMeanSigmaProfile`
+
+    :param k: Degree of the polynomial.
+    :type k: int
+
+    **Estimated parameters**
+
+    :param `coefficients_`: Array of coefficients.
+    :type `coefficients_`: :class:`numpy.ndarray` of length k
+    """
+
+    def __init__(self, k):
+        self.k = k
+
+    def fit(self, X_for_smoother, y):
+        sigma = np.asarray(X_for_smoother[:, 2], dtype=np.float64)
+        w = 1.0 / (sigma * sigma)
+        self.coefficients_ = np.polyfit(
+            np.asarray(X_for_smoother[:, 0], dtype=np.float64),
+            np.asarray(y, dtype=np.float64),
+            self.k,
+            w=w,
+        )
+        return self
+
+    def predict(self, X):
+        if not hasattr(self, "coefficients_"):
+            raise ValueError("The {} has not been fitted!".format(self.__class__.__name__))
+        x = np.asarray(X[:, 0], dtype=np.float64)
+        return np.polyval(self.coefficients_, x)
+
+
+class LinearSmoother(PolynomialSmoother):
+    r"""Least squares linear fit (special case of PolynomialSmoother).
+
+    Fit a linear curve ``p(x) = p[0] * x + p[1]`` to points `(x, y)`.
+    Returns a vector of coefficients `p` that minimises
+    the squared error.
+
+    This class delegates to :class:`numpy.polyfit`.
+
+    **Required columns** in the ``X_for_smoother`` passed to :meth:`fit`:
+
+    * column 0: ...
+    * column 1: ignored
+    * column 2: uncertainty of the average ``y`` in each bin
+
+    :param fallback_when_negative_slope: Enforce non negative slope of linear fit. If negative
+        slope is encountered, only the intercept is fitted. (Default=False)
+    :type fallback_when_negative_slope: bool
+
+    **Estimated parameters**
+
+    :param `coefficients_`: Array of coefficients.
+    :type `coefficients_`: :class:`numpy.ndarray` of length k
+    """
+
+    def __init__(self, fallback_when_negative_slope=False):
+        self.fallback_when_negative_slope = fallback_when_negative_slope
+
+    def fit(self, X_for_smoother, y):
+        sigma = np.asarray(X_for_smoother[:, 2], dtype=np.float64)
+        w = 1.0 / (sigma * sigma)
+        x = X_for_smoother[:, 0]
+        deg = 0 if len(x) <= 1 else 1
+        self.coefficients_ = np.polyfit(
+            np.asarray(x, dtype=np.float64),
+            np.asarray(y, dtype=np.float64),
+            deg,
+            w=w,
+        )
+        if self.fallback_when_negative_slope is True and self.coefficients_[0] < 0:
+            self.coefficients_ = np.polyfit(
+                np.asarray(x, dtype=np.float64),
+                np.asarray(y, dtype=np.float64),
+                0,
+                w=w,
+            )
+        return self
+
+
+class LSQUnivariateSpline(AbstractBinSmoother):
+    r"""
+    Wrapper which delegates to :class:`scipy.interpolate.LSQUnivariateSpline`.
+
+    Parameters
+    ----------
+
+    degree : int
+        Degree of the smoothing spline, must be ``1 <= k <= 5``. The number of
+        data points must be greater than the spline degree.
+
+    interior_knots : list
+        Interior knots of the spline. Must be in ascending order.
+    """
+
+    def __init__(self, interior_knots, degree=3):
+        self.degree = degree
+        self.interior_knots = interior_knots
+        self.fitted_spline = None
+
+    def fit(self, X_for_smoother, y):
+        check_spline_degree = self.degree <= 5 and self.degree < len(X_for_smoother)
+        if check_spline_degree:
+            X = X_for_smoother.astype(np.float64)
+            x = X[:, 0]
+            y = y.astype(np.float64)
+            t = np.asanyarray(self.interior_knots, dtype=np.float64)
+            w = X[:, 1]
+            k = self.degree
+            self.fitted_spline = scipy.interpolate.LSQUnivariateSpline(x, y, t, w, k=k)
+        else:
+            raise ValueError(
+                "Spline degree equals {}. Must be <= 5 and less" " than the available data points".format(self.degree)
+            )
+        return self
+
+    def predict(self, X):
+        if self.fitted_spline is None:
+            raise ValueError("LSQUnivariateSpline has not been fitted!")
+        return self.fitted_spline(X.astype(np.float64)[:, 0])
+
+
+class IsotonicRegressor(AbstractBinSmoother):
+    r"""
+    Wrapper which delegates to :class:`sklearn.isotonic.IsotonicRegression`.
+    Use if you expect a feature to be monotonic. An example is given in
+    http://scikit-learn.org/stable/modules/isotonic.html .
+
+    Parameters
+    ----------
+    increasing : boolean or string, optional, default: "auto"
+        If boolean, whether or not to fit the isotonic regression with y
+        increasing or decreasing.
+
+        The string value "auto" determines whether y should
+        increase or decrease based on the Spearman correlation estimate's
+        sign.
+
+    Note
+    ----
+
+    X requires the following columns.
+
+    column0 :
+        ...
+    column1 :
+        ignored
+    column2 :
+        weights
+    """
+
+    def __init__(self, increasing="auto"):
+        self.est_ = None
+        self.increasing = increasing
+
+    def fit(self, X_for_smoother, y):
+        X = X_for_smoother.astype(np.float64)
+        sigma = X[:, 2]
+        sigma = np.where(sigma > 0, sigma, 1e12)
+        w = 1.0 / (sigma * sigma)
+        self.est_ = sklearn.isotonic.IsotonicRegression(increasing=self.increasing, out_of_bounds="clip")
+        self.est_.fit(X[:, 0], y.astype(np.float64), sample_weight=w)
+        return self
+
+    def predict(self, X):
+        if self.est_ is None:
+            raise ValueError("IsotonicRegressor has not been fitted!")
+        return self.est_.predict(X.astype(np.float64)[:, 0])
+
+
+__all__ = [
+    "PredictingBinValueMixin",
+    "BinValuesSmoother",
+    "RegularizeToPriorExpectationSmoother",
+    "RegularizeToOneSmoother",
+    "WeightedMeanSmoother",
+    "UnivariateSplineSmoother",
+    "OrthogonalPolynomialSmoother",
+    "SeasonalSmoother",
+    "SeasonalLassoSmoother",
+    "PolynomialSmoother",
+    "LSQUnivariateSpline",
+    "IsotonicRegressor",
+]

--- a/skpro/libs/cyclic_boosting/smoothing/onedim.py
+++ b/skpro/libs/cyclic_boosting/smoothing/onedim.py
@@ -19,7 +19,7 @@ from skpro.libs.cyclic_boosting.smoothing.orthofit import (
 )
 
 
-class PredictingBinValueMixin(object):
+class PredictingBinValueMixin:
     """Mixin for smoothers of one-dimensional bins with :meth:`predict`
     returning the corresponding entry in the estimated parameter
     ``smoothed_y_`` which must have been calculated in :meth:`fit`.
@@ -40,10 +40,14 @@ class PredictingBinValueMixin(object):
 
     def predict(self, X):
         if not hasattr(self, "smoothed_y_"):
-            raise ValueError("The {} has not been fitted!".format(self.__class__.__name__))
+            raise ValueError(f"The {self.__class__.__name__} has not been fitted!")
         binnos = X[:, 0]
         binnos_round = np.asarray(np.rint(binnos), dtype=np.int64)
-        is_valid = np.isfinite(binnos) & (binnos >= 0) & (binnos_round < (len(self.smoothed_y_)))
+        is_valid = (
+            np.isfinite(binnos)
+            & (binnos >= 0)
+            & (binnos_round < (len(self.smoothed_y_)))
+        )
 
         pred = utils.nans(len(binnos))
         pred[is_valid] = self.smoothed_y_[binnos_round[is_valid]]
@@ -101,7 +105,9 @@ class BinValuesSmoother(AbstractBinSmoother, PredictingBinValueMixin):
         self.__dict__.update(state)
 
 
-class RegularizeToPriorExpectationSmoother(AbstractBinSmoother, PredictingBinValueMixin):
+class RegularizeToPriorExpectationSmoother(
+    AbstractBinSmoother, PredictingBinValueMixin
+):
     r"""Smoother of one-dimensional bins regularizing values with uncertainties
     to a prior expectation.
 
@@ -169,7 +175,9 @@ class RegularizeToOneSmoother(RegularizeToPriorExpectationSmoother):
     """
 
     def __init__(self, threshold=2.5):
-        RegularizeToPriorExpectationSmoother.__init__(self, prior_expectation=1, threshold=threshold)
+        RegularizeToPriorExpectationSmoother.__init__(
+            self, prior_expectation=1, threshold=threshold
+        )
 
 
 class WeightedMeanSmoother(AbstractBinSmoother, PredictingBinValueMixin):
@@ -216,7 +224,9 @@ class WeightedMeanSmoother(AbstractBinSmoother, PredictingBinValueMixin):
         self.prior_prediction = prior_prediction
 
     def fit(self, X_for_smoother, y):
-        self.smoothed_y_ = utils.regularize_to_error_weighted_mean(y, X_for_smoother[:, 2], self.prior_prediction)
+        self.smoothed_y_ = utils.regularize_to_error_weighted_mean(
+            y, X_for_smoother[:, 2], self.prior_prediction
+        )
 
 
 class WeightedMeanSmootherNeighbors(AbstractBinSmoother, PredictingBinValueMixin):
@@ -228,9 +238,13 @@ class WeightedMeanSmootherNeighbors(AbstractBinSmoother, PredictingBinValueMixin
 
     def fit(self, X_for_smoother, y):
         if len(y) < 3:
-            self.smoothed_y_ = utils.regularize_to_error_weighted_mean(y, X_for_smoother[:, 2])
+            self.smoothed_y_ = utils.regularize_to_error_weighted_mean(
+                y, X_for_smoother[:, 2]
+            )
         else:
-            self.smoothed_y_ = utils.regularize_to_error_weighted_mean_neighbors(y, X_for_smoother[:, 2], window_size=3)
+            self.smoothed_y_ = utils.regularize_to_error_weighted_mean_neighbors(
+                y, X_for_smoother[:, 2], window_size=3
+            )
 
 
 class OrthogonalPolynomialSmoother(AbstractBinSmoother):
@@ -255,7 +269,7 @@ class OrthogonalPolynomialSmoother(AbstractBinSmoother):
     def predict(self, X):
         assert X.ndim == 2
         if not hasattr(self, "pp_"):
-            raise ValueError("The {} has not been fitted!".format(self.__class__.__name__))
+            raise ValueError(f"The {self.__class__.__name__} has not been fitted!")
         x = np.ascontiguousarray(X[:, 0], dtype=np.float64)
         x[x < self.minimal_x] = self.minimal_x
         x[x > self.maximal_x] = self.maximal_x
@@ -283,10 +297,18 @@ def _seasonality_first_order(x, c_const, c_sin, c_cos):
 
 
 def _seasonality_second_order(x, c_const, c_sin_1x, c_cos_1x, c_sin_2x, c_cos_2x):
-    return c_const + c_sin_1x * np.sin(x) + c_cos_1x * np.cos(x) + c_sin_2x * np.sin(2 * x) + c_cos_2x * np.cos(2 * x)
+    return (
+        c_const
+        + c_sin_1x * np.sin(x)
+        + c_cos_1x * np.cos(x)
+        + c_sin_2x * np.sin(2 * x)
+        + c_cos_2x * np.cos(2 * x)
+    )
 
 
-def _seasonality_third_order(x, c_const, c_sin_1x, c_cos_1x, c_sin_2x, c_cos_2x, c_sin_3x, c_cos_3x):
+def _seasonality_third_order(
+    x, c_const, c_sin_1x, c_cos_1x, c_sin_2x, c_cos_2x, c_sin_3x, c_cos_3x
+):
     return (
         c_const
         + c_sin_1x * np.sin(x)
@@ -355,7 +377,9 @@ class SeasonalSmoother(AbstractBinSmoother):
         Parameters from the fit.
     """
 
-    def __init__(self, offset_tozero=True, order=1, custom_fit_function=None, fallback_value=0.0):
+    def __init__(
+        self, offset_tozero=True, order=1, custom_fit_function=None, fallback_value=0.0
+    ):
         self.offset_tozero = offset_tozero
         self.order = order
         self.custom_fit_function = custom_fit_function
@@ -364,7 +388,10 @@ class SeasonalSmoother(AbstractBinSmoother):
         else:
             self.fit_function = custom_fit_function
             if order != 1:
-                warnings.warn("You specified a `custom_fit_function` thus " "the `order` parameter will be ignored!")
+                warnings.warn(
+                    "You specified a `custom_fit_function` thus "
+                    "the `order` parameter will be ignored!"
+                )
         self.converged = None
         self.fallback_value = fallback_value
 
@@ -375,7 +402,9 @@ class SeasonalSmoother(AbstractBinSmoother):
         self.frequency_ = 1.0 / len(X_for_smoother)
         xdata = self.transform_X(X_for_smoother)
         try:
-            self.par_, _ = scipy.optimize.curve_fit(self.fit_function, xdata=xdata, ydata=y, sigma=X_for_smoother[:, 2])
+            self.par_, _ = scipy.optimize.curve_fit(
+                self.fit_function, xdata=xdata, ydata=y, sigma=X_for_smoother[:, 2]
+            )
             if self.offset_tozero:
                 self.par_[0] = 0.0
         except TypeError:
@@ -389,7 +418,7 @@ class SeasonalSmoother(AbstractBinSmoother):
     def predict(self, X):
         if self.converged or self.converged is None:
             if not hasattr(self, "par_"):
-                raise ValueError("The {} has not been fitted!".format(self.__class__.__name__))
+                raise ValueError(f"The {self.__class__.__name__} has not been fitted!")
             return self.fit_function(self.transform_X(X), *self.par_)
         else:
             return np.ones(len(X), dtype=np.float64) * self.fallback_value
@@ -450,7 +479,7 @@ class SeasonalLassoSmoother(AbstractBinSmoother):
     def predict(self, X):
         if not self.fallback_mode:
             if not self.est:
-                raise ValueError("The {} has not been fitted!".format(self.__class__.__name__))
+                raise ValueError(f"The {self.__class__.__name__} has not been fitted!")
             Xt = self.prepare_X(X[:, 0])
             return self.est.predict(Xt)
         else:
@@ -568,7 +597,7 @@ class UnivariateSplineSmoother(AbstractBinSmoother):
 
     def predict(self, X):
         if not hasattr(self, "spline_"):
-            raise ValueError("The {} has not been fitted!".format(self.__class__.__name__))
+            raise ValueError(f"The {self.__class__.__name__} has not been fitted!")
         return self.spline_(np.asarray(X[:, 0], dtype=np.float64))
 
 
@@ -617,7 +646,7 @@ class PolynomialSmoother(AbstractBinSmoother):
 
     def predict(self, X):
         if not hasattr(self, "coefficients_"):
-            raise ValueError("The {} has not been fitted!".format(self.__class__.__name__))
+            raise ValueError(f"The {self.__class__.__name__} has not been fitted!")
         x = np.asarray(X[:, 0], dtype=np.float64)
         return np.polyval(self.coefficients_, x)
 
@@ -703,7 +732,8 @@ class LSQUnivariateSpline(AbstractBinSmoother):
             self.fitted_spline = scipy.interpolate.LSQUnivariateSpline(x, y, t, w, k=k)
         else:
             raise ValueError(
-                "Spline degree equals {}. Must be <= 5 and less" " than the available data points".format(self.degree)
+                "Spline degree equals {}. Must be <= 5 and less"
+                " than the available data points".format(self.degree)
             )
         return self
 
@@ -751,7 +781,9 @@ class IsotonicRegressor(AbstractBinSmoother):
         sigma = X[:, 2]
         sigma = np.where(sigma > 0, sigma, 1e12)
         w = 1.0 / (sigma * sigma)
-        self.est_ = sklearn.isotonic.IsotonicRegression(increasing=self.increasing, out_of_bounds="clip")
+        self.est_ = sklearn.isotonic.IsotonicRegression(
+            increasing=self.increasing, out_of_bounds="clip"
+        )
         self.est_.fit(X[:, 0], y.astype(np.float64), sample_weight=w)
         return self
 

--- a/skpro/libs/cyclic_boosting/smoothing/orthofit.py
+++ b/skpro/libs/cyclic_boosting/smoothing/orthofit.py
@@ -1,0 +1,167 @@
+
+import numba as nb
+import numpy as np
+
+N_COEFFICIENTS = 5
+N_PARAMETERS = 21
+
+
+@nb.njit()
+def cy_orthogonal_poly_fit_equidistant(binnos: nb.float64[:], y_values: nb.float64[:], y_errors: nb.float64[:]):
+    weights = np.empty(y_errors.shape[0])
+    parameters = np.empty((N_PARAMETERS, N_COEFFICIENTS))
+
+    for j in range(y_errors.shape[0]):
+        weights[j] = 1.0 / (y_errors[j] * y_errors[j])
+
+    n_degrees = fit_orthogonal_poly_(binnos, y_values, weights, parameters)
+
+    n_significant_parameters = significant_parameters_(parameters, n_degrees, len(y_values))
+    n_degrees = reduce_to_signifcant_parameters(n_significant_parameters, parameters, n_degrees, len(y_values))
+    return parameters, n_degrees
+
+
+@nb.njit()
+def fit_orthogonal_poly_(
+    x: nb.float64[:],
+    y: nb.float64[:],
+    weights: nb.float64[:],
+    parameters: nb.float64[:],
+) -> nb.float64:
+    n_supporting_points = x.shape[0]
+    alpha = 0.0
+    beta = 0.0
+    gamma = 0.0
+    delta = 0.0
+    scratch = np.empty((2, x.shape[0]))
+
+    for j in range(n_supporting_points):
+        delta += weights[j] * y[j]
+        gamma += weights[j]
+
+    n_degrees = min(N_PARAMETERS, n_supporting_points)
+
+    if gamma != 0.0:
+        gamma = 1.0 / np.sqrt(gamma)
+
+    delta *= gamma
+
+    sum_squared = 0.0
+
+    for k in range(n_supporting_points):
+        tmp = y[k] - gamma * delta
+        sum_squared += weights[k] * tmp * tmp
+        scratch[0, k] = gamma
+        scratch[1, k] = 0.0
+
+    parameters[0, 0] = alpha
+    parameters[0, 1] = beta
+    parameters[0, 2] = gamma
+    parameters[0, 3] = delta
+    parameters[0, 4] = sum_squared
+
+    # recursive loop for higher terms
+    ii = 1
+    for k in range(1, n_degrees):
+        ii = 3 - ii
+        alpha = 0.0
+        beta = 0.0
+        for j in range(0, n_supporting_points):
+            alpha += weights[j] * x[j] * scratch[3 - ii - 1, j] * scratch[3 - ii - 1, j]
+            beta += weights[j] * x[j] * scratch[ii - 1, j] * scratch[3 - ii - 1, j]
+
+        gamma = 0.0
+        for j in range(0, n_supporting_points):
+            scratch[ii - 1, j] = (x[j] - alpha) * scratch[3 - ii - 1, j] - beta * scratch[ii - 1, j]
+            gamma += weights[j] * scratch[ii - 1, j] * scratch[ii - 1, j]
+
+        if gamma != 0.0:
+            gamma = 1.0 / np.sqrt(gamma)
+
+        delta = 0.0
+        for j in range(0, n_supporting_points):
+            scratch[ii - 1, j] *= gamma
+            delta += weights[j] * scratch[ii - 1, j] * y[j]
+
+        sum_squared = max(0.0, sum_squared - delta * delta)
+        parameters[k, 0] = alpha
+        parameters[k, 1] = beta
+        parameters[k, 2] = gamma
+        parameters[k, 3] = delta
+        parameters[k, 4] = sum_squared
+    parameters[0, 1] = 1.0
+    parameters[0, 0] = np.nan
+    return n_degrees
+
+
+@nb.njit()
+def significant_parameters_(parameters, n_degrees, n_supporting_points):
+    result = n_degrees
+    npp = 0
+
+    if result < 3:
+        return result
+
+    for k in range(2, n_degrees):
+        result = k + 1
+        # chi^2 < ndf
+        if parameters[k, 4] < n_supporting_points - (k + 1):
+            break
+        # 3.84 = chi2(parameters=0.95, ndf=1)
+        if parameters[k, 3] ** 2 < 3.84:
+            npp += 1
+        # 5.99 = chi2(parameter_arr=0.95,ndf=2)
+        if parameters[k, 3] ** 2 + parameters[k - 1, 3] ** 2 < 6.0:
+            npp += 1
+        if npp >= 4:
+            break
+    return result
+
+
+@nb.njit()
+def custom_clip(value, lower, upper):
+    if value >= lower and value <= upper:
+        return value
+    elif value < lower:
+        return lower
+    elif value > upper:
+        return upper
+
+
+@nb.njit()
+def reduce_to_signifcant_parameters(n_signi_par, parameters, n_degrees, n_supporting_points):
+    n_degrees = min(n_degrees, n_signi_par)
+    if n_degrees == n_supporting_points:
+        if n_supporting_points > 2:
+            n_degrees = custom_clip(int(n_supporting_points * 0.2), 2, N_PARAMETERS)
+        else:
+            n_degrees = 1
+
+    # this line may have divisions by zero, which are also present in the
+    # fortran equivalent
+    diff = n_supporting_points - n_degrees
+    if diff > 0.0:
+        parameters[0, 1] = parameters[n_degrees - 1, 4] / diff
+
+    return n_degrees
+
+
+@nb.njit()
+def cy_apply_orthogonal_poly_fit_equidistant(binnos, parameters, n_degrees):
+    n_supporting_points = binnos.shape[0]
+    result = np.empty(n_supporting_points)
+    values = np.empty(2)
+
+    for i in range(n_supporting_points):
+        values[0] = parameters[0, 2]
+        values[1] = 0.0
+        y_estimate = parameters[0, 2] * parameters[0, 3]
+        j = 1
+        for k in range(1, n_degrees):
+            j = 3 - j
+            values[j - 1] = (
+                (binnos[i] - parameters[k, 0]) * values[2 - j] - parameters[k, 1] * values[j - 1]
+            ) * parameters[k, 2]
+            y_estimate += parameters[k, 3] * values[j - 1]
+        result[i] = y_estimate
+    return result

--- a/skpro/libs/cyclic_boosting/smoothing/orthofit.py
+++ b/skpro/libs/cyclic_boosting/smoothing/orthofit.py
@@ -1,4 +1,3 @@
-
 import numba as nb
 import numpy as np
 
@@ -7,7 +6,9 @@ N_PARAMETERS = 21
 
 
 @nb.njit()
-def cy_orthogonal_poly_fit_equidistant(binnos: nb.float64[:], y_values: nb.float64[:], y_errors: nb.float64[:]):
+def cy_orthogonal_poly_fit_equidistant(
+    binnos: nb.float64[:], y_values: nb.float64[:], y_errors: nb.float64[:]
+):
     weights = np.empty(y_errors.shape[0])
     parameters = np.empty((N_PARAMETERS, N_COEFFICIENTS))
 
@@ -16,8 +17,12 @@ def cy_orthogonal_poly_fit_equidistant(binnos: nb.float64[:], y_values: nb.float
 
     n_degrees = fit_orthogonal_poly_(binnos, y_values, weights, parameters)
 
-    n_significant_parameters = significant_parameters_(parameters, n_degrees, len(y_values))
-    n_degrees = reduce_to_signifcant_parameters(n_significant_parameters, parameters, n_degrees, len(y_values))
+    n_significant_parameters = significant_parameters_(
+        parameters, n_degrees, len(y_values)
+    )
+    n_degrees = reduce_to_signifcant_parameters(
+        n_significant_parameters, parameters, n_degrees, len(y_values)
+    )
     return parameters, n_degrees
 
 
@@ -72,7 +77,9 @@ def fit_orthogonal_poly_(
 
         gamma = 0.0
         for j in range(0, n_supporting_points):
-            scratch[ii - 1, j] = (x[j] - alpha) * scratch[3 - ii - 1, j] - beta * scratch[ii - 1, j]
+            scratch[ii - 1, j] = (x[j] - alpha) * scratch[
+                3 - ii - 1, j
+            ] - beta * scratch[ii - 1, j]
             gamma += weights[j] * scratch[ii - 1, j] * scratch[ii - 1, j]
 
         if gamma != 0.0:
@@ -129,7 +136,9 @@ def custom_clip(value, lower, upper):
 
 
 @nb.njit()
-def reduce_to_signifcant_parameters(n_signi_par, parameters, n_degrees, n_supporting_points):
+def reduce_to_signifcant_parameters(
+    n_signi_par, parameters, n_degrees, n_supporting_points
+):
     n_degrees = min(n_degrees, n_signi_par)
     if n_degrees == n_supporting_points:
         if n_supporting_points > 2:
@@ -160,7 +169,8 @@ def cy_apply_orthogonal_poly_fit_equidistant(binnos, parameters, n_degrees):
         for k in range(1, n_degrees):
             j = 3 - j
             values[j - 1] = (
-                (binnos[i] - parameters[k, 0]) * values[2 - j] - parameters[k, 1] * values[j - 1]
+                (binnos[i] - parameters[k, 0]) * values[2 - j]
+                - parameters[k, 1] * values[j - 1]
             ) * parameters[k, 2]
             y_estimate += parameters[k, 3] * values[j - 1]
         result[i] = y_estimate

--- a/skpro/libs/cyclic_boosting/utils.py
+++ b/skpro/libs/cyclic_boosting/utils.py
@@ -1,0 +1,1132 @@
+import copy
+import logging
+import warnings
+
+import decorator
+import numba as nb
+import numpy as np
+import pandas as pd
+
+
+from typing import Iterable, List, Optional
+
+from dataclasses import dataclass
+
+_logger = logging.getLogger(__name__)
+
+
+LOWER_1_SIGMA_QUANTILE = (1.0 - 0.6827) / 2
+LOWER_2_SIGMA_QUANTILE = (1.0 - 0.9545) / 2
+
+
+class ConvergenceError(RuntimeError):
+    """Exception type, that should be thrown if an estimator cannot converge
+    and therefore its result cannot be trusted."""
+
+
+def not_seen_events(x, wx, n_bins):
+    """
+    Return a boolean array that slices x so that only values with
+    a non-finite weightsum `wx` are used.
+
+    Parameters
+    ----------
+    x: :class:`pandas.DataFrame` or :class:`numpy.ndarray`
+        Array can be of any dimension. The array has to consist
+        out of contigous integers.
+
+    wx: :class:`numpy.ndarray` weightsum of all bins occuring in x
+
+    n_bins: :class:`numpy.ndarray` of shape ``(M,)``
+        number of bins in each dimension
+
+    Example
+    -------
+    >>> x = np.c_[np.array([0, 1, 2, 3, 4, np.nan, -1])]
+    >>> wx = np.array([3, 2, 0, 1, 0])
+    >>> nbins = np.array([4, 1])
+    >>> from skpro.libs.cyclic_boosting.utils import not_seen_events
+    >>> not_seen_events(x, wx, nbins)
+    array([False, False, True, False,  True,  True,  True], dtype=bool)
+
+    >>> x = pd.DataFrame({"a": [0, 1, 0, 1, np.nan, 0, -1],
+    ...                   "b": [0, 0, 1, 1, 1, np.nan, -1]})
+    >>> wx = np.array([1, 0, 1, 0, 1])
+    >>> nbins = np.array([2, 2])
+    >>> not_seen_events(x, wx, nbins)
+    array([False, False, True, True, False, False, False], dtype=bool)
+    """
+    max_lex_bins = int(np.prod(n_bins))
+    not_seen = wx == 0.0
+
+    if len(not_seen) == max_lex_bins:
+        # Add nan-bin if not present yet.
+        not_seen = np.r_[not_seen, True]
+
+    finite_x = slice_finite_semi_positive(x)
+    if x.shape[1] > 1:
+        x, n_bins = multidim_binnos_to_lexicographic_binnos(x, n_bins)
+    else:
+        x = np.asarray(x).reshape(-1)
+    x = np.round(x)
+    x = np.asarray(x, dtype=int)
+    x = np.where(~finite_x | (x > max_lex_bins), max_lex_bins, x)
+
+    res = not_seen[x].reshape(-1)
+    return res
+
+
+def get_X_column(X, column, array_for_1_dim=True):
+    """
+    Picks columns from :class:`pandas.DataFrame` or :class:`numpy.ndarray`.
+
+    Parameters
+    ----------
+    X: :class:`pandas.DataFrame` or :class:`numpy.ndarray`
+        Data Source from which columns are picked.
+    column:
+        The format depends on the type of X. For :class:`pandas.DataFrame` you
+        can give a string or a list/tuple of strings naming the columns. For
+        :class:`numpy.ndarray` an integer or a list/tuple of integers indexing
+        the columns.
+    array_for_1_dim: bool
+        In default mode (set to True) the return type for a one dimensional
+        access is a np.ndarray with shape (n, ). If set to False it is a
+        np.ndarray with shape (1, n).
+    """
+    if isinstance(column, tuple):
+        column = list(column)
+    if not array_for_1_dim:
+        if not isinstance(column, list):
+            column = [column]
+    else:
+        if isinstance(column, list) and len(column) == 1:
+            column = column[0]
+    if isinstance(X, pd.DataFrame):
+        return X[column].values
+    else:
+        return X[:, column]
+
+
+def slice_finite_semi_positive(x):
+    """
+    Return slice of all finite and semi positive definite values of x
+
+    Parameters
+    ----------
+    x: :class:`pandas.DataFrame` or :class:`numpy.ndarray`
+        Array can be of any dimension.
+
+    Example
+    -------
+
+    >>> x = np.array([1, np.nan, 3, -2])
+    >>> from skpro.libs.cyclic_boosting.utils import slice_finite_semi_positive
+    >>> slice_finite_semi_positive(x)
+    array([ True, False,  True, False], dtype=bool)
+
+    >>> X = pd.DataFrame({'a': [1, np.nan, 3], 'b': [-1, 2, 3]})
+    >>> slice_finite_semi_positive(X)
+    array([False, False,  True], dtype=bool)
+    """
+    if isinstance(x, pd.DataFrame):
+        x = x.values
+
+    if len(x.shape) > 1:
+        finite_semi_positive = np.isfinite(x).all(axis=1)
+        m_pos = (x[finite_semi_positive] >= 0).all(axis=1)
+        finite_semi_positive[finite_semi_positive] &= m_pos
+
+    else:
+        finite_semi_positive = np.isfinite(x) & (x >= 0)
+
+    return np.asarray(finite_semi_positive)
+
+
+def nans(shape):
+    """Create a new numpy array filled with NaNs.
+
+    :param shape: shape of the :class:`numpy.ndarray`
+    :type shape: :obj:`int` or :obj:`tuple`
+
+    :rtype: :class:`numpy.ndarray` (numpy.nan, dim=1)
+
+    >>> from skpro.libs.cyclic_boosting.utils import nans
+    >>> nans(3)
+    array([ nan,  nan,  nan])
+
+    >>> nans((2, 2))
+    array([[ nan,  nan],
+           [ nan,  nan]])
+    """
+    result = np.empty(shape)
+    result.fill(np.nan)
+    return result
+
+
+def multidim_binnos_to_lexicographic_binnos(binnos, n_bins=None, binsteps=None):
+    """Map index-tuples of ``M``-dimensional features to integers.
+
+    In the cyclic boosting algorithm there is a one-dimensional array of
+    factors for each one-dimensional feature. For processing of
+    multi-dimensional variables (i.e. combinations of several one-dimensional
+    feature variables) we have bins for all bin combinations. For example, if
+    you have two one-dimensional features ``p`` and ``q`` with ``n_p`` and
+    ``n_q`` bins, the two-dimensional feature ``(p, q)`` will have a
+    two-dimensional factor array of shape ``(n_p, n_q)``.
+
+    The internal representation of this array, however, is that of a
+    one-dimensional array. Thus, a function is needed that maps index-tuples
+    ``(p, q,...)`` to integer indices.  This is the purpose of this function.
+
+    This function performs this mapping for ``N`` rows of index ``M``-tuples.
+
+    If there are any missing values in a row, the returned ordinal number is
+    set to ``np.prod(n_bins)``.
+
+    Parameters
+    ----------
+    binnos: :class:`numpy.ndarray` of shape ``(N, M)``
+        multidimensional bin numbers
+
+    n_bins: :class:`numpy.ndarray` of shape ``(M,)`` or `None`
+        number of bins in each dimension; if `None`, it will be determined from
+        ``binnos``.
+
+    binsteps: :class:`numpy.ndarray` of type `int64` and shape ``(M,)``
+        bin steps as returned by :func:`bin_steps` when called on ``n_bins``;
+        if `None`, it will be determined from ``binnos``.
+
+    Returns
+    -------
+    tuple
+        ordinal numbers of the bins in lexicographic order as
+        :class:`numpy.ndarray` of type `int64` and maximal bin numbers as
+        :class:`numpy.ndarray` of shape ``(M,)``
+
+    Examples
+    --------
+
+    >>> binnos = np.c_[[1, 1, 0, 0, np.nan, 1, np.nan],
+    ...                [0, 1, 2, 1, 1, 2, np.nan]]
+    >>> n_bins = np.array([2, 3])
+    >>> binsteps = bin_steps(n_bins)
+    >>> from skpro.libs.cyclic_boosting.utils import multidim_binnos_to_lexicographic_binnos
+    >>> lex_binnos, n_finite = multidim_binnos_to_lexicographic_binnos(
+    ...     binnos, n_bins=n_bins, binsteps=binsteps)
+    >>> lex_binnos
+    array([3, 4, 2, 1, 6, 5, 6])
+    >>> n_finite
+    array([2, 3])
+    >>> lex_binnos, n_finite =  multidim_binnos_to_lexicographic_binnos(binnos)
+    >>> lex_binnos
+    array([3, 4, 2, 1, 6, 5, 6])
+    >>> n_finite
+    array([2, 3])
+    """
+    if isinstance(binnos, pd.DataFrame):
+        binnos = binnos.values
+
+    if n_bins is None:
+        finite_bins = binnos[slice_finite_semi_positive(binnos)]
+        if len(finite_bins) == 0:
+            n_bins = np.zeros(binnos.shape[1], dtype=np.int64)
+        else:
+            n_bins = np.max(finite_bins, axis=0).astype(np.int64) + 1
+
+    if binsteps is None:
+        binsteps = bin_steps(n_bins)
+
+    is_valid = np.isfinite(binnos).all(axis=1)
+    is_valid[is_valid] &= ((binnos[is_valid] >= 0) & (binnos[is_valid] < n_bins[None, :])).all(axis=1)
+
+    if not np.any(is_valid):
+        result = np.repeat(0, len(binnos))
+    else:
+        result = np.repeat(np.prod(n_bins), len(binnos))
+
+    result[is_valid] = np.dot(np.floor(binnos[is_valid]), binsteps[1:])
+
+    if n_bins.prod() >= np.iinfo(np.int32).max:
+        _logger.warning(
+            "Enumerating multidimensional bins: A multidimensional feature of "
+            "shape {n_bins} requires {total_bins} unique bins in total. "
+            "Please consider whether this is what you want.".format(n_bins=n_bins, total_bins=n_bins.prod())
+        )
+    result = result.astype(np.int64)
+    return result, n_bins
+
+
+@nb.njit()
+def bin_steps(n_bins: nb.int64[:]):
+    """
+    Multidimensional bin steps for lexicographical order
+
+    :param n_bins: number of bins for each dimension
+    :type n_bins: ``numpy.ndarray`` (element-type ``float64``, shape ``(M,)``)
+
+    :return: in slot ``i + 1`` for dimension ``i``, the number of steps needed
+        for iterating through the following dimensions in lexicographical order
+        until the bin number can be increased for dimension ``i``.
+
+        See the doctests of :func:`arange_multi`: It's the number of rows between
+        changes in column ``i``.
+
+        In slot 0 this is the number steps needed to iterate through all
+        dimensions.
+    :rtype: ``numpy.ndarray`` (element-type ``int64``, shape ``(M + 1,)``)
+
+    >>> from skpro.libs.cyclic_boosting.utils import bin_steps
+    >>> bin_steps(np.array([3, 2]))
+    array([6, 2, 1])
+
+    >>> bin_steps(np.array([3, 2, 4, 1, 2]))
+    array([48, 16,  8,  2,  2,  1])
+    """
+    total_bin_steps = 1
+    M = n_bins.shape[0]
+    bin_steps = np.empty(M + 1, dtype=np.int64)
+
+    for m in range(M, -1, -1):
+        bin_steps[m] = total_bin_steps
+        total_bin_steps = n_bins[m - 1] * total_bin_steps
+
+    return bin_steps
+
+
+@nb.njit()
+def arange_multi(stops) -> np.ndarray:
+    """
+    Multidimensional generalization of :func:`numpy.arange`
+
+    :param stops: upper limits (exclusive) for the corresponding dimensions in
+        the result
+    :type stops: sequence of numbers
+
+    :return: matrix of combinations of range values in lexicographic order
+    :rtype: ``numpy.ndarray`` (element-type ``int64``, shape
+        ``(n_bins, len(stops))``)
+
+    >>> from skpro.libs.cyclic_boosting.utils import arange_multi
+    >>> arange_multi([2, 3])
+    array([[0, 0],
+           [0, 1],
+           [0, 2],
+           [1, 0],
+           [1, 1],
+           [1, 2]])
+
+    In this example, the last dimension has only one bin:
+
+    >>> arange_multi([3, 4, 1])
+    array([[0, 0, 0],
+           [0, 1, 0],
+           [0, 2, 0],
+           [0, 3, 0],
+           [1, 0, 0],
+           [1, 1, 0],
+           [1, 2, 0],
+           [1, 3, 0],
+           [2, 0, 0],
+           [2, 1, 0],
+           [2, 2, 0],
+           [2, 3, 0]])
+
+    >>> arange_multi([2])
+    array([[0],
+           [1]])
+    """
+    stops1 = np.asarray(stops)
+    M = stops1.shape[0]
+    bin_steps1 = bin_steps(stops1)
+    total_bin_steps = bin_steps1[0]
+
+    result = np.zeros((total_bin_steps, M), dtype=np.int64)
+
+    for m in range(M):
+        bin_steps_m = bin_steps1[m + 1]
+        binno = 0
+        for i in range(0, total_bin_steps, bin_steps_m):
+            for j in range(bin_steps_m):
+                result[i + j, m] = binno
+            binno += 1
+            if binno >= stops1[m]:
+                binno = 0
+
+    return result
+
+
+def calc_linear_bins(x, nbins):
+    """Calculate a linear binning for all values in x with nbins
+
+    :param x: Input array.
+    :type x: :obj:`list` or :class:`numpy.ndarray` (float64, dim=1)
+
+    :param nbins: number of bins desired
+    :type nbins: int
+
+    **Example**
+
+    >>> x = np.array([0.0, 0.1, 0.3, 0.4, 0.8, 0.9, 0.95, 1.1, 1.3, 1.5])
+    >>> nbins = 3
+    >>> from skpro.libs.cyclic_boosting.utils import calc_linear_bins
+    >>> bin_boundaries, bin_centers = calc_linear_bins(x, nbins)
+    >>> bin_centers
+    array([ 0.25,  0.75,  1.25])
+    >>> bin_boundaries
+    array([ 0. ,  0.5,  1. ,  1.5])
+    """
+    minx, maxx = np.min(x), np.max(x)
+    bin_boundaries = np.linspace(minx, maxx, nbins + 1)
+    bin_centers = 0.5 * (bin_boundaries[1:] + bin_boundaries[:-1])
+    return bin_boundaries, bin_centers
+
+
+def digitize(x, bins):
+    """
+    This is an alternative version of :func:`numpy.digitize`. It puts x values
+    greater or equal to bins.max() on the last index of `bins`.
+    Values smaller than bins.min() are put on the first index of `bins`.
+
+    :param x: Input array to be binned. It has to be 1-dimensional.
+    :type x: :obj:`list` or :class:`numpy.ndarray` (float64, dim=1)
+
+    :param bins: Array of bins. It has to be 1-dimensional and monotonic.
+    :type bins: :obj:`list` or :class:`numpy.ndarray` (float64, dim=1)
+
+    :return: Output array of indices, of same shape as `x`.
+    :rtype: :obj:`list` or :class:`numpy.ndarray` (float64, dim=1)
+
+    **Raises**
+
+    ValueError
+        If the input is not 1-dimensional, or if `bins` is not monotonic.
+    TypeError
+        If the type of the input is complex.
+
+    **See Also**
+
+    :func:`numpy.digitize`
+
+    **Notes**
+
+    If values in `x` are such that they fall outside the bin range,
+    attempting to index `bins` with the indices that `digitize` returns
+    will result in an IndexError.
+
+    **Examples**
+
+    >>> x = np.array([-1000, -0.2, 0.2, 6.4, 3.0, 10, 11, 1000])
+    >>> bins = np.array([0.0, 1.0, 2.5, 4.0, 10.0])
+    >>> from skpro.libs.cyclic_boosting.utils import digitize
+    >>> inds = digitize(x, bins)
+    >>> inds
+    array([0, 0, 1, 4, 3, 4, 4, 4])
+    """
+    bin_numbers = np.digitize(x, bins)
+    is_max = x >= bins.max()
+    bin_numbers[is_max] -= 1
+    return bin_numbers
+
+
+def calc_means_medians(binnumbers, y, weights=None):
+    """Calculate the means, medians, counts, and errors for y grouped over the
+    binnumbers.
+
+    Parameters
+    ----------
+
+    binnumbers: :obj:`list` or :class:`numpy.ndarray` (float64, dim=1)
+        binnumbers
+
+    y: :obj:`list` or :class:`numpy.ndarray` (float64, dim=1)
+        target values
+
+    weights: :obj:`list` or :class:`numpy.ndarray` (float64, dim=1)
+        array of event weights
+
+    **Example**
+
+    >>> binnumbers = np.array([0.0, 0., 0., 1., 1., 1., 2., 2., 3., 3.])
+    >>> y = np.array([0.0, 0.2, 0.5, 0.6, 0.7, 0.85, 1.0, 1.2, 1.4, 1.6])
+    >>> from skpro.libs.cyclic_boosting.utils import calc_means_medians
+    >>> means, medians, counts, errors = calc_means_medians(
+    ...     binnumbers, y)
+    >>> means
+    0.0    0.233333
+    1.0    0.716667
+    2.0    1.100000
+    3.0    1.500000
+    dtype: float64
+
+    >>> medians
+    0.0    0.2
+    1.0    0.7
+    2.0    1.1
+    3.0    1.5
+    dtype: float64
+
+    >>> errors
+    [0.0   -0.13654
+    1.0   -0.06827
+    2.0   -0.06827
+    3.0   -0.06827
+    dtype: float64, 0.0    0.204810
+    1.0    0.102405
+    2.0    0.068270
+    3.0    0.068270
+    dtype: float64, 0.0   -0.19090
+    1.0   -0.09545
+    2.0   -0.09545
+    3.0   -0.09545
+    dtype: float64, 0.0    0.286350
+    1.0    0.143175
+    2.0    0.095450
+    3.0    0.095450
+    dtype: float64]
+
+    >>> counts
+    0.0    3
+    1.0    3
+    2.0    2
+    3.0    2
+    dtype: int64
+    """
+    with warnings.catch_warnings(record=False):
+        warnings.simplefilter("ignore")
+        if weights is None or len(np.unique(weights)) == 1:
+            return _calc_means_medians_evenly_weighted(binnumbers, y)
+        else:
+            return _calc_means_medians_with_weights(binnumbers, y, weights)
+
+
+def calc_weighted_quantile(binnumbers, y, weights, quantile):
+    df = pd.DataFrame({"y": y, "weights": weights, "binnumbers": binnumbers})
+    return df.groupby("binnumbers").apply(_weighted_quantile_of_dataframe(quantile))
+
+
+def _calc_means_medians_evenly_weighted(binnumbers, y):
+    """Calculate the means, medians, counts, and errors for y grouped over the
+    binnumbers.
+
+    Parameters
+    ----------
+
+    binnumbers: :obj:`list` or :class:`numpy.ndarray` (float64, dim=1)
+        binnumbers
+
+    y: :obj:`list` or :class:`numpy.ndarray` (float64, dim=1)
+        target values
+    """
+    groupby = pd.Series(y).groupby(binnumbers)
+    means = groupby.mean()
+    medians = groupby.median()
+    counts = groupby.size()
+
+    quantiles = [
+        groupby.quantile(LOWER_1_SIGMA_QUANTILE),
+        groupby.quantile(1 - LOWER_1_SIGMA_QUANTILE),
+        groupby.quantile(LOWER_2_SIGMA_QUANTILE),
+        groupby.quantile(1 - LOWER_2_SIGMA_QUANTILE),
+    ]
+
+    errors = [series - medians for series in quantiles]
+
+    return means, medians, counts, errors
+
+
+def _calc_means_medians_with_weights(binnumbers, y, weights):
+    """Calculate the means, medians, counts, and errors for y grouped over the
+    binnumbers using weights.
+
+    Parameters
+    ----------
+
+    binnumbers: :obj:`list` or :class:`numpy.ndarray` (float64, dim=1)
+        binnumbers
+
+    y: :obj:`list` or :class:`numpy.ndarray` (float64, dim=1)
+        target values
+
+    weights: :obj:`list` or :class:`numpy.ndarray` (float64, dim=1)
+        array of event weights
+    """
+    df = pd.DataFrame({"y": y, "weights": weights, "binnumbers": binnumbers})
+    groupby = df.groupby("binnumbers")
+
+    means = groupby.apply(_weighted_mean_of_dataframe)
+    medians = groupby.apply(_weighted_median_of_dataframe)
+    counts = groupby.apply(_weighted_size_of_dataframe)
+
+    quantiles = [
+        groupby.apply(_weighted_quantile_of_dataframe(LOWER_1_SIGMA_QUANTILE)),
+        groupby.apply(_weighted_quantile_of_dataframe(1 - LOWER_1_SIGMA_QUANTILE)),
+        groupby.apply(_weighted_quantile_of_dataframe(LOWER_2_SIGMA_QUANTILE)),
+        groupby.apply(_weighted_quantile_of_dataframe(1 - LOWER_2_SIGMA_QUANTILE)),
+    ]
+    errors = [series - medians for series in quantiles]
+
+    return means, medians, counts, errors
+
+
+def _weighted_quantile_of_dataframe(quantile):
+    """
+    Generates a function which calculates the weighted quantile of a given pandas.DataFrame
+
+    Parameters
+    ----------
+
+    quantile: float between 0 and 1
+    """
+
+    def quantile_calculation(x):
+        """
+        Calculates the weighted quantile of a given pandas.DataFrame.
+        Expects two columns: y and weights
+
+        Parameters
+        ----------
+
+        x: :class:`pandas.DataFrame` with (at least) two columns y and weights
+        """
+        x = x.sort_values("y")
+        cumsum = x.weights.cumsum()
+        cutoff = x.weights.sum() * quantile
+        try:
+            return x.y[cumsum >= cutoff].iloc[0]
+        except IndexError:
+            return min(x.y)
+
+    return quantile_calculation
+
+
+def _weighted_median_of_dataframe(x):
+    """
+    Calculates the weighted size of a given pandas.DataFrame.
+    Expects two columns: y and weights
+
+    Parameters
+    ----------
+
+    x: :class:`pandas.DataFrame` with (at least) two columns y and weights
+    """
+    x = x.sort_values("y")
+    cumsum = x.weights.cumsum()
+    cutoff = x.weights.sum() / 2.0
+    try:
+        return x.y[cumsum >= cutoff].iloc[0]
+    except IndexError:
+        return min(x.y)
+
+
+def _weighted_mean_of_dataframe(x):
+    """
+    Calculates the weighted mean of a given pandas.DataFrame.
+    Expects two columns: y and weights
+
+    Parameters
+    ----------
+
+    x: :class:`pandas.DataFrame` with (at least) two columns y and weights
+    """
+    weighted_sum = (x.y * x.weights).sum()
+    sum_of_weights = x.weights.sum()
+    return weighted_sum / sum_of_weights
+
+
+def _weighted_size_of_dataframe(x):
+    """
+    Calculates the weighted size of a given pandas.DataFrame.
+    Expects one column: weights
+
+    Parameters
+    ----------
+
+    x: :class:`pandas.DataFrame` with (at least) one column called weights
+    """
+    return x.weights.sum()
+
+
+def weighted_stddev(values, weights):
+    r"""Calculates the weighted standard deviation :math:`\sigma`:
+
+    .. math::
+
+        \sigma = \frac{\sum_i w_i \cdot (x_i - /mu_{wx})^2}{\sum_i w_i}
+
+    Parameters
+    ----------
+    values: :class:`numpy.ndarray` (float64, dim=1)
+        Values of the samples :math:`x_i`.
+    weights: :class:`numpy.ndarray` (float64, dim=1)
+        Weights of the samples :math:`w_i`.
+    """
+    mean_w = np.sum(weights * values) / np.sum(weights)
+    numerator = np.sum(weights * (values - mean_w) ** 2)
+    denominator = np.sum(weights)
+    stddev_w = np.sqrt(numerator / denominator)
+    return stddev_w
+
+
+def clone(estimator, safe=True):
+    """Constructs a new estimator with the same constructor parameters.
+
+    A better name for this function would be 'reconstruct'.
+
+    This is a reimplemenation of :func:`sklearn.base.clone` respecting wishes of
+    estimators and their subestimators to avoid reconstructing certain
+    attributes.
+
+    Clone performs a deep copy of the model in an estimator
+    without actually copying attached data. It yields a new estimator
+    with the same parameters that has not been fit on any data.
+    """
+    estimator_type = type(estimator)
+    if estimator_type in (list, tuple, set, frozenset):
+        return estimator_type([clone(e, safe=safe) for e in estimator])
+    elif not hasattr(estimator, "get_params"):
+        if not safe:
+            return copy.deepcopy(estimator)
+        else:
+            raise TypeError(
+                "Cannot clone object '%s' (type %s): "
+                "it does not seem to be a scikit-learn estimator as "
+                "it does not implement a 'get_params' methods." % (repr(estimator), type(estimator))
+            )
+    klass = estimator.__class__
+    new_object_params = estimator.get_params(deep=False)
+
+    if hasattr(estimator, "no_deepcopy"):
+        no_deepcopy = estimator.no_deepcopy
+        for name, param in new_object_params.items():
+            if name not in no_deepcopy:
+                new_object_params[name] = clone(param, safe=False)
+    else:
+        for name, param in new_object_params.items():
+            new_object_params[name] = clone(param, safe=False)
+
+    new_object = klass(**new_object_params)
+
+    return new_object
+
+
+def regularize_to_prior_expectation(values, uncertainties, prior_expectation, threshold=2.5):
+    r"""Regularize values with uncertainties to a prior expectation.
+
+    :param values: measured values
+    :type values: :class:`numpy.ndarray` (float64, dim=1)
+
+    :param uncertainties: uncertainties for the values.
+    :type uncertainties: :class:`numpy.ndarray` (float64, dim=1)
+
+    :param prior_expectation: The prior expectations dominate
+        the regularized value if the uncertainties are large.
+    :type prior_expectation: :class:`numpy.ndarray` (float64, dim=1) or float
+
+    :param threshold: Threshold in terms of sigma. If the significance of a
+        value:
+
+        .. math::
+
+            \text{sig}(x_i) = \frac{x_i - \text{prior\_expectation}_i}
+            {\text{uncertainty}_i}
+
+        is below the threshold, the prior expectation replaces the value.
+    :type threshold: float
+
+    **Doctests**
+
+    >>> values = np.array([0, 1, 2, 3])
+    >>> uncertainties = np.ones_like(values)*0.1
+    >>> prior_expectation = 1.
+    >>> from skpro.libs.cyclic_boosting.utils import regularize_to_prior_expectation
+    >>> regularized_values = regularize_to_prior_expectation(
+    ... values, uncertainties, prior_expectation)
+    >>> regularized_values
+    array([ 0.03175416,  1.        ,  1.96824584,  2.98431348])
+    >>> np.allclose(1 - np.sqrt(((values[0] - 1) / 0.1)**2 - 2.5**2) * 0.1,
+    ...     regularized_values[0])
+    True
+    >>> np.allclose(1 + np.sqrt(((values[-1] - 1) / 0.1)**2 - 2.5**2) * 0.1,
+    ...     regularized_values[-1])
+    True
+    """
+    significance = (values - prior_expectation) / uncertainties
+    return prior_expectation + uncertainties * np.where(
+        np.abs(significance) > threshold,
+        np.sign(significance) * np.sqrt(np.abs(significance**2.0 - threshold**2.0)),
+        0,
+    )
+
+
+def regularize_to_error_weighted_mean(values, uncertainties, prior_prediction=None):
+    r"""Regularize values with uncertainties to its error-weighted mean.
+
+    :param values: measured values
+    :type values: :class:`numpy.ndarray` (float64, dim=1)
+
+    :param uncertainties: uncertainties for the values.
+    :type uncertainties: :class:`numpy.ndarray` (float64, dim=1)
+
+    :param prior_prediction: If the `prior_prediction` is specified, all values
+        are regularized with it and not with the error weighted mean.
+    :type prior_prediction: float
+
+    :returns: regularized values
+    :rtype: :class:`numpy.ndarray` (float64, dim=1)
+
+    The error weighted mean is defined as:
+
+    .. math::
+
+         \bar{x}_{\sigma} = \frac{\sum\limits_{i} \frac{1}
+         {\sigma^2_i} \cdot x_i}{\sum\limits_{i} \frac{1}{\sigma^2_i}}
+
+    with the uncertainties :math:`\sigma_i` and values :math:`x_i`.
+    The uncertainty :math:`\sigma_{\bar{x}}` for :math:`\bar{x}`
+    is calculated as:
+
+    .. math::
+
+        \sigma^2_{\bar{x}} = \frac{\sum\limits_{i} \frac{1}{\sigma^2_i}
+        (x - \bar{x}_{\sigma})^2}{\sum\limits_{i} \frac{1}{\sigma^2_i}}
+
+    The regularized values are calculated as follows:
+
+    .. math::
+
+        x_i^{'} = \frac{\frac{1}{\sigma^2_i} \cdot x_i +
+        \frac{1}{\sigma^2_{\bar{x}}} \cdot \bar{x}}
+        {\frac{1}{\sigma^2_i} + \frac{1}{\sigma^2_{\bar{x}}}}
+
+    >>> values = np.array([100., 100., 100., 90., 110., 180., 180., 20., 20.])
+    >>> uncertainties = np.array([10., 10., 10., 10., 10., 10., 15., 10., 15.])
+    >>> from skpro.libs.cyclic_boosting.utils import regularize_to_error_weighted_mean
+    >>> regularize_to_error_weighted_mean(values, uncertainties)
+    array([ 100.        ,  100.        ,  100.        ,   90.40501997,
+            109.59498003,  176.75984027,  173.06094747,   23.24015973,
+             26.93905253])
+
+    >>> values = np.array([100.])
+    >>> uncertainties = np.array([10.])
+    >>> np.allclose(regularize_to_error_weighted_mean(values, uncertainties),
+    ...             values)
+    True
+
+    >>> values = np.array([100., 101.])
+    >>> uncertainties = np.array([10., 10.])
+    >>> regularize_to_error_weighted_mean(
+    ...     values, uncertainties, prior_prediction=50.)
+    array([ 98.11356348,  99.07583475])
+
+    >>> values = np.array([100., 10])
+    >>> uncertainties = np.array([10.])
+    >>> regularize_to_error_weighted_mean(values, uncertainties)
+    Traceback (most recent call last):
+    ValueError: <values> and <uncertainties> must have the same shape
+    """
+    if values.shape != uncertainties.shape:
+        raise ValueError("values and uncertainties must have the same shape")
+    if len(values) < 1 or (prior_prediction is None and len(values) == 1):
+        return values
+
+    x = values
+    wx = 1.0 / np.square(uncertainties)
+    sum_wx = np.sum(wx)
+    if prior_prediction is None:
+        if np.allclose(x, x[0]):
+            # if all values are the same,
+            # regularizing to the mean makes no sense
+            return x
+        x_mean = np.sum(wx * x) / sum_wx
+    else:
+        if np.allclose(x, prior_prediction):
+            return x
+        x_mean = prior_prediction
+    wx_incl = 1.0 / (np.sum(wx * np.square(x - x_mean)) / sum_wx)
+    res = (wx * x + wx_incl * x_mean) / (wx + wx_incl)
+    return res
+
+
+def regularize_to_error_weighted_mean_neighbors(
+    values: np.ndarray, uncertainties: np.ndarray, window_size: Optional[int] = 3
+) -> np.ndarray:
+    """
+    Regularize values with uncertainties to its error-weighted mean, using a
+    sliding window.
+
+    Parameters
+    ----------
+    values : np.ndarray
+        data (`float` type) to be regularized
+    uncertainties : np.ndarray
+        uncertainties (`float` type) of values
+    window_size : int
+        size of the sliding window to be used (e.g., 3 means include direct
+        left and right neighbors)
+
+    Returns
+    -------
+    np.ndarray
+        regularized values
+    """
+    if values.shape != uncertainties.shape:
+        raise ValueError("values and uncertainties must have the same shape")
+
+    if len(values) < 3:
+        return regularize_to_error_weighted_mean(values, uncertainties)
+
+    window_arr = np.ones(window_size)
+    x = values
+    wx = np.where(uncertainties > 0, 1.0 / np.square(uncertainties), 0.0)
+
+    sum_wx = np.convolve(wx, window_arr, "same")
+    x_mean = np.convolve(wx * x, window_arr, "same") / sum_wx
+
+    wx_incl = np.ones(len(x))
+    for i in range(len(x)):
+        wx_incl[i] = (sum_wx / np.convolve(wx * np.square(x - x_mean[i]), window_arr, "same"))[i]
+
+    res = (wx * x + wx_incl * x_mean) / (wx + wx_incl)
+    return res
+
+
+def neutralize_one_dim_influence(values, uncertainties):
+    """
+    Neutralize influence of one dimensional features in a two-dimensional factor matrix
+
+    :param values: measured values
+    :type values: :class:`numpy.ndarray` (float64, dim=2)
+
+    :param uncertainties: uncertainties for the values.
+    :type uncertainties: :class:`numpy.ndarray` (float64, dim=2)
+
+    returns an updated 2D-table that has no net shift on any of the 2 projections
+    """
+    deviation = 100.0
+    iteration = 0
+    T0 = np.einsum("ij->i", uncertainties)
+    T1 = np.einsum("ij->j", uncertainties)
+    S0 = np.einsum("ij->i", values * uncertainties)
+
+    while deviation > 0.01 and iteration < 4:
+        iteration += 1
+
+        #  row corrections
+        values = values - np.outer(S0 / T0, np.ones(values.shape[1]))
+
+        # recalc column sum after row correction
+        S1 = np.sum(values * uncertainties, axis=0)
+
+        #  column corrections
+        values = values - np.outer(np.ones(values.shape[0]), S1 / T1)
+
+        # recalc column and row sums after column correction
+        S0 = np.sum(values * uncertainties, axis=1)
+        S1 = np.sum(values * uncertainties, axis=0)
+
+        #  check total absolute row and column sum for determining convergence
+        deviation = abs(S0).sum() + abs(S1).sum()
+    return values
+
+
+def get_bin_bounds(binners, feat_group):
+    """
+    Gets the bin boundaries for each feature group.
+
+    Parameters
+    ----------
+    binners: list
+        List of binners.
+    feat_group: str or tuple of str
+        A feature property for which the bin boundaries should be extracted
+        from the binners.
+    """
+    if binners is None:
+        return None
+    bin_bounds = {}
+    for binner in binners:
+        bin_bounds.update(binner.get_feature_bin_boundaries())
+    if feat_group in bin_bounds and bin_bounds[feat_group] is not None:
+        return bin_bounds[feat_group][:, 0]
+    else:
+        return None
+
+
+def generator_to_decorator(gen):
+    """Turn a generator into a decorator.
+
+    The mechanism is similar to :func:`contextlib.contextmanager` which turns
+    a generator into a contextmanager. :mod:`decorator` is used internally.
+
+    Thanks to :mod:`decorator`, this function preserves the docstring and the
+    signature of the function to be decorated.
+
+    The docstring of the resulting decorator will include the original
+    docstring of the generator and an additional remark stating
+    that this is the corresponding decorator.
+
+    :param gen: wrapping the function call.
+    :type gen: generator function
+
+    :return: decorator
+
+    For a detailed example, see
+    :func:`generator_to_decorator_and_contextmanager`.
+    """
+
+    @decorator.decorator
+    def created_decorator(func, *args, **kwargs):
+        gen_instance = gen()
+        try:
+            next(gen_instance)
+            return func(*args, **kwargs)
+        finally:
+            gen_instance.close()
+
+    doc = gen.__doc__ or ""
+    created_decorator.__doc__ = doc + "\n    This is the corresponding decorator."
+    return created_decorator
+
+
+def linear_regression(x, y, w):
+    r"""Performs a linear regression allowing uncertainties in y.
+
+    :math:`f(x) = y = \alpha + \beta \cdot x`
+
+    :param x: x vector
+    :type x: :class:`numpy.ndarray`
+
+    :param y: y vector
+    :type y: :class:`numpy.ndarray`
+
+    :param w: weight vector
+    :type w: :class:`numpy.ndarray`
+
+    :returns: The coefficients `alpha` and `beta`.
+    :rtype: :obj:`tuple` of 2 :obj:`float`
+    """
+    s_w = np.sum(w)
+    s_wx = np.dot(w, x)
+    s_wxx = np.dot(np.square(x), w)
+    s_wy = np.dot(w, y)
+    s_wxy = np.sum(w * x * y)
+    det = s_w * s_wxx - s_wx * s_wx
+    alpha = (s_wxx * s_wy - s_wx * s_wxy) / det
+    beta = (s_w * s_wxy - s_wx * s_wy) / det
+    return alpha, beta
+
+
+def get_feature_column_names(X, exclude_columns=[]):
+    features = list(X.columns)
+    for col in exclude_columns:
+        if col in features:
+            features.remove(col)
+    return features
+
+
+def continuous_quantile_from_discrete_pdf(y, quantile, weights):
+    """
+    Calculates a continous quantile value approximation for a given quantile
+    from an array of potentially discrete values.
+
+    Parameters
+    ----------
+    y : np.ndarray
+        containing data with `float` type (potentially discrete)
+    quantile : float
+        desired quantile
+
+    Returns
+    -------
+    float
+        calculated quantile value
+    """
+    y = np.asarray(y)
+    weights = np.asarray(weights)
+
+    sorting = y.argsort()
+    sorted_y = y[sorting]
+    cumsum = weights[sorting].cumsum()
+    quantile_index = weights.sum() * quantile
+    quantile_y = sorted_y[cumsum >= quantile_index][0]
+
+    all_quantile_y = np.where(sorted_y == quantile_y)[0]
+    index_low = all_quantile_y[0]
+    index_high = all_quantile_y[-1]
+    if index_high > index_low:
+        quantile_y += (int(quantile_index) - index_low) / (index_high - index_low)
+
+    return quantile_y
+
+
+@dataclass
+class ConvergenceParameters:
+    """Class for registering the convergence parameters"""
+
+    loss_change: float = 1e20
+    delta: float = 100.0
+
+    def set_loss_change(self, updated_loss_change: float) -> None:
+        self.loss_change = updated_loss_change
+
+    def set_delta(self, updated_delta: float) -> None:
+        self.delta = updated_delta
+
+
+def get_normalized_values(values: Iterable) -> List[float]:
+    values_total = sum(values)
+    if round(values_total, 6) != 0.0:
+        return [value / values_total for value in values]
+    return [value for value in values]
+
+
+def smear_discrete_cdftruth(cdf_func: callable, y: int) -> float:
+    """
+    Smearing of the CDF value of a sample from a discrete random variable. Main
+    usage is for a histogram of CDF values to check an estimated individual
+    probability distribution (should be flat).
+
+    Parameters
+    ----------
+    y : int
+        value from discrete random variable
+    cdf_func : callable
+        cumulative distribution function
+
+    Returns
+    -------
+    float
+        smeared CDF value for y
+    """
+    cdf_high = cdf_func(y)
+    if y >= 1:
+        cdf_low = cdf_func(y - 1)
+    else:
+        cdf_low = 0.0
+    cdf_truth = cdf_low + np.random.uniform(0, 1) * (cdf_high - cdf_low)
+    return cdf_truth
+
+
+def smear_discrete_cdftruth_qpd(qpds: np.ndarray, y: np.ndarray) -> np.ndarray:
+    """
+    Smearing of the CDF values of samples from discrete random variables. Main
+    usage is for a histogram of CDF values to check an estimated individual
+    probability distribution (should be flat).
+
+    Parameters
+    ----------
+    y : np.ndarray
+        values from discrete random variables
+    qpds : np.ndarray
+        array of QPDs
+
+    Returns
+    -------
+    np.ndarray
+        smeared CDF values for y
+    """
+    cdf_high = qpds.cdf(y, inner=True)
+    cdf_low = np.where(y >= 1, qpds.cdf(y - 1, inner=True), 0.0)
+    cdf_truth = cdf_low + np.random.uniform(0, 1, len(y)) * (cdf_high - cdf_low)
+    return cdf_truth

--- a/skpro/libs/cyclic_boosting/utils.py
+++ b/skpro/libs/cyclic_boosting/utils.py
@@ -1,16 +1,13 @@
 import copy
 import logging
 import warnings
+from dataclasses import dataclass
+from typing import Iterable, List, Optional
 
 import decorator
 import numba as nb
 import numpy as np
 import pandas as pd
-
-
-from typing import Iterable, List, Optional
-
-from dataclasses import dataclass
 
 _logger = logging.getLogger(__name__)
 
@@ -238,7 +235,9 @@ def multidim_binnos_to_lexicographic_binnos(binnos, n_bins=None, binsteps=None):
         binsteps = bin_steps(n_bins)
 
     is_valid = np.isfinite(binnos).all(axis=1)
-    is_valid[is_valid] &= ((binnos[is_valid] >= 0) & (binnos[is_valid] < n_bins[None, :])).all(axis=1)
+    is_valid[is_valid] &= (
+        (binnos[is_valid] >= 0) & (binnos[is_valid] < n_bins[None, :])
+    ).all(axis=1)
 
     if not np.any(is_valid):
         result = np.repeat(0, len(binnos))
@@ -251,7 +250,9 @@ def multidim_binnos_to_lexicographic_binnos(binnos, n_bins=None, binsteps=None):
         _logger.warning(
             "Enumerating multidimensional bins: A multidimensional feature of "
             "shape {n_bins} requires {total_bins} unique bins in total. "
-            "Please consider whether this is what you want.".format(n_bins=n_bins, total_bins=n_bins.prod())
+            "Please consider whether this is what you want.".format(
+                n_bins=n_bins, total_bins=n_bins.prod()
+            )
         )
     result = result.astype(np.int64)
     return result, n_bins
@@ -691,7 +692,8 @@ def clone(estimator, safe=True):
             raise TypeError(
                 "Cannot clone object '%s' (type %s): "
                 "it does not seem to be a scikit-learn estimator as "
-                "it does not implement a 'get_params' methods." % (repr(estimator), type(estimator))
+                "it does not implement a 'get_params' methods."
+                % (repr(estimator), type(estimator))
             )
     klass = estimator.__class__
     new_object_params = estimator.get_params(deep=False)
@@ -710,7 +712,9 @@ def clone(estimator, safe=True):
     return new_object
 
 
-def regularize_to_prior_expectation(values, uncertainties, prior_expectation, threshold=2.5):
+def regularize_to_prior_expectation(
+    values, uncertainties, prior_expectation, threshold=2.5
+):
     r"""Regularize values with uncertainties to a prior expectation.
 
     :param values: measured values
@@ -885,7 +889,9 @@ def regularize_to_error_weighted_mean_neighbors(
 
     wx_incl = np.ones(len(x))
     for i in range(len(x)):
-        wx_incl[i] = (sum_wx / np.convolve(wx * np.square(x - x_mean[i]), window_arr, "same"))[i]
+        wx_incl[i] = (
+            sum_wx / np.convolve(wx * np.square(x - x_mean[i]), window_arr, "same")
+        )[i]
 
     res = (wx * x + wx_incl * x_mean) / (wx + wx_incl)
     return res

--- a/skpro/regression/cyclic_boosting.py
+++ b/skpro/regression/cyclic_boosting.py
@@ -120,7 +120,7 @@ class CyclicBoosting(BaseProbaRegressor):
         "authors": ["setoguchi-naoki", "felix-wick"],
         "maintainers": ["setoguchi-naoki"],
         "estimator_type": "regressor_proba",
-        "python_dependencies": "cyclic_boosting>=1.4.0",
+        "python_dependencies": ["numba", "numexpr", "decorator"],
         # estimator tags
         # --------------
         "capability:multioutput": False,
@@ -129,6 +129,7 @@ class CyclicBoosting(BaseProbaRegressor):
         "y_inner_mtype": "pd_DataFrame_Table",
         # CI and test flags
         # -----------------
+        "tests:libs": ["skpro.libs.cyclic_boosting"],
         "tests:vm": True,  # requires its own test VM to run
     }
 
@@ -199,11 +200,15 @@ class CyclicBoosting(BaseProbaRegressor):
 
         # build estimators
         if self.mode == "multiplicative":
-            from cyclic_boosting import pipeline_CBMultiplicativeQuantileRegressor
+            from skpro.libs.cyclic_boosting import (
+                pipeline_CBMultiplicativeQuantileRegressor,
+            )
 
             regressor = pipeline_CBMultiplicativeQuantileRegressor
         elif self.mode == "additive":
-            from cyclic_boosting import pipeline_CBAdditiveQuantileRegressor
+            from skpro.libs.cyclic_boosting import (
+                pipeline_CBAdditiveQuantileRegressor,
+            )
 
             regressor = pipeline_CBAdditiveQuantileRegressor
         else:

--- a/skpro/regression/cyclic_boosting.py
+++ b/skpro/regression/cyclic_boosting.py
@@ -206,9 +206,7 @@ class CyclicBoosting(BaseProbaRegressor):
 
             regressor = pipeline_CBMultiplicativeQuantileRegressor
         elif self.mode == "additive":
-            from skpro.libs.cyclic_boosting import (
-                pipeline_CBAdditiveQuantileRegressor,
-            )
+            from skpro.libs.cyclic_boosting import pipeline_CBAdditiveQuantileRegressor
 
             regressor = pipeline_CBAdditiveQuantileRegressor
         else:

--- a/skpro/regression/tests/test_cyclic_boosting.py
+++ b/skpro/regression/tests/test_cyclic_boosting.py
@@ -35,7 +35,7 @@ def test_cyclic_boosting_simple_use():
 )
 def test_cyclic_boosting_with_manual_parameters():
     """Test use of cyclic boosting regressor with_manual_parameters."""
-    from cyclic_boosting import flags
+    from skpro.libs.cyclic_boosting import flags
     from sklearn.datasets import load_diabetes
     from sklearn.model_selection import train_test_split
 
@@ -91,6 +91,6 @@ def test_cyclic_boosting_missing_feature_validation():
     y = pd.DataFrame({"target": [1, 2, 3]})
 
     with pytest.raises(
-        ValueError, match="\\{'nonexistent1', 'nonexistent2'\\} are not in X"
+        ValueError, match="Features \\['nonexistent1', 'nonexistent2'\\] are not in X"
     ):
         reg.fit(X, y)

--- a/skpro/regression/tests/test_cyclic_boosting.py
+++ b/skpro/regression/tests/test_cyclic_boosting.py
@@ -35,9 +35,10 @@ def test_cyclic_boosting_simple_use():
 )
 def test_cyclic_boosting_with_manual_parameters():
     """Test use of cyclic boosting regressor with_manual_parameters."""
-    from skpro.libs.cyclic_boosting import flags
     from sklearn.datasets import load_diabetes
     from sklearn.model_selection import train_test_split
+
+    from skpro.libs.cyclic_boosting import flags
 
     X, y = load_diabetes(return_X_y=True, as_frame=True)
     y = pd.DataFrame(y)


### PR DESCRIPTION
## Summary

Fixes #1090.

This PR vendors the `cyclic_boosting` library into `skpro.libs` and updates it for compatibility with recent NumPy versions. Since the upstream project appears to be unmaintained, this allows `skpro` to maintain compatibility independently while preserving the existing functionality.

## Changes

* Forked the `cyclic_boosting` package into `skpro.libs`.
* Updated deprecated NumPy API usage (e.g. replacing removed/deprecated functionality such as `np.product` where applicable).
* Updated imports and internal references to use the vendored implementation.
* Preserved the original behavior while ensuring compatibility with current NumPy releases.

## Why

The upstream `cyclic_boosting` project appears to be inactive and is no longer compatible with newer NumPy versions due to deprecated API usage. Vendoring the library into `skpro` enables continued maintenance, avoids dependency on an unmaintained package, and ensures compatibility with supported NumPy versions.

## Testing

* Verified that the vendored implementation imports successfully.
* Confirmed compatibility with current NumPy versions.
* Ran the relevant test suite to ensure existing functionality remains unchanged.
