### PR TITLE
[ENH] Add distfitter scitype to base class registry

### DIFF
--- a/skpro/registry/_base_classes.py
+++ b/skpro/registry/_base_classes.py
@@ -133,6 +133,35 @@ class regressor_proba(_BaseScitypeOfObject):
 
 
 # ----------------------------------
+# Distribution fitters scitypes
+# ----------------------------------
+
+
+class distfitter(_BaseScitypeOfObject):
+    """Distribution fitter."""
+
+    _tags = {
+        "scitype_name": "distfitter",
+        "short_descr": "distribution fitter",
+        "parent_scitype": "estimator",
+    }
+
+    @classmethod
+    def get_base_class(cls):
+        """Return base class for distfitter scitype."""
+        from skpro.distfitter.base import BaseDistFitter
+
+        return BaseDistFitter
+
+    @classmethod
+    def get_test_class(cls):
+        """Return test class for distfitter scitype."""
+        from skpro.distfitter.tests.test_all_distfitters import TestAllDistFitters
+
+        return TestAllDistFitters
+
+
+# ----------------------------------
 # Distribution scitypes
 # ----------------------------------
 


### PR DESCRIPTION
Distribution fitters (`NormalFitter`, `MOMFitter`) were missing from the `registry._base_classes` registration, causing `check_estimator` to fail for these estimators.

Fixes #1084.

Added the `distfitter` scitype with:
- `BaseDistFitter` as its base class
- `TestAllDistFitters` as its test class
- `parent_scitype`: `estimator`

Follows the existing pattern used by `regressor_proba` and other registered scitypes.