### PR TITLE
[ENH] Add __dynamic_tags__ and __post_init__ to base framework

### DIFF
--- a/extension_templates/distfitter.py
+++ b/extension_templates/distfitter.py
@@ -82,7 +82,8 @@ class ClassName(BaseDistFitter):
     # todo: fill init
     # params should be written to self and never changed
     # super call must not be removed, change class name
-    # parameter checks can go after super call
+    # parameter checks and component initialization should go in __post_init__
+    # dynamic tag logic should go in __dynamic_tags__
     def __init__(self, paramname, paramname2="paramname2default"):
         # todo: write any hyper-parameters and components to self
         self.paramname = paramname
@@ -91,9 +92,22 @@ class ClassName(BaseDistFitter):
         # leave this as is
         super().__init__()
 
+    # todo: optional, for conditional tag setting
+    # tags set here override class-level _tags and are set
+    # after __init__ but before __post_init__
+    # if not needed, delete this method
+    def __dynamic_tags__(self):
+        """Set dynamic tags conditional on parameters."""
+        pass
+
+    # todo: optional, for parameter validation and derived quantities
+    # if not needed, delete this method
+    def __post_init__(self):
+        """Initialize non-parameter attributes and validate parameters."""
         # todo: optional, parameter checking logic (if applicable) should happen here
         # if writes derived values to self, should *not* overwrite self.parama etc
         # instead, write to self._parama, self._newparam (starting with _)
+        pass
 
     # todo: implement this, mandatory
     def _fit(self, X, C=None):

--- a/extension_templates/distfitter.py
+++ b/extension_templates/distfitter.py
@@ -112,7 +112,6 @@ class ClassName(BaseDistFitter):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
 
         IMPORTANT: no significant compute or memory use should happen in __post_init__,

--- a/extension_templates/distfitter.py
+++ b/extension_templates/distfitter.py
@@ -97,7 +97,10 @@ class ClassName(BaseDistFitter):
     # after __init__ but before __post_init__
     # if not needed, delete this method
     def __dynamic_tags__(self):
-        """Set dynamic tags conditional on parameters."""
+        """Dynamic tag setter logic for setting tag values conditional on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
         pass
 
     # todo: optional, for parameter validation and derived quantities

--- a/extension_templates/distfitter.py
+++ b/extension_templates/distfitter.py
@@ -106,7 +106,18 @@ class ClassName(BaseDistFitter):
     # todo: optional, for parameter validation and derived quantities
     # if not needed, delete this method
     def __post_init__(self):
-        """Initialize non-parameter attributes and validate parameters."""
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * dynamic tag setting
+        * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
+        """
         # todo: optional, parameter checking logic (if applicable) should happen here
         # if writes derived values to self, should *not* overwrite self.parama etc
         # instead, write to self._parama, self._newparam (starting with _)

--- a/extension_templates/distributions.py
+++ b/extension_templates/distributions.py
@@ -99,7 +99,8 @@ class ClassName(BaseDistribution):
     # todo: fill init
     # params should be written to self and never changed
     # super call must not be removed, change class name
-    # parameter checks can go after super call
+    # parameter checks and component initialization should go in __post_init__
+    # dynamic tag logic should go in __dynamic_tags__
     def __init__(self, param1, param2="param2default", index=None, columns=None):
         # all distributions must have index and columns arg with None defaults
         # this is to ensure pandas-like behaviour
@@ -111,9 +112,22 @@ class ClassName(BaseDistribution):
         # leave this as is
         super().__init__(index=index, columns=columns)
 
+    # todo: optional, for conditional tag setting
+    # tags set here override class-level _tags and are set
+    # after __init__ but before __post_init__
+    # if not needed, delete this method
+    def __dynamic_tags__(self):
+        """Set dynamic tags conditional on parameters."""
+        pass
+
+    # todo: optional, for parameter validation and derived quantities
+    # if not needed, delete this method
+    def __post_init__(self):
+        """Initialize non-parameter attributes and validate parameters."""
         # todo: optional, parameter checking logic (if applicable) should happen here
         # if writes derived values to self, should *not* overwrite self.parama etc
         # instead, write to self._parama, self._newparam (starting with _)
+        pass
 
     # todo: implement as many of the following methods as possible
     # if not implemented, the base class will try to fill it in

--- a/extension_templates/distributions.py
+++ b/extension_templates/distributions.py
@@ -126,7 +126,18 @@ class ClassName(BaseDistribution):
     # todo: optional, for parameter validation and derived quantities
     # if not needed, delete this method
     def __post_init__(self):
-        """Initialize non-parameter attributes and validate parameters."""
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * dynamic tag setting
+        * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
+        """
         # todo: optional, parameter checking logic (if applicable) should happen here
         # if writes derived values to self, should *not* overwrite self.parama etc
         # instead, write to self._parama, self._newparam (starting with _)

--- a/extension_templates/distributions.py
+++ b/extension_templates/distributions.py
@@ -117,7 +117,10 @@ class ClassName(BaseDistribution):
     # after __init__ but before __post_init__
     # if not needed, delete this method
     def __dynamic_tags__(self):
-        """Set dynamic tags conditional on parameters."""
+        """Dynamic tag setter logic for setting tag values conditional on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
         pass
 
     # todo: optional, for parameter validation and derived quantities

--- a/extension_templates/distributions.py
+++ b/extension_templates/distributions.py
@@ -132,7 +132,6 @@ class ClassName(BaseDistribution):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
 
         IMPORTANT: no significant compute or memory use should happen in __post_init__,

--- a/extension_templates/regression.py
+++ b/extension_templates/regression.py
@@ -99,7 +99,8 @@ class ClassName(BaseProbaRegressor):
     # todo: fill init
     # params should be written to self and never changed
     # super call must not be removed, change class name
-    # parameter checks can go after super call
+    # parameter checks and component initialization should go in __post_init__
+    # dynamic tag logic should go in __dynamic_tags__
     def __init__(self, paramname, paramname2="paramname2default"):
         # estimators should precede parameters
         #  if estimators have default values, set None and initialize below
@@ -111,6 +112,23 @@ class ClassName(BaseProbaRegressor):
         # leave this as is
         super().__init__()
 
+    # todo: optional, for conditional tag setting
+    # tags set here override class-level _tags and are set
+    # after __init__ but before __post_init__
+    # if not needed, delete this method
+    def __dynamic_tags__(self):
+        """Set dynamic tags conditional on parameters."""
+        # example 1: conditional setting of a tag
+        # if self.paramname == 42:
+        #   self.set_tags(capability:missing=True)
+        # example 2: cloning tags from component
+        #   self.clone_tags(self.estimator, ["capability:multioutput"])
+        pass
+
+    # todo: optional, for parameter validation and derived quantities
+    # if not needed, delete this method
+    def __post_init__(self):
+        """Initialize non-parameter attributes and validate parameters."""
         # todo: optional, parameter checking logic (if applicable) should happen here
         # if writes derived values to self, should *not* overwrite self.parama etc
         # instead, write to self._parama, self._newparam (starting with _)
@@ -118,18 +136,9 @@ class ClassName(BaseProbaRegressor):
         # todo: default estimators should have None arg defaults
         #  and be initialized here
         #  do this only with default estimators, not with parameters
-        # if est2 is None:
+        # if self.paramname2 is None:
         #     self.estimator = MyDefaultEstimator()
-
-        # todo: if tags of estimator depend on component tags, set these here
-        #  only needed if estimator is a composite
-        #  tags set in the constructor apply to the object and override the class
-        #
-        # example 1: conditional setting of a tag
-        # if est.foo == 42:
-        #   self.set_tags(handles-missing-data=True)
-        # example 2: cloning tags from component
-        #   self.clone_tags(est2, ["enforce_index_type", "handles-missing-data"])
+        pass
 
     # todo: implement this, mandatory
     def _fit(self, X, y):

--- a/extension_templates/regression.py
+++ b/extension_templates/regression.py
@@ -137,7 +137,6 @@ class ClassName(BaseProbaRegressor):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
 
         IMPORTANT: no significant compute or memory use should happen in __post_init__,

--- a/extension_templates/regression.py
+++ b/extension_templates/regression.py
@@ -131,7 +131,18 @@ class ClassName(BaseProbaRegressor):
     # todo: optional, for parameter validation and derived quantities
     # if not needed, delete this method
     def __post_init__(self):
-        """Initialize non-parameter attributes and validate parameters."""
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * dynamic tag setting
+        * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
+        """
         # todo: optional, parameter checking logic (if applicable) should happen here
         # if writes derived values to self, should *not* overwrite self.parama etc
         # instead, write to self._parama, self._newparam (starting with _)

--- a/extension_templates/regression.py
+++ b/extension_templates/regression.py
@@ -117,7 +117,10 @@ class ClassName(BaseProbaRegressor):
     # after __init__ but before __post_init__
     # if not needed, delete this method
     def __dynamic_tags__(self):
-        """Set dynamic tags conditional on parameters."""
+        """Dynamic tag setter logic for setting tag values conditional on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
         # example 1: conditional setting of a tag
         # if self.paramname == 42:
         #   self.set_tags(capability:missing=True)

--- a/extension_templates/survival.py
+++ b/extension_templates/survival.py
@@ -80,7 +80,8 @@ class ClassName(BaseSurvReg):
     # todo: fill init
     # params should be written to self and never changed
     # super call must not be removed, change class name
-    # parameter checks can go after super call
+    # parameter checks and component initialization should go in __post_init__
+    # dynamic tag logic should go in __dynamic_tags__
     def __init__(self, paramname, paramname2="paramname2default"):
         # estimators should precede parameters
         #  if estimators have default values, set None and initialize below
@@ -92,6 +93,23 @@ class ClassName(BaseSurvReg):
         # leave this as is
         super().__init__()
 
+    # todo: optional, for conditional tag setting
+    # tags set here override class-level _tags and are set
+    # after __init__ but before __post_init__
+    # if not needed, delete this method
+    def __dynamic_tags__(self):
+        """Set dynamic tags conditional on parameters."""
+        # example 1: conditional setting of a tag
+        # if self.paramname == 42:
+        #   self.set_tags(capability:survival=True)
+        # example 2: cloning tags from component
+        #   self.clone_tags(self.estimator, ["capability:survival"])
+        pass
+
+    # todo: optional, for parameter validation and derived quantities
+    # if not needed, delete this method
+    def __post_init__(self):
+        """Initialize non-parameter attributes and validate parameters."""
         # todo: optional, parameter checking logic (if applicable) should happen here
         # if writes derived values to self, should *not* overwrite self.parama etc
         # instead, write to self._parama, self._newparam (starting with _)
@@ -99,18 +117,9 @@ class ClassName(BaseSurvReg):
         # todo: default estimators should have None arg defaults
         #  and be initialized here
         #  do this only with default estimators, not with parameters
-        # if est2 is None:
+        # if self.paramname2 is None:
         #     self.estimator = MyDefaultEstimator()
-
-        # todo: if tags of estimator depend on component tags, set these here
-        #  only needed if estimator is a composite
-        #  tags set in the constructor apply to the object and override the class
-        #
-        # example 1: conditional setting of a tag
-        # if est.foo == 42:
-        #   self.set_tags(handles-missing-data=True)
-        # example 2: cloning tags from component
-        #   self.clone_tags(est2, ["enforce_index_type", "handles-missing-data"])
+        pass
 
     # todo: implement this, mandatory
     def _fit(self, X, y, C=None):

--- a/extension_templates/survival.py
+++ b/extension_templates/survival.py
@@ -118,7 +118,6 @@ class ClassName(BaseSurvReg):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
 
         IMPORTANT: no significant compute or memory use should happen in __post_init__,

--- a/extension_templates/survival.py
+++ b/extension_templates/survival.py
@@ -98,7 +98,10 @@ class ClassName(BaseSurvReg):
     # after __init__ but before __post_init__
     # if not needed, delete this method
     def __dynamic_tags__(self):
-        """Set dynamic tags conditional on parameters."""
+        """Dynamic tag setter logic for setting tag values conditional on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
         # example 1: conditional setting of a tag
         # if self.paramname == 42:
         #   self.set_tags(capability:survival=True)

--- a/extension_templates/survival.py
+++ b/extension_templates/survival.py
@@ -112,7 +112,18 @@ class ClassName(BaseSurvReg):
     # todo: optional, for parameter validation and derived quantities
     # if not needed, delete this method
     def __post_init__(self):
-        """Initialize non-parameter attributes and validate parameters."""
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * dynamic tag setting
+        * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
+        """
         # todo: optional, parameter checking logic (if applicable) should happen here
         # if writes derived values to self, should *not* overwrite self.parama etc
         # instead, write to self._parama, self._newparam (starting with _)

--- a/skpro/base/_base.py
+++ b/skpro/base/_base.py
@@ -27,10 +27,53 @@ class BaseObject(_CommonTags, _BaseObject):
 
     def __init__(self):
         super().__init__()
+        self.__dynamic_tags__()
+        self.__post_init__()
+
+    def __dynamic_tags__(self):
+        """Set dynamic tags conditional on parameters.
+
+        Override this method to set tags that depend on the estimator's
+        parameters, e.g., cloning tags from a component estimator.
+        This is called at the end of ``__init__``, after ``super().__init__()``.
+        """
+
+    def __post_init__(self):
+        """Initialize non-parameter attributes and validate parameters.
+
+        Override this method to place parameter checks or initialization
+        of derived quantities that should not be constructor parameters.
+        This is called at the end of ``__init__``, after ``__dynamic_tags__``.
+
+        Avoid overriding ``__init__`` directly; place any such logic here.
+        """
 
 
 class BaseEstimator(_CommonTags, _BaseEstimator):
     """Base class for fittable objects."""
+
+    def __init__(self):
+        super().__init__()
+        self.__dynamic_tags__()
+        self.__post_init__()
+
+    def __dynamic_tags__(self):
+        """Set dynamic tags conditional on parameters.
+
+        Override this method to set tags that depend on the estimator's
+        parameters, e.g., cloning tags from a component estimator.
+        This is called at the end of ``__init__``, after ``super().__init__()``.
+        """
+
+    def __post_init__(self):
+        """Initialize non-parameter attributes and validate parameters.
+
+        Override this method to place parameter checks or initialization
+        of derived quantities that should not be constructor parameters.
+        This is called at the end of ``__init__``, after ``__dynamic_tags__``.
+
+        Avoid overriding ``__init__`` directly; place any such logic here.
+        """
 
 
 class BaseMetaEstimator(_CommonTags, _BaseMetaEstimator):

--- a/skpro/base/_base.py
+++ b/skpro/base/_base.py
@@ -43,7 +43,6 @@ class BaseObject(_CommonTags, _BaseObject):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
 
         IMPORTANT: no significant compute or memory use should happen in __post_init__,
@@ -72,7 +71,6 @@ class BaseEstimator(_CommonTags, _BaseEstimator):
 
         * parameter validation
         * initialization logic beyond self.param = param
-        * dynamic tag setting
         * any soft dependency imports in the constructor
 
         IMPORTANT: no significant compute or memory use should happen in __post_init__,

--- a/skpro/base/_base.py
+++ b/skpro/base/_base.py
@@ -31,11 +31,9 @@ class BaseObject(_CommonTags, _BaseObject):
         self.__post_init__()
 
     def __dynamic_tags__(self):
-        """Set dynamic tags conditional on parameters.
+        """Dynamic tag setter logic for setting tag values conditional on parameters.
 
-        Override this method to set tags that depend on the estimator's
-        parameters, e.g., cloning tags from a component estimator.
-        This is called at the end of ``__init__``, after ``super().__init__()``.
+        This method should be used for setting dynamic tags only.
         """
 
     def __post_init__(self):
@@ -58,11 +56,9 @@ class BaseEstimator(_CommonTags, _BaseEstimator):
         self.__post_init__()
 
     def __dynamic_tags__(self):
-        """Set dynamic tags conditional on parameters.
+        """Dynamic tag setter logic for setting tag values conditional on parameters.
 
-        Override this method to set tags that depend on the estimator's
-        parameters, e.g., cloning tags from a component estimator.
-        This is called at the end of ``__init__``, after ``super().__init__()``.
+        This method should be used for setting dynamic tags only.
         """
 
     def __post_init__(self):

--- a/skpro/base/_base.py
+++ b/skpro/base/_base.py
@@ -37,13 +37,17 @@ class BaseObject(_CommonTags, _BaseObject):
         """
 
     def __post_init__(self):
-        """Initialize non-parameter attributes and validate parameters.
+        """Post-init constructor logic, can be used by inheriting classes.
 
-        Override this method to place parameter checks or initialization
-        of derived quantities that should not be constructor parameters.
-        This is called at the end of ``__init__``, after ``__dynamic_tags__``.
+        This method should be used for:
 
-        Avoid overriding ``__init__`` directly; place any such logic here.
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * dynamic tag setting
+        * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
         """
 
 
@@ -62,13 +66,17 @@ class BaseEstimator(_CommonTags, _BaseEstimator):
         """
 
     def __post_init__(self):
-        """Initialize non-parameter attributes and validate parameters.
+        """Post-init constructor logic, can be used by inheriting classes.
 
-        Override this method to place parameter checks or initialization
-        of derived quantities that should not be constructor parameters.
-        This is called at the end of ``__init__``, after ``__dynamic_tags__``.
+        This method should be used for:
 
-        Avoid overriding ``__init__`` directly; place any such logic here.
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * dynamic tag setting
+        * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
         """
 
 


### PR DESCRIPTION
Part of #1083 - update skpro base framework with sktime upgrades.

Adds two lifecycle hooks to `BaseObject` and `BaseEstimator`:
- **`__dynamic_tags__`**: for conditional tag setting based on parameters (e.g., cloning tags from component estimators), called after `super().__init__()`
- **`__post_init__`**: for parameter validation and initialization of derived quantities, called after `__dynamic_tags__`

Updates all four extension templates (`regression.py`, `distfitter.py`, `distributions.py`, `survival.py`) to document and include these methods, with examples of conditional tag setting and default estimator initialization.

This is the first incremental upgrade of skpro's base framework following sktime's pattern.