### PR TITLE
[DOC] distributtion fitters API reference

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -18,6 +18,7 @@ It describes the classes and functions included in ``skpro``.
     api_reference/regression
     api_reference/survival
     api_reference/distributions
+    api_reference/distfitter
     api_reference/metrics
     api_reference/tags
     api_reference/base

--- a/docs/source/api_reference/distfitter.rst
+++ b/docs/source/api_reference/distfitter.rst
@@ -1,10 +1,10 @@
 
-.. _distfitters_ref:
+.. _distfitter_ref:
 
 Distribution fitters
 ====================
 
-The :mod:`skpro.distfitters` module contains
+The :mod:`skpro.distfitter` module contains
 distribution fitters which combine a ``pandas.DataFrame``-like API
 with a ``scikit-base`` compatible object interface.
 
@@ -12,8 +12,8 @@ All distribution fitters in ``skpro`` can be listed using the ``skpro.registry.a
 using ``object_types="distfitter"``, optionally filtered by tags.
 Valid tags can be listed using ``skpro.registry.all_tags``.
 
-Distribution fitters
---------------------
+Parmetric fitters
+------------------
 
 .. currentmodule:: skpro.distfitter
 

--- a/docs/source/api_reference/distfitter.rst
+++ b/docs/source/api_reference/distfitter.rst
@@ -12,7 +12,7 @@ All distribution fitters in ``skpro`` can be listed using the ``skpro.registry.a
 using ``object_types="distfitter"``, optionally filtered by tags.
 Valid tags can be listed using ``skpro.registry.all_tags``.
 
-Parmetric fitters
+Parametric fitters
 ------------------
 
 .. currentmodule:: skpro.distfitter

--- a/docs/source/api_reference/distfitter.rst
+++ b/docs/source/api_reference/distfitter.rst
@@ -1,0 +1,36 @@
+
+.. _distfitters_ref:
+
+Distribution fitters
+====================
+
+The :mod:`skpro.distfitters` module contains
+distribution fitters which combine a ``pandas.DataFrame``-like API
+with a ``scikit-base`` compatible object interface.
+
+All distribution fitters in ``skpro`` can be listed using the ``skpro.registry.all_objects`` utility,
+using ``object_types="distfitter"``, optionally filtered by tags.
+Valid tags can be listed using ``skpro.registry.all_tags``.
+
+Distribution fitters
+--------------------
+
+.. currentmodule:: skpro.distfitter
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    MOMFitter
+    NormalFitter
+
+Base
+----
+
+.. currentmodule:: skpro.distfitter.base
+
+.. autosummary::
+    :toctree: auto_generated/
+    :template: class.rst
+
+    BaseDistFitter


### PR DESCRIPTION
Adds an API reference page for the distribution fitters in `skpro`.