### PR TITLE
[ENH] `AsymmetricLaplace` distribution via `_ScipyAdapter`

### DIFF
--- a/docs/source/api_reference/distributions.rst
+++ b/docs/source/api_reference/distributions.rst
@@ -35,6 +35,7 @@ Continuous support - full reals
     :toctree: auto_generated/
     :template: class.rst
 
+    AsymmetricLaplace
     Cauchy
     Gumbel
     Laplace

--- a/skpro/distributions/__init__.py
+++ b/skpro/distributions/__init__.py
@@ -5,6 +5,7 @@
 
 __all__ = [
     "Alpha",
+    "AsymmetricLaplace",
     "Beta",
     "Binomial",
     "BurrIII",
@@ -68,6 +69,7 @@ __all__ = [
 ]
 
 from skpro.distributions.alpha import Alpha
+from skpro.distributions.asymmetric_laplace import AsymmetricLaplace
 from skpro.distributions.beta import Beta
 from skpro.distributions.binomial import Binomial
 from skpro.distributions.burr_iii import BurrIII

--- a/skpro/distributions/asymmetric_laplace.py
+++ b/skpro/distributions/asymmetric_laplace.py
@@ -1,0 +1,153 @@
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+"""Asymmetric Laplace probability distribution."""
+
+__author__ = ["Ashish-Kumar-Dash"]
+__all__ = ["AsymmetricLaplace"]
+
+import numpy as np
+import pandas as pd
+from scipy.stats import laplace_asymmetric, rv_continuous
+
+from skpro.distributions.adapters.scipy import _ScipyAdapter
+
+
+class AsymmetricLaplace(_ScipyAdapter):
+    r"""Asymmetric Laplace distribution.
+
+    Most methods wrap ``scipy.stats.laplace_asymmetric``.
+
+    The Asymmetric Laplace distribution is parametrized by asymmetry
+    :math:`\kappa > 0`, location :math:`\mu`, and scale :math:`\sigma > 0`,
+    such that the pdf is
+
+    .. math::
+
+        f(x; \kappa, \mu, \sigma) = \frac{1}{\sigma(\kappa + \kappa^{-1})}
+        \begin{cases}
+            \exp\left(-\kappa \frac{x - \mu}{\sigma}\right),
+                & x \geq \mu \\
+            \exp\left(\frac{x - \mu}{\kappa \sigma}\right),
+                & x < \mu
+        \end{cases}
+
+    For :math:`\kappa = 1`, this reduces to the symmetric Laplace distribution.
+
+    Parameters
+    ----------
+    kappa : float or array of float (1D or 2D), must be positive
+        asymmetry parameter; ``kappa = 1`` gives the symmetric Laplace
+    mu : float or array of float (1D or 2D)
+        location parameter of the distribution
+    scale : float or array of float (1D or 2D), must be positive
+        scale parameter of the distribution
+    index : pd.Index, optional, default = RangeIndex
+    columns : pd.Index, optional, default = RangeIndex
+
+    Examples
+    --------
+    >>> from skpro.distributions import AsymmetricLaplace
+
+    >>> d = AsymmetricLaplace(kappa=2, mu=0, scale=1)
+    """
+
+    _tags = {
+        "authors": ["Ashish-Kumar-Dash"],
+        "capabilities:exact": [
+            "mean",
+            "var",
+            "energy",
+            "pdf",
+            "log_pdf",
+            "cdf",
+            "ppf",
+        ],
+        "distr:measuretype": "continuous",
+        "broadcast_init": "on",
+    }
+
+    def __init__(self, kappa, mu=0, scale=1, index=None, columns=None):
+        self.kappa = kappa
+        self.mu = mu
+        self.scale = scale
+
+        super().__init__(index=index, columns=columns)
+
+    def _get_scipy_object(self) -> rv_continuous:
+        return laplace_asymmetric
+
+    def _get_scipy_param(self):
+        kappa = self._bc_params["kappa"]
+        mu = self._bc_params["mu"]
+        scale = self._bc_params["scale"]
+        return [kappa], {"loc": mu, "scale": scale}
+
+    def _energy_self(self):
+        r"""Energy of self, w.r.t. self.
+
+        :math:`\mathbb{E}[|X-Y|]`, where :math:`X, Y` are i.i.d. copies of self.
+
+        Returns
+        -------
+        2D np.ndarray, same shape as ``self``
+            energy values w.r.t. the given points
+        """
+        K = self._bc_params["kappa"]
+        sc = self._bc_params["scale"]
+
+        energy_arr = sc * (K**4 + K**2 + 1) / (K * (1 + K**2))
+        if energy_arr.ndim > 0:
+            energy_arr = np.sum(energy_arr, axis=1)
+        return energy_arr
+
+    def _energy_x(self, x):
+        r"""Energy of self, w.r.t. a constant frame x.
+
+        :math:`\mathbb{E}[|X-x|]`, where :math:`X` is a copy of self,
+        and :math:`x` is a constant.
+
+        Parameters
+        ----------
+        x : 2D np.ndarray, same shape as ``self``
+            values to compute energy w.r.t. to
+
+        Returns
+        -------
+        2D np.ndarray, same shape as ``self``
+            energy values w.r.t. the given points
+        """
+        K = self._bc_params["kappa"]
+        mu = self._bc_params["mu"]
+        sc = self._bc_params["scale"]
+
+        z = (x - mu) / sc
+        pos = z >= 0
+
+        energy_arr = np.where(
+            pos,
+            z
+            + (K**2 - 1) / K
+            + 2 * np.exp(-K * np.where(pos, z, 0)) / (K * (1 + K**2)),
+            -z
+            - (K**2 - 1) / K
+            + 2 * K**3 * np.exp(np.where(pos, 0, z) / K) / (1 + K**2),
+        )
+        energy_arr = sc * energy_arr
+
+        if energy_arr.ndim > 0:
+            energy_arr = np.sum(energy_arr, axis=1)
+        return energy_arr
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator."""
+        params1 = {"kappa": [[0.5, 2], [1, 3], [2, 0.5]], "mu": 0, "scale": 1}
+        params2 = {
+            "kappa": 2,
+            "mu": 0,
+            "scale": 1,
+            "index": pd.Index([1, 2, 5]),
+            "columns": pd.Index(["a", "b"]),
+        }
+        params3 = {"kappa": 0.5, "mu": -1, "scale": 2}
+
+        return [params1, params2, params3]

--- a/skpro/distributions/energy_formulae.md
+++ b/skpro/distributions/energy_formulae.md
@@ -28,6 +28,7 @@ This file collects analytic formulae, derivations, and summary tables for energy
 | Poisson(3)                    | 1.907392  | 1.910830    | 0.003438  |
 | Rayleigh(1.0)                 | 0.734174  | 0.734174    | 0.000000  |
 | TruncatedNormal(0,1,-1,2)     | 0.824430  | 0.824881    | 0.000451  |
+| AsymmetricLaplace(2,0,1)      | 2.100000  | 2.096770    | 0.003230  |
 
 ## Example: Beta(2,3)
 
@@ -311,6 +312,37 @@ $$
 F(t)(1-F(t)) = \left( 1 - \exp\left(-\frac{t^2}{2\sigma^2}\right) \right) \exp\left(-\frac{t^2}{2\sigma^2}\right) = \exp\left(-\frac{t^2}{2\sigma^2}\right) - \exp\left(-\frac{t^2}{\sigma^2}\right)
 $$
 Integrating this yields $\sigma \sqrt{\frac{\pi}{2}} - \frac{\sigma \sqrt{\pi}}{2}$, which multiplied by 2 gives the analytical solution.
+
+---
+
+## Example: AsymmetricLaplace($\kappa$, $\mu$, $\sigma$)
+
+**PDF:**
+$$
+f(x) = \frac{\kappa}{\sigma(1+\kappa^2)}
+\begin{cases} e^{-\kappa (x-\mu)/\sigma}, & x \geq \mu \\ e^{(x-\mu)/(\kappa\sigma)}, & x < \mu \end{cases}
+$$
+
+**Energy:**
+$$
+\mathbb{E}|X-Y| = \sigma \, \frac{\kappa^4 + \kappa^2 + 1}{\kappa (1 + \kappa^2)}
+$$
+
+**Derivation:**
+Energy is shift-invariant and scales with $\sigma$, so take $\mu=0$, $\sigma=1$. The CDF is
+$$
+F(t) = \frac{\kappa^2 e^{t/\kappa}}{1+\kappa^2} \ (t < 0), \qquad
+F(t) = 1 - \frac{e^{-\kappa t}}{1+\kappa^2} \ (t \geq 0)
+$$
+Using the general formula and splitting at $0$:
+$$
+\mathbb{E}|X-Y| = 2 \int_{-\infty}^{\infty} F(t)(1-F(t)) dt
+$$
+The substitutions $u=e^{t/\kappa}$ (for $t<0$) and $v=e^{-\kappa t}$ (for $t \geq 0$) reduce each piece to a quadratic, giving
+$$
+\int_{-\infty}^{\infty} F(1-F) dt = \frac{\kappa A(2-A)}{2} + \frac{B(2-B)}{2\kappa}, \quad A=\frac{\kappa^2}{1+\kappa^2},\ B=\frac{1}{1+\kappa^2}
+$$
+Doubling and simplifying the numerator $\kappa^6+2\kappa^4+2\kappa^2+1=(\kappa^4+\kappa^2+1)(1+\kappa^2)$ yields the result. For $\kappa=1$ this is $\frac{3}{2}\sigma$.
 
 ---
 


### PR DESCRIPTION
#### Reference Issues/PRs

N/A

  #### What does this implement/fix? Explain your changes.
Adds `AsymmetricLaplace` distribution, wrapping `scipy.stats.laplace_asymmetric` via the `_ScipyAdapter` pattern.

The Asymmetric Laplace generalizes the symmetric Laplace by adding an asymmetry parameter `kappa`. For `kappa = 1`, it reduces to the symmetric Laplace. It is the natural error distribution for Bayesian quantile regression.

  Parameters: `kappa` (asymmetry), `mu` (location), `scale`.

  Includes closed-form `_energy_self` and `_energy_x` for exact CRPS computation:
  - `E|X-Y| = scale * (κ⁴ + κ² + 1) / (κ(1 + κ²))`
  - `E|X-x|` piecewise on `z = (x - μ) / scale`

  Both formulas verified against Monte Carlo estimates for κ ∈ {0.5, 1.0, 2.0, 3.0}.

  #### Does your contribution introduce a new dependency? If yes, which one?

  No. Uses `scipy.stats.laplace_asymmetric` which is already a core dependency.

  #### What should a reviewer concentrate their feedback on?

  - Correctness of the closed-form energy formulas
  - Whether the parametrization (`kappa`, `mu`, `scale`) is appropriate

  #### Did you add any tests for the change?

  Yes, `get_test_params` provides 3 parameter sets (array, scalar+index/columns, scalar) exercised by the generic `TestAllDistributions` suite (103 tests pass).

  #### Any other comments?

  None.

  #### PR checklist

  ##### For all contributions
  - [x] I've added myself to the list of contributors
  - [x] The PR title starts with [ENH]

  ##### For new estimators
  - [x] I've added the estimator to the API reference — `distributions.rst`
  - [x] I've added an illustrative usage example to the docstring
  - [x] No soft dependency — uses scipy (core dependency)
