### PR TITLE
[DOC] Fix Histogram docstring formatting

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -271,6 +271,15 @@
       "contributions": [
         "bug"
       ]
+    },
+    {
+      "login": "Kushagra651",
+      "name": "Kushagra",
+      "avatar_url": "https://avatars.githubusercontent.com/Kushagra651?v=4",
+      "profile": "https://github.com/Kushagra651",
+      "contributions": [
+        "doc"
+      ]
     }
   ]
 }

--- a/skpro/distributions/histogram.py
+++ b/skpro/distributions/histogram.py
@@ -8,48 +8,65 @@ from skpro.distributions.base import _BaseArrayDistribution
 
 
 class Histogram(_BaseArrayDistribution):
-    """Histogram Probability Distribution.
+    """Histogram probability distribution.
 
     The histogram probability distribution is parameterized
-    by the ``bins`` and ``bin_mass``.
+    by ``bins`` and ``bin_mass``, which together define
+    the bin edges and probability mass per bin.
 
     Parameters
     ----------
-    bins : tuple(float, float, int) or numpy.array of float 1D or 2D list of size m x n
-        1. tuple(first bin's start point, last bin's end point, number of bins)
-           Used when ``bin widths`` are ``equal``.
-            example:
-                    bins:(0,4,4)
-        2. array has the bin boundaries with 1st element the first bin's
-           starting point and rest are the bin ending points of all bins
-            example:
-                    bins:[0, 1, 2, 3, 4]
-        3. 2D list of size m x n containing m*n float numpy.arrays or tuple
-           like ``case 1``.
-            example:
-                bins:
-                [
-                        [[0, 1, 2, 3, 4], [5, 5.5, 5.8, 6.5, 7, 7.5]],
-                        [(2, 12, 5), [0, 1, 2, 3, 4]],
-                        [[1.5, 2.5, 3.1, 4, 5.4], [-4, -2, -1.5, 5, 10]]
-                ]
-    bin_mass : array of float 1D or 2D list of size m x n
-        1. Array has the mass of the bins or area of the bins.
-           example:
-                bin_mass:[0.1, 0.2, 0.3, 0.4]
-           ``Note``: ``len(bin_mass)`` will be ``(len(bins)-1)``.
-           ``Note``: ``sum(bin_mass)`` must be ``1``.
-        2. 2D list of size m x n containing m*n float numpy.arrays
-           each satisfying ``case 1``.
-            example:
-                bin_mass:
-                [
-                        [[0.1, 0.2, 0.3, 0.4], [0.25, 0.1, 0, 0.4, 0.25]],
-                        [[0.1, 0.2, 0.4, 0.2, 0.1], [0.4, 0.3, 0.2, 0.1]],
-                        [[0.06, 0.15, 0.09, 0.7], [0.4, 0.15, 0.325, 0.125]]
-                ]
+    bins : tuple, 1D array-like, or 2D list of array-like
+        Specifies the bin edges. Three forms are supported:
+
+        1. ``tuple(start, end, n_bins)`` - used when bin widths are
+           equal. The bins are generated automatically.
+
+           Example: ``bins = (0, 4, 4)``
+
+        2. 1D array-like of bin edges, where the first element is the
+           start of the first bin and the remaining elements are the
+           end points of each bin.
+
+           Example: ``bins = [0, 1, 2, 3, 4]``
+
+        3. 2D list of size ``m x n``, where each entry is a tuple or
+           array as in case 1 or 2, used for the array-valued case.
+
+           Example::
+
+               bins = [
+                   [[0, 1, 2, 3, 4], [5, 5.5, 5.8, 6.5, 7, 7.5]],
+                   [(2, 12, 5), [0, 1, 2, 3, 4]],
+                   [[1.5, 2.5, 3.1, 4, 5.4], [-4, -2, -1.5, 5, 10]],
+               ]
+
+    bin_mass : 1D array-like or 2D list of array-like
+        Specifies the probability mass of each bin.
+
+        1. 1D array-like of bin masses, with length
+           ``len(bins) - 1``, summing to 1.
+
+           Example: ``bin_mass = [0.1, 0.2, 0.3, 0.4]``
+
+        2. 2D list of size ``m x n``, where each entry is a 1D
+           array-like as in case 1, used for the array-valued case.
+
+           Example::
+
+               bin_mass = [
+                   [[0.1, 0.2, 0.3, 0.4], [0.25, 0.1, 0, 0.4, 0.25]],
+                   [[0.1, 0.2, 0.4, 0.2, 0.1], [0.4, 0.3, 0.2, 0.1]],
+                   [[0.06, 0.15, 0.09, 0.7], [0.4, 0.15, 0.325, 0.125]],
+               ]
+
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
+
+    Examples
+    --------
+    >>> from skpro.distributions.histogram import Histogram
+    >>> hist = Histogram(bins=(0, 4, 4), bin_mass=[0.1, 0.2, 0.3, 0.4])
     """
 
     _tags = {


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://skpro.readthedocs.io/en/latest/contribute.html
-->

#### Reference Issues/PRs
Fixes #1077
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Fixes the badly formatted `Histogram` class docstring as reported in #1077.

- Shortened overloaded type lines for `bins` and `bin_mass` to follow numpydoc convention
- Reformatted the three input format cases as clean numbered lists with proper RST code blocks
- Added `Examples` section with a runnable snippet, matching the style of neighboring classes like `Normal`

No logic changes — docstring only.
<!--
A clear and concise description of what you have implemented.
-->

#### Does your contribution introduce a new dependency? If yes, which one?
No.
<!--
If your contribution does add a new core dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core skpro package to a minimum.
-->

#### What should a reviewer concentrate their feedback on?

Whether the docstring formatting now matches the numpydoc conventions used in neighboring distribution classes like `Normal`.

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

No new tests added. Existing estimator contract tests pass (30/30), including `test_doctest_examples[Histogram]` which validates the new `Examples` section.

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

##### For new estimators
- [ ] I've added the estimator to the API reference - in `docs/source/api_reference/taskname.rst`, follow the pattern.
- [ ] I've added one or more illustrative usage examples to the docstring, in a pydocstyle compliant `Examples` section.
- [ ] If the estimator relies on a soft dependency, I've set the `python_dependencies` tag and ensured
  dependency isolation, see the [estimator dependencies guide](https://www.sktime.net/en/latest/developer_guide/dependencies.html#adding-a-soft-dependency).


<!--
Thanks for contributing!
-->
