### PR TITLE
[ENH] robustify `__post_init__` contract, move constructor code to `__post_init__`

### DIFF
--- a/skpro/base/_base.py
+++ b/skpro/base/_base.py
@@ -28,13 +28,13 @@ class BaseObject(_CommonTags, _BaseObject):
     def __init__(self):
         super().__init__()
         self.__dynamic_tags__()
-        self.__post_init__()
 
     def __dynamic_tags__(self):
         """Dynamic tag setter logic for setting tag values conditional on parameters.
 
         This method should be used for setting dynamic tags only.
         """
+        pass
 
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.
@@ -48,6 +48,7 @@ class BaseObject(_CommonTags, _BaseObject):
         IMPORTANT: no significant compute or memory use should happen in __post_init__,
         memory and compute intensive operations should be in _fit, not __post_init__.
         """
+        pass
 
 
 class BaseEstimator(_CommonTags, _BaseEstimator):
@@ -56,13 +57,13 @@ class BaseEstimator(_CommonTags, _BaseEstimator):
     def __init__(self):
         super().__init__()
         self.__dynamic_tags__()
-        self.__post_init__()
 
     def __dynamic_tags__(self):
         """Dynamic tag setter logic for setting tag values conditional on parameters.
 
         This method should be used for setting dynamic tags only.
         """
+        pass
 
     def __post_init__(self):
         """Post-init constructor logic, can be used by inheriting classes.
@@ -76,6 +77,7 @@ class BaseEstimator(_CommonTags, _BaseEstimator):
         IMPORTANT: no significant compute or memory use should happen in __post_init__,
         memory and compute intensive operations should be in _fit, not __post_init__.
         """
+        pass
 
 
 class BaseMetaEstimator(_CommonTags, _BaseMetaEstimator):

--- a/skpro/distfitter/base/_base.py
+++ b/skpro/distfitter/base/_base.py
@@ -40,10 +40,15 @@ class BaseDistFitter(BaseEstimator):
 
     def __init__(self):
         super().__init__()
-        _check_estimator_deps(self)
 
         self._X_converter_store = {}
         self._C_converter_store = {}
+
+        # this block has a double purpose:
+        # - emit a warning if dependencies are not met, but allow instantiation
+        # - if dependencies are met, call __post_init__ used by inheriting classes
+        if _check_estimator_deps(self, severity="warning"):
+            self.__post_init__()
 
     def fit(self, X, C=None):
         """Fit distribution to data.

--- a/skpro/distributions/base/_base.py
+++ b/skpro/distributions/base/_base.py
@@ -52,8 +52,11 @@ class BaseDistribution(BaseObject):
         self.index = _coerce_to_pd_index_or_none(index)
         self.columns = _coerce_to_pd_index_or_none(columns)
 
-        super().__init__()
-        _check_estimator_deps(self)
+        # this block has a double purpose:
+        # - emit a warning if dependencies are not met, but allow instantiation
+        # - if dependencies are met, call __post_init__ used by inheriting classes
+        if _check_estimator_deps(self, severity="warning"):
+            self.__post_init__()
 
         self._init_shape_bc(index=index, columns=columns)
 

--- a/skpro/distributions/base/_base.py
+++ b/skpro/distributions/base/_base.py
@@ -52,6 +52,8 @@ class BaseDistribution(BaseObject):
         self.index = _coerce_to_pd_index_or_none(index)
         self.columns = _coerce_to_pd_index_or_none(columns)
 
+        super().__init__()
+
         # this block has a double purpose:
         # - emit a warning if dependencies are not met, but allow instantiation
         # - if dependencies are met, call __post_init__ used by inheriting classes

--- a/skpro/regression/base/_base.py
+++ b/skpro/regression/base/_base.py
@@ -38,11 +38,16 @@ class BaseProbaRegressor(BaseEstimator):
 
     def __init__(self):
         super().__init__()
-        _check_estimator_deps(self)
 
         self._X_converter_store = {}
         self._y_converter_store = {}
         self._C_converter_store = {}
+
+        # this block has a double purpose:
+        # - emit a warning if dependencies are not met, but allow instantiation
+        # - if dependencies are met, call __post_init__ used by inheriting classes
+        if _check_estimator_deps(self, severity="warning"):
+            self.__post_init__()
 
     def __rmul__(self, other):
         """Magic * method, return (left) concatenated Pipeline.

--- a/skpro/regression/cyclic_boosting.py
+++ b/skpro/regression/cyclic_boosting.py
@@ -164,6 +164,25 @@ class CyclicBoosting(BaseProbaRegressor):
 
         super().__init__()
 
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
+        """
+        dist_type = self.dist_type
+        dist = self.dist
+        feature_groups = self.feature_groups
+        feature_properties = self.feature_properties
+        alpha = self.alpha
+        maximal_iterations = self.maximal_iterations
+
         # todo 2.15.0: remove the following 'if' check and deprecation warning
         # handle deprecation of dist_type -> dist
         if dist_type != "deprecated":

--- a/skpro/regression/delta.py
+++ b/skpro/regression/delta.py
@@ -55,6 +55,11 @@ class DeltaPointRegressor(BaseProbaRegressor):
 
         super().__init__()
 
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values conditional on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
         # todo: find the equivalent tag in sklearn for missing data handling
         # tags_to_clone = ["capability:missing"]
         # self.clone_tags(estimator, tags_to_clone)

--- a/skpro/regression/enbpi.py
+++ b/skpro/regression/enbpi.py
@@ -126,10 +126,28 @@ class EnbpiRegressor(BaseProbaRegressor):
 
         super().__init__()
 
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values conditional on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
         # todo: find the equivalent tag in sklearn for missing data handling
         # tags_to_clone = ["capability:missing"]
         # self.clone_tags(estimator, tags_to_clone)
 
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
+        """
+        agg_fun = self.agg_fun
         aggfun_dict = {
             "mean": np.nanmean,
             "median": np.nanmedian,

--- a/skpro/regression/ensemble/_bagging.py
+++ b/skpro/regression/ensemble/_bagging.py
@@ -111,6 +111,12 @@ class BaggingRegressor(BaseProbaRegressor):
 
         super().__init__()
 
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values conditional on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
+        estimator = self.estimator
         tags_to_clone = ["capability:missing", "capability:survival"]
         self.clone_tags(estimator, tags_to_clone)
 

--- a/skpro/regression/ensemble/_stacking.py
+++ b/skpro/regression/ensemble/_stacking.py
@@ -103,6 +103,11 @@ class StackingProbaRegressor(BaseMetaEstimator, BaseProbaRegressor):
 
         super().__init__()
 
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values conditional on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
         est_list = self._estimators
 
         self._anytagis_then_set("capability:missing", False, True, est_list)

--- a/skpro/regression/ensemble/_voting.py
+++ b/skpro/regression/ensemble/_voting.py
@@ -75,6 +75,11 @@ class VotingProbaRegressor(BaseMetaEstimator, BaseProbaRegressor):
 
         super().__init__()
 
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values conditional on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
         est_list = self._estimators
 
         # self can handle missing data if and only if all components can

--- a/skpro/regression/gam/_gam.py
+++ b/skpro/regression/gam/_gam.py
@@ -139,6 +139,20 @@ class GAMRegressor(BaseProbaRegressor):
 
         super().__init__()
 
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
+        """
+        distribution = self.distribution
+        dist = self.dist
         # todo 2.15.0: remove the following 'if' check and deprecation warning
         # handle deprecation of distribution -> dist
         if distribution != "deprecated":

--- a/skpro/regression/gp/_sklearn.py
+++ b/skpro/regression/gp/_sklearn.py
@@ -164,7 +164,6 @@ class GaussianProcess(_DelegateWithFittedParamForwarding):
         skpro_est = SklearnProbaReg(skl_estimator)
         self._estimator = skpro_est.clone()
 
-
     FITTED_PARAMS_TO_FORWARD = [
         "kernel_",
         "L_",

--- a/skpro/regression/gp/_sklearn.py
+++ b/skpro/regression/gp/_sklearn.py
@@ -125,6 +125,29 @@ class GaussianProcess(_DelegateWithFittedParamForwarding):
         self.n_targets = n_targets
         self.random_state = random_state
 
+        super().__init__()
+
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
+        """
+        kernel = self.kernel
+        alpha = self.alpha
+        optimizer = self.optimizer
+        n_restarts_optimizer = self.n_restarts_optimizer
+        normalize_y = self.normalize_y
+        copy_X_train = self.copy_X_train
+        n_targets = self.n_targets
+        random_state = self.random_state
+
         from sklearn.gaussian_process import GaussianProcessRegressor
 
         skl_estimator = GaussianProcessRegressor(
@@ -141,7 +164,6 @@ class GaussianProcess(_DelegateWithFittedParamForwarding):
         skpro_est = SklearnProbaReg(skl_estimator)
         self._estimator = skpro_est.clone()
 
-        super().__init__()
 
     FITTED_PARAMS_TO_FORWARD = [
         "kernel_",

--- a/skpro/regression/linear/_glm.py
+++ b/skpro/regression/linear/_glm.py
@@ -288,6 +288,20 @@ class GLMRegressor(BaseProbaRegressor):
 
         super().__init__()
 
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
+        """
+        family = self.family
+        dist = self.dist
         # todo 2.15.0: remove the following 'if' check and deprecation warning
         # handle deprecation of family -> dist
         if family != "deprecated":

--- a/skpro/regression/linear/_glum.py
+++ b/skpro/regression/linear/_glum.py
@@ -201,6 +201,20 @@ class GlumRegressor(BaseProbaRegressor):
 
         super().__init__()
 
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
+        """
+        family = self.family
+        dist = self.dist
         # todo 2.15.0: remove the following 'if' check and deprecation warning
         # handle deprecation of family -> dist
         if family != "deprecated":

--- a/skpro/regression/linear/_sklearn.py
+++ b/skpro/regression/linear/_sklearn.py
@@ -159,7 +159,6 @@ class ARDRegression(_DelegateWithFittedParamForwarding):
         skpro_est = SklearnProbaReg(skl_estimator, inner_type="np.ndarray")
         self._estimator = skpro_est.clone()
 
-
     FITTED_PARAMS_TO_FORWARD = [
         "coef_",
         "alpha_",

--- a/skpro/regression/linear/_sklearn.py
+++ b/skpro/regression/linear/_sklearn.py
@@ -114,6 +114,32 @@ class ARDRegression(_DelegateWithFittedParamForwarding):
         self.copy_X = copy_X
         self.verbose = verbose
 
+        super().__init__()
+
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
+        """
+        max_iter = self.max_iter
+        tol = self.tol
+        alpha_1 = self.alpha_1
+        alpha_2 = self.alpha_2
+        lambda_1 = self.lambda_1
+        lambda_2 = self.lambda_2
+        compute_score = self.compute_score
+        threshold_lambda = self.threshold_lambda
+        fit_intercept = self.fit_intercept
+        copy_X = self.copy_X
+        verbose = self.verbose
+
         from sklearn.linear_model import ARDRegression
 
         skl_estimator = ARDRegression(
@@ -133,7 +159,6 @@ class ARDRegression(_DelegateWithFittedParamForwarding):
         skpro_est = SklearnProbaReg(skl_estimator, inner_type="np.ndarray")
         self._estimator = skpro_est.clone()
 
-        super().__init__()
 
     FITTED_PARAMS_TO_FORWARD = [
         "coef_",

--- a/skpro/regression/linear/_sklearn_poisson.py
+++ b/skpro/regression/linear/_sklearn_poisson.py
@@ -89,6 +89,25 @@ class PoissonRegressor(BaseProbaRegressor):
 
         super().__init__()
 
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
+        """
+        alpha = self.alpha
+        fit_intercept = self.fit_intercept
+        max_iter = self.max_iter
+        tol = self.tol
+        verbose = self.verbose
+        warm_start = self.warm_start
+
         from sklearn.linear_model import PoissonRegressor
 
         skl_estimator = PoissonRegressor(

--- a/skpro/regression/multiquantile.py
+++ b/skpro/regression/multiquantile.py
@@ -123,6 +123,22 @@ class MultipleQuantileRegressor(BaseProbaRegressor):
 
         super().__init__()
 
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
+        """
+        alpha = self.alpha
+        quantile_regressor = self.quantile_regressor
+        mean_regressor = self.mean_regressor
+
         if alpha is None:
             _alpha = [0.1, 0.25, 0.5, 0.75, 0.9]
         elif len(alpha) == 0:

--- a/skpro/regression/ondil.py
+++ b/skpro/regression/ondil.py
@@ -68,11 +68,27 @@ class OndilOnlineGamlss(BaseProbaRegressor):
         self.distribution = distribution
         self.dist = dist
         self.ondil_init_params = ondil_init_params
-        # explicit dict of kwargs forwarded to the ondil constructor.
-        self._ondil_kwargs = dict(ondil_init_params or {})
 
         super().__init__()
 
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
+        """
+        ondil_init_params = self.ondil_init_params
+        # explicit dict of kwargs forwarded to the ondil constructor.
+        self._ondil_kwargs = dict(ondil_init_params or {})
+
+        distribution = self.distribution
+        dist = self.dist
         # todo 2.15.0: remove the following 'if' check and deprecation warning
         # handle deprecation of distribution -> dist
         if distribution != "deprecated":

--- a/skpro/regression/online/_batch_mixture.py
+++ b/skpro/regression/online/_batch_mixture.py
@@ -78,6 +78,12 @@ class OnlineBatchMixture(BaseProbaRegressor):
 
         super().__init__()
 
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values conditional on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
+        estimator = self.estimator
         tags_to_clone = [
             "capability:missing",
             "capability:survival",

--- a/skpro/regression/online/_dont_refit.py
+++ b/skpro/regression/online/_dont_refit.py
@@ -33,12 +33,30 @@ class OnlineDontRefit(_DelegatedProbaRegressor):
 
         super().__init__()
 
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values conditional on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
+        estimator = self.estimator
         tags_to_clone = [
             "capability:missing",
             "capability:survival",
         ]
         self.clone_tags(estimator, tags_to_clone)
 
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
+        """
         self.estimator_ = self.estimator.clone()
 
     def _update(self, X, y, C=None):

--- a/skpro/regression/online/_refit.py
+++ b/skpro/regression/online/_refit.py
@@ -35,6 +35,12 @@ class OnlineRefit(_DelegatedProbaRegressor):
 
         super().__init__()
 
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values conditional on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
+        estimator = self.estimator
         tags_to_clone = [
             "capability:missing",
             "capability:survival",

--- a/skpro/regression/online/_refit_every.py
+++ b/skpro/regression/online/_refit_every.py
@@ -41,12 +41,31 @@ class OnlineRefitEveryN(_DelegatedProbaRegressor):
 
         super().__init__()
 
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values conditional on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
+        estimator = self.estimator
         tags_to_clone = [
             "capability:missing",
             "capability:survival",
         ]
         self.clone_tags(estimator, tags_to_clone)
 
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
+        """
+        estimator = self.estimator
         self.estimator_ = estimator.clone()
 
         self._X = None

--- a/skpro/regression/residual.py
+++ b/skpro/regression/residual.py
@@ -156,6 +156,22 @@ class ResidualDouble(BaseProbaRegressor):
 
         super().__init__()
 
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
+        """
+        dist = self.dist
+        distr_type = self.distr_type
+        estimator = self.estimator
+        estimator_resid = self.estimator_resid
         # todo 2.15.0: remove the following 'if' check and deprecation warning
         # handle deprecation of distr_type -> dist
         if distr_type != "deprecated":

--- a/skpro/regression/xgboostlss.py
+++ b/skpro/regression/xgboostlss.py
@@ -228,10 +228,27 @@ class XGBoostLSS(BaseProbaRegressor):
 
         super().__init__()
 
+    def __dynamic_tags__(self):
+        """Dynamic tag setter logic for setting tag values conditional on parameters.
+
+        This method should be used for setting dynamic tags only.
+        """
         # If n_trials is not zero, optuna is required for hyperparameter optimization
-        if n_trials != 0:
+        if self.n_trials != 0:
             self.set_tags(**{"python_dependencies": ["xgboostlss", "optuna"]})
 
+    def __post_init__(self):
+        """Post-init constructor logic, can be used by inheriting classes.
+
+        This method should be used for:
+
+        * parameter validation
+        * initialization logic beyond self.param = param
+        * any soft dependency imports in the constructor
+
+        IMPORTANT: no significant compute or memory use should happen in __post_init__,
+        memory and compute intensive operations should be in _fit, not __post_init__.
+        """
         self._xgb_params = [
             "max_depth",
             "max_leaves",


### PR DESCRIPTION
This PR:

* robustifies the `__post_init__` contract by bringing it in line with the `sktime` convention that the estimators can be constructed using `__post_init__`
* moves estimator code in many (not all) estimators to the correct `__post_init__` or `__dynamic_tags__` location