### PR TITLE
[BUG] fix Bayesian regressors overwriting __init__ parameters

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -271,6 +271,14 @@
       "contributions": [
         "bug"
       ]
+    },
+    {
+      "login": "molloyzak13",
+      "name": "Zak Molloy",
+      "contributions": [
+        "bug",
+        "code"
+      ]
     }
   ]
 }

--- a/skpro/regression/bayesian/_linear_conjugate.py
+++ b/skpro/regression/bayesian/_linear_conjugate.py
@@ -122,28 +122,8 @@ class BayesianConjugateLinearRegressor(BaseProbaRegressor):
             Known precision of the Gaussian likelihood noise (beta)
             This is the inverse of the noise variance.
         """
-        if coefs_prior_cov is None:
-            raise ValueError("`coefs_prior_cov` must be provided.")
-        else:
-            self.coefs_prior_cov = coefs_prior_cov
-
-        # Set coefs_prior_mu to a zero vector if not provided
-        if coefs_prior_mu is None:
-            self.coefs_prior_mu = np.zeros((self.coefs_prior_cov.shape[0], 1))
-        # Ensure coefs_prior_mu is a column vector
-        elif coefs_prior_mu.ndim != 2 or coefs_prior_mu.shape[1] != 1:
-            raise ValueError(
-                "coefs_prior_mu must be a column vector with shape (n_features, 1)."
-            )
-        else:
-            self.coefs_prior_mu = coefs_prior_mu
-
-        # Validate dimensions of coefs_prior_mu and coefs_prior_cov
-        if self.coefs_prior_mu.shape[0] != self.coefs_prior_cov.shape[0]:
-            raise ValueError(
-                "Dimensionality of `coefs_prior_mu` and `coefs_prior_cov` must match."
-            )
-
+        self.coefs_prior_cov = coefs_prior_cov
+        self.coefs_prior_mu = coefs_prior_mu
         self.noise_precision = noise_precision
 
         super().__init__()
@@ -162,10 +142,28 @@ class BayesianConjugateLinearRegressor(BaseProbaRegressor):
         -------
         self : reference to self
         """
+        if self.coefs_prior_cov is None:
+            raise ValueError("`coefs_prior_cov` must be provided.")
+
+        # Resolve coefs_prior_mu: use zero vector if not provided
+        coefs_prior_mu = self.coefs_prior_mu
+        if coefs_prior_mu is None:
+            coefs_prior_mu = np.zeros((self.coefs_prior_cov.shape[0], 1))
+        elif coefs_prior_mu.ndim != 2 or coefs_prior_mu.shape[1] != 1:
+            raise ValueError(
+                "coefs_prior_mu must be a column vector with shape (n_features, 1)."
+            )
+
+        # Validate dimensions of coefs_prior_mu and coefs_prior_cov
+        if coefs_prior_mu.shape[0] != self.coefs_prior_cov.shape[0]:
+            raise ValueError(
+                "Dimensionality of `coefs_prior_mu` and `coefs_prior_cov` must match."
+            )
+
         self._y_cols = y.columns
 
         # Construct the prior mean and covariance
-        self._coefs_prior_mu = self.coefs_prior_mu
+        self._coefs_prior_mu = coefs_prior_mu
         self._coefs_prior_cov = self.coefs_prior_cov
         self._coefs_prior_precision = np.linalg.inv(self._coefs_prior_cov)
 
@@ -319,4 +317,10 @@ class BayesianConjugateLinearRegressor(BaseProbaRegressor):
             "noise_precision": 0.5,
         }
 
-        return [params1, params2]
+        params3 = {
+            "coefs_prior_mu": None,
+            "coefs_prior_cov": np.eye(10),
+            "noise_precision": 1.0,
+        }
+
+        return [params1, params2, params3]

--- a/skpro/regression/bayesian/_linear_mcmc.py
+++ b/skpro/regression/bayesian/_linear_mcmc.py
@@ -147,9 +147,13 @@ class BayesianLinearRegressor(BaseProbaRegressor):
             y_data = pm.Data("y", self._y_vals, dims=("obs_id"))
 
             # Priors for model parameters, taken from self._prior_config
-            self.intercept = self._prior_config["intercept"].create_variable("intercept")
+            self.intercept = self._prior_config["intercept"].create_variable(
+                "intercept"
+            )
             self.slopes = self._prior_config["slopes"].create_variable("slopes")
-            self.noise_var = self._prior_config["noise_var"].create_variable("noise_var")
+            self.noise_var = self._prior_config["noise_var"].create_variable(
+                "noise_var"
+            )
             self.noise = pm.Deterministic("noise", self.noise_var**0.5)
 
             # Expected value of the target variable

--- a/skpro/regression/bayesian/_linear_mcmc.py
+++ b/skpro/regression/bayesian/_linear_mcmc.py
@@ -62,12 +62,8 @@ class BayesianLinearRegressor(BaseProbaRegressor):
     }
 
     def __init__(self, prior_config=None, sampler_config=None):
-        if sampler_config is None:
-            sampler_config = {}
-        if prior_config is None:
-            prior_config = {}  # configuration for priors
-        self.sampler_config = {**self.default_sampler_config, **sampler_config}
-        self.prior_config = {**self.default_prior_config, **prior_config}
+        self.prior_config = prior_config
+        self.sampler_config = sampler_config
         self.model = None  # generated during fitting
         self.idata = None  # generated during fitting
         self._predict_done = False  # a flag indicating if a prediction has been done
@@ -127,6 +123,16 @@ class BayesianLinearRegressor(BaseProbaRegressor):
         import pandas as pd
         import pymc as pm
 
+        # Resolve prior and sampler configs with class defaults
+        prior_config = self.prior_config
+        if prior_config is None:
+            prior_config = {}
+        sampler_config = self.sampler_config
+        if sampler_config is None:
+            sampler_config = {}
+        self._prior_config = {**self.default_prior_config, **prior_config}
+        self._sampler_config = {**self.default_sampler_config, **sampler_config}
+
         assert len(y.columns) == 1, "y must have only one column!"
         self._X = X
         self._y = y
@@ -140,10 +146,10 @@ class BayesianLinearRegressor(BaseProbaRegressor):
             X_data = pm.Data("X", X, dims=("obs_id", "pred_id"))
             y_data = pm.Data("y", self._y_vals, dims=("obs_id"))
 
-            # Priors for model parameters, taken from self.prior_config
-            self.intercept = self.prior_config["intercept"].create_variable("intercept")
-            self.slopes = self.prior_config["slopes"].create_variable("slopes")
-            self.noise_var = self.prior_config["noise_var"].create_variable("noise_var")
+            # Priors for model parameters, taken from self._prior_config
+            self.intercept = self._prior_config["intercept"].create_variable("intercept")
+            self.slopes = self._prior_config["slopes"].create_variable("slopes")
+            self.noise_var = self._prior_config["noise_var"].create_variable("noise_var")
             self.noise = pm.Deterministic("noise", self.noise_var**0.5)
 
             # Expected value of the target variable
@@ -157,7 +163,7 @@ class BayesianLinearRegressor(BaseProbaRegressor):
             )
 
             # Constructing the posterior
-            self.idata = pm.sample(**self.sampler_config)
+            self.idata = pm.sample(**self._sampler_config)
 
         # Incorporation of training_data as a new group in self.idata
         training_data = pd.concat([X, y], axis=1)
@@ -295,7 +301,7 @@ class BayesianLinearRegressor(BaseProbaRegressor):
                     # Create a new 'sample_id' column by
                     # combining the 'chain' and 'draw' columns
                     pred_proba_df["sample_id"] = (
-                        pred_proba_df["chain"] * self.sampler_config["draws"]
+                        pred_proba_df["chain"] * self._sampler_config["draws"]
                         + pred_proba_df["draw"]
                     )
                     pred_proba_df = pred_proba_df[["obs_id", "sample_id", "y_obs"]]
@@ -389,8 +395,8 @@ class BayesianLinearRegressor(BaseProbaRegressor):
                 )
             self.idata.extend(
                 pm.sample_prior_predictive(
-                    samples=self.sampler_config["draws"],
-                    random_seed=self.sampler_config["random_seed"],
+                    samples=self._sampler_config["draws"],
+                    random_seed=self._sampler_config["random_seed"],
                 )
             )  # todo: the keyword 'samples' will be changed to 'draws'
             # in pymc 5.16


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #1102.

#### What does this implement/fix? Explain your changes.

The two Bayesian regressors were breaking the skpro API contract by overwriting constructor parameters after assignment. In the API spec (`extension_templates/regression`), `__init__` must only do `self.param = param` -- no validation, no reshaping, no default-filling.

`BayesianConjugateLinearRegressor` was running full validation in `__init__`: None-checking `coefs_prior_cov`, reshaping `coefs_prior_mu` to a column vector, filling a zero-vector default, and validating dimension match between prior mean and covariance. Moved all of that to `__post_init__`. The `__init__` now just stores the raw values. Also added a third `get_test_params` case with `coefs_prior_mu=None` to cover the default zero-vector path, which wasn't exercised before.

`BayesianLinearRegressor` was merging user-supplied config dicts with class defaults inside `__init__` and writing the merged result back to `self.prior_config` and `self.sampler_config`. Moved the merge into `_fit`, using local variables, and stored the resolved configs in `self._prior_config` / `self._sampler_config` (private attributes). Updated all references throughout the class to use the private versions so the original `self.prior_config` and `self.sampler_config` stay as the user passed them.

The pattern matches what PR #1103 applied to the other non-compliant estimator classes -- store raw parameters in `__init__`, handle validation and defaults later in the lifecycle.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

The `BayesianConjugateLinearRegressor` change is a straightforward `__init__` to `__post_init__` move, mirroring #1103. The `BayesianLinearRegressor` case is slightly different since it merges config dicts at fit time rather than post-init -- I stored the resolved configs in private attrs and updated all references throughout the class. Would appreciate a check that I haven't missed any remaining reference to `self.prior_config` or `self.sampler_config` outside the `_fit` scope.

#### Did you add any tests for the change?

Added a `params3` case to `BayesianConjugateLinearRegressor.get_test_params` with `coefs_prior_mu=None` to exercise the zero-vector default path. The existing `params1` and `params2` cases cover the other paths.

#### Any other comments?

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
  How to: add yourself to the [all-contributors file](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory (not the `CONTRIBUTORS.md`). Common badges: `code` - fixing a bug, or adding code logic. `doc` - writing or improving documentation or docstrings. `bug` - reporting or diagnosing a bug (get this plus `code` if you also fixed the bug in the PR).`maintenance` - CI, test framework, release.
  See here for [full badge reference](https://allcontributors.org/docs/en/emoji-key)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

