### PR TITLE
[BUG] enable and stabilize discrete PMF plotting regression

### DIFF
--- a/skpro/distributions/tests/test_proba_basic.py
+++ b/skpro/distributions/tests/test_proba_basic.py
@@ -165,7 +165,8 @@ def test_discrete_pmf_plotting():
     assert ax.containers, "Expected at least one stem container"
 
     container = ax.containers[0]
-    # For current matplotlib versions, StemContainer includes markerline/stemlines/baseline.
+    # For current matplotlib versions, StemContainer includes
+    # markerline/stemlines/baseline.
     # This check validates that the PMF is plotted at multiple support points.
     if hasattr(container, "markerline") and hasattr(container.markerline, "get_xdata"):
         assert len(container.markerline.get_xdata()) > 5

--- a/skpro/distributions/tests/test_proba_basic.py
+++ b/skpro/distributions/tests/test_proba_basic.py
@@ -162,13 +162,16 @@ def test_discrete_pmf_plotting():
     # For small distributions, check that all support points are plotted
     # Binomial(n=10) has support [0,1,2,...,10] = 11 points
     # The stem plot should have evaluated at these points
-    if hasattr(ax.containers[0], "get_children"):
-        # Check the number of data points in the marker line
-        # StemContainer always has 3 children (markerline, stemlines, baseline)
-        # regardless of data count, so check the data itself
-        children = ax.containers[0].get_children()
-        markerline = children[0]
-        assert len(markerline.get_xdata()) > 5, "Should plot at multiple support points"
+    assert ax.containers, "Expected at least one stem container"
+
+    container = ax.containers[0]
+    # For current matplotlib versions, StemContainer includes
+    # markerline/stemlines/baseline.
+    # This check validates that the PMF is plotted at multiple support points.
+    if hasattr(container, "markerline") and hasattr(container.markerline, "get_xdata"):
+        assert len(container.markerline.get_xdata()) > 5
+    else:
+        assert len(container.get_children()) > 5
 
 
 def test_to_df_parametric():

--- a/skpro/distributions/tests/test_proba_basic.py
+++ b/skpro/distributions/tests/test_proba_basic.py
@@ -141,7 +141,6 @@ def test_proba_plotting(fun):
     assert isinstance(ax, Axes)
 
 
-@pytest.mark.skip(reason="Undiagnosed failure. Skipping until resolved. See #918.")
 @pytest.mark.skipif(
     not _check_soft_dependencies("matplotlib", severity="none"),
     reason="skip if matplotlib is not available",
@@ -163,11 +162,15 @@ def test_discrete_pmf_plotting():
     # For small distributions, check that all support points are plotted
     # Binomial(n=10) has support [0,1,2,...,10] = 11 points
     # The stem plot should have evaluated at these points
-    if hasattr(ax.containers[0], "get_children"):
-        # This is a rough check - the stem plot should have multiple elements
-        assert (
-            len(ax.containers[0].get_children()) > 5
-        ), "Should plot at multiple support points"
+    assert ax.containers, "Expected at least one stem container"
+
+    container = ax.containers[0]
+    # For current matplotlib versions, StemContainer includes markerline/stemlines/baseline.
+    # This check validates that the PMF is plotted at multiple support points.
+    if hasattr(container, "markerline") and hasattr(container.markerline, "get_xdata"):
+        assert len(container.markerline.get_xdata()) > 5
+    else:
+        assert len(container.get_children()) > 5
 
 
 def test_to_df_parametric():


### PR DESCRIPTION
## What I changed

This unskips and hardens `test_discrete_pmf_plotting` for current matplotlib behavior.

- Removed the temporary skip in `test_discrete_pmf_plotting`.
- Replaced the brittle container child-count assertion with one that checks stem marker points directly.
- The test now validates support-point plotting behavior without depending on matplotlib internals that vary across versions.

Fixes #918.
