### PR TITLE
[BUG] TruncatedPareto: add closed-form mean and var

### DIFF
--- a/skpro/distributions/tests/test_truncated_pareto.py
+++ b/skpro/distributions/tests/test_truncated_pareto.py
@@ -1,0 +1,77 @@
+"""Tests for TruncatedPareto distribution."""
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+
+import warnings
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+from scipy import integrate
+from scipy.stats import pareto
+
+from skpro.distributions.truncated_pareto import TruncatedPareto
+from skpro.tests.test_switch import run_test_module_changed
+
+# (b, scale, lower, upper), spanning wide windows and the b == 1 / b == 2
+# moment boundaries (where the naive power-law formula becomes logarithmic).
+MOMENT_CASES = [
+    (2.0, 1.0, 1.0, 10.0),
+    (3.0, 2.0, 2.0, 20.0),
+    (2.0, 1.0, 1.0, 100.0),  # wide window: base ppf-average is ~33% low here
+    (0.5, 1.0, 1.0, 50.0),
+    (1.0, 1.0, 1.0, 10.0),  # b == 1: mean uses the log form
+    (2.0, 1.0, 1.0, 50.0),  # b == 2: second moment uses the log form
+    (4.0, 1.0, 1.0, 1000.0),
+]
+
+
+def _quad_moments(b, scale, lower, upper):
+    """Mean/var by adaptive pdf integration on the bounded support (oracle)."""
+    norm = pareto.cdf(upper, b, scale=scale) - pareto.cdf(lower, b, scale=scale)
+    pdf = lambda x: pareto.pdf(x, b, scale=scale) / norm  # noqa: E731
+    m1, _ = integrate.quad(lambda x: x * pdf(x), lower, upper, limit=200)
+    m2, _ = integrate.quad(lambda x: x * x * pdf(x), lower, upper, limit=200)
+    return m1, m2 - m1 * m1
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
+@pytest.mark.parametrize("b,scale,lower,upper", MOMENT_CASES)
+def test_truncated_pareto_moments_exact(b, scale, lower, upper):
+    """mean/var match the closed form / adaptive quadrature, no approx warning."""
+    dist = TruncatedPareto(b=b, scale=scale, lower=lower, upper=upper)
+    exp_mean, exp_var = _quad_moments(b, scale, lower, upper)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # exact tag must not fall back + warn
+        mean = float(np.asarray(dist.mean()).ravel()[0])
+        var = float(np.asarray(dist.var()).ravel()[0])
+
+    assert_allclose(mean, exp_mean, rtol=1e-9)
+    assert_allclose(var, exp_var, rtol=1e-9)
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
+def test_truncated_pareto_moments_broadcast():
+    """Closed-form moments broadcast and preserve shape/index/columns."""
+    b = [[2.0, 3.0], [1.0, 2.0]]  # includes b == 1 and b == 2 boundaries
+    dist = TruncatedPareto(b=b, scale=1.0, lower=1.0, upper=25.0)
+
+    mean = dist.mean()
+    var = dist.var()
+
+    assert mean.shape == dist.shape
+    assert var.shape == dist.shape
+    assert mean.index.equals(dist.index)
+    assert var.columns.equals(dist.columns)
+
+    for i in range(2):
+        for j in range(2):
+            exp_mean, exp_var = _quad_moments(b[i][j], 1.0, 1.0, 25.0)
+            assert_allclose(mean.iloc[i, j], exp_mean, rtol=1e-9)
+            assert_allclose(var.iloc[i, j], exp_var, rtol=1e-9)

--- a/skpro/distributions/truncated_pareto.py
+++ b/skpro/distributions/truncated_pareto.py
@@ -46,6 +46,56 @@ class TruncatedPareto(BaseDistribution):
         self.upper = upper
         super().__init__(index=index, columns=columns)
 
+    def _raw_moment(self, k):
+        r"""Return the ``k``-th raw moment :math:`\mathbb{E}[X^k]`, entry-wise.
+
+        With shape ``b``, scale ``s`` and truncation ``[l, u]``,
+
+        .. math::
+            \mathbb{E}[X^k] = \frac{b s^b}{Z} \int_l^u x^{k-b-1} dx,
+            \quad Z = (s/l)^b - (s/u)^b.
+
+        The integral equals :math:`(u^{k-b} - l^{k-b}) / (k-b)` for
+        :math:`b \neq k`, and :math:`\ln(u/l)` at the removable singularity
+        :math:`b = k`.
+        """
+        b = self._bc_params["b"]
+        scale = self._bc_params["scale"]
+        lower = self._bc_params["lower"]
+        upper = self._bc_params["upper"]
+
+        norm = (scale / lower) ** b - (scale / upper) ** b
+        exponent = k - b
+        # k - b == 0 is a removable singularity; avoid 0/0 in the unused branch
+        safe_exponent = np.where(exponent == 0, 1.0, exponent)
+        integral = np.where(
+            exponent == 0,
+            np.log(upper / lower),
+            (upper**exponent - lower**exponent) / safe_exponent,
+        )
+        return b * scale**b / norm * integral
+
+    def _mean(self):
+        """Return expected value of the distribution.
+
+        Returns
+        -------
+        2D np.ndarray, same shape as ``self``
+            expected value of distribution (entry-wise)
+        """
+        return self._raw_moment(1)
+
+    def _var(self):
+        r"""Return element/entry-wise variance of the distribution.
+
+        Returns
+        -------
+        2D np.ndarray, same shape as ``self``
+            variance of the distribution (entry-wise)
+        """
+        mean = self._raw_moment(1)
+        return self._raw_moment(2) - mean**2
+
     def _pdf(self, x):
         b = self._bc_params["b"]
         scale = self._bc_params["scale"]


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

`TruncatedPareto` declares `mean` and `var` as `capabilities:exact`, but it has no closed-form implementation of either, so both fall back to `BaseDistribution`'s numeric approximation (averaging the ppf over 1000 equidistant-in-probability nodes) and emit the "does not have a numerically exact implementation ... filled in by approximating" warning. The `exact` claim is therefore false, and the value is inaccurate: the equidistant-in-probability average under-resolves the heavy upper tail, so the variance is understated on wide truncation windows — up to ~33% low.

Reported vs. true variance on current `main` (true = `scipy.integrate.quad` over the bounded support):

| `b, scale, [lower, upper]` | true var | reported var | error |
|---|---|---|---|
| 2, 1, [1, 10]  | 1.345902 | 1.314102 | -2.36% |
| 3, 2, [2, 20]  | 1.972243 | 1.846493 | -6.38% |
| 2, 1, [1, 100] | 5.290077 | 3.531642 | **-33.24%** |
| 4, 1, [1, 1000] | 0.222220 | 0.187481 | -15.63% |

This adds closed-form `_mean` and `_var`. For shape `b`, scale `s`, support `[l, u]`, the raw moments are `E[X^k] = (b s^b / Z) ∫_l^u x^{k-b-1} dx` with `Z = (s/l)^b - (s/u)^b`. The integral is `(u^{k-b} - l^{k-b})/(k-b)` for `b != k`, and `ln(u/l)` at the removable singularity `b == k` (the log form the naive `α/(α-k)` expression misses — it applies to the mean at `b == 1` and to the second moment at `b == 2`). The tag is now true and no warning is emitted.

Verified against `scipy.integrate.quad` to `1e-9` across the parameter grid, including the `b == 1` and `b == 2` boundaries and a wide window. The new `test_truncated_pareto.py` fails on the current code (both on the mismatch and on the now-forbidden approximation warning) and passes with the fix; the full `test_all_distrs.py` battery stays green.

This is in line with the ongoing closed-form / capability-tag work — the explicit-closed-form drive (#688, #803, #698) and the sibling capability-tag fixes (#950, #962, #973).

#### Scope note — the QPD family shares the same false tag

Auditing all distributions for the same pattern, `QPD_S`, `QPD_B`, `QPD_U` and `QPD_Johnson` also list `mean`/`var` under `capabilities:exact` while falling back to the same numeric approximation. Unlike `TruncatedPareto` they have no elementary closed form, so the honest fix is either accurate quadrature or a tag correction (as in #950 / #962), not a closed form. I've left them out of this PR to keep it focused and would be happy to follow up on them separately if you'd like.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### PR checklist

- [x] The PR title starts with `[BUG]`.
