### PR TITLE
[ENH] `Triangular` distribution via `_ScipyAdapter` with exact energy

### DIFF
--- a/docs/source/api_reference/distributions.rst
+++ b/docs/source/api_reference/distributions.rst
@@ -42,6 +42,7 @@ Continuous support - full reals
     Normal
     SkewNormal
     TDistribution
+    Triangular
     TruncatedNormal
     Uniform
 

--- a/skpro/distributions/__init__.py
+++ b/skpro/distributions/__init__.py
@@ -59,6 +59,7 @@ __all__ = [
     "SkewNormal",
     "TDistribution",
     "TransformedDistribution",
+    "Triangular",
     "TruncatedDistribution",
     "TruncatedNormal",
     "TruncatedPareto",
@@ -118,6 +119,7 @@ from skpro.distributions.skellam import Skellam
 from skpro.distributions.skew_normal import SkewNormal
 from skpro.distributions.t import TDistribution
 from skpro.distributions.trafo import TransformedDistribution
+from skpro.distributions.triangular import Triangular
 from skpro.distributions.truncated import TruncatedDistribution
 from skpro.distributions.truncated_normal import TruncatedNormal
 from skpro.distributions.truncated_pareto import TruncatedPareto

--- a/skpro/distributions/energy_formulae.md
+++ b/skpro/distributions/energy_formulae.md
@@ -28,6 +28,7 @@ This file collects analytic formulae, derivations, and summary tables for energy
 | Poisson(3)                    | 1.907392  | 1.910830    | 0.003438  |
 | Rayleigh(1.0)                 | 0.734174  | 0.734174    | 0.000000  |
 | TruncatedNormal(0,1,-1,2)     | 0.824430  | 0.824881    | 0.000451  |
+| Triangular(0,1,3)             | 0.711111  | 0.711957    | 0.000846  |
 
 ## Example: Beta(2,3)
 
@@ -311,6 +312,53 @@ $$
 F(t)(1-F(t)) = \left( 1 - \exp\left(-\frac{t^2}{2\sigma^2}\right) \right) \exp\left(-\frac{t^2}{2\sigma^2}\right) = \exp\left(-\frac{t^2}{2\sigma^2}\right) - \exp\left(-\frac{t^2}{\sigma^2}\right)
 $$
 Integrating this yields $\sigma \sqrt{\frac{\pi}{2}} - \frac{\sigma \sqrt{\pi}}{2}$, which multiplied by 2 gives the analytical solution.
+
+---
+
+## Example: Triangular(a, c, b)
+
+Lower limit $a$, mode $c$, upper limit $b$, with $a \leq c \leq b$. Write
+$d = b - a$, $p = c - a$, $q = b - c$ (so $d = p + q$), and mean
+$\mu = (a + b + c)/3$.
+
+**Self-energy** $\mathbb{E}|X-Y|$, using $\mathbb{E}|X-Y| = 2\int_S F(t)(1-F(t))\,dt$:
+
+The CDF is $F(t) = \frac{(t-a)^2}{d\,p}$ on $[a,c]$ and
+$F(t) = 1 - \frac{(b-t)^2}{d\,q}$ on $[c,b]$. Substituting $u=t-a$ on the left
+piece and $v=b-t$ on the right piece, both integrals reduce to
+$\int_0^r \frac{w^2}{d r}\left(1 - \frac{w^2}{d r}\right) dw
+= \frac{r^2}{3d} - \frac{r^3}{5 d^2}$ for $r \in \{p, q\}$. Hence
+
+$$
+\mathbb{E}|X-Y| = \frac{2(p^2 + q^2)}{3 d} - \frac{2(p^3 + q^3)}{5 d^2}.
+$$
+
+For the symmetric case $p = q = d/2$ this gives $\tfrac{7}{30} d$.
+
+**Cross-energy** $\mathbb{E}|X-x|$, using $\mathbb{E}|X-x| = \int_{-\infty}^{x} F(t)\,dt + \int_{x}^{\infty}(1-F(t))\,dt$:
+
+Let $I_F(x) = \int_a^{x} F(t)\,dt$. Then $\mathbb{E}|X-x| = 2 I_F(x) - I_F(b) + (b - x)$,
+with $I_F(b) = b - \mu$ and, piecewise,
+
+$$
+I_F(x) =
+\begin{cases}
+0, & x \leq a \\[1ex]
+\dfrac{(x-a)^3}{3 d p}, & a \leq x \leq c \\[1ex]
+\dfrac{p^2 - q^2}{3 d} + (x - c) + \dfrac{(b-x)^3}{3 d q}, & c \leq x \leq b \\[1ex]
+(b - \mu) + (x - b), & x \geq b.
+\end{cases}
+$$
+
+This is continuous at $x=c$ and reduces to $\mu - x$ for $x \leq a$ and
+$x - \mu$ for $x \geq b$. Degenerate triangles ($p=0$ or $q=0$) are covered:
+the vanishing-denominator branch corresponds to an empty region and is never
+evaluated on its own support.
+
+**MC cross-check** (2M samples per case, $\mathrm{rel} < 2\times10^{-3}$
+throughout): self-energy and cross-energy verified for asymmetric,
+symmetric, and both degenerate ($c=a$, $c=b$) parametrizations, and for $x$
+inside and outside $[a,b]$.
 
 ---
 

--- a/skpro/distributions/tests/test_triangular.py
+++ b/skpro/distributions/tests/test_triangular.py
@@ -1,0 +1,62 @@
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+"""Tests for the Triangular distribution parametrization mapping.
+
+The generic distribution suite only checks internal consistency (pdf/cdf/ppf
+inversion, log_pdf = log pdf). It cannot detect a wrong ``(lower, mode, upper)``
+-> scipy ``(c, loc, scale)`` mapping: a mirrored mapping still yields a valid
+triangular that passes every generic test, and it does not check energy
+*correctness* (only that a value is produced). These tests pin the mapping and
+the hand-derived energy formula to exact closed-form values (cf. the mapping-bug
+class of #954 and the Laplace energy bug #720).
+"""
+
+__author__ = ["Ashish-Kumar-Dash"]
+
+import numpy as np
+
+from skpro.distributions import Triangular
+
+
+def test_mapping_semantics():
+    """Mean and pdf peak must match the (lower, mode, upper) parametrization.
+
+    Uses an asymmetric triangle, where a mirrored mapping (peak at
+    ``lower + upper - mode``) would give a different mean and peak location.
+    """
+    lower, mode, upper = 0.0, 1.0, 3.0
+    mirror = lower + upper - mode  # peak location under a mirrored mapping
+
+    # two identical rows so pdf can be evaluated at mode and mirror at once
+    d = Triangular(
+        lower=[[lower], [lower]],
+        mode=[[mode], [mode]],
+        upper=[[upper], [upper]],
+    )
+
+    # mean of a triangular is (a + c + b) / 3; a mirror would give 5/3, not 4/3
+    assert np.isclose(d.mean().values[0, 0], (lower + mode + upper) / 3)
+
+    # pdf peaks at the mode, not at the mirror point
+    pdf = d.pdf(np.array([[mode], [mirror]])).values.flatten()
+    assert pdf[0] > pdf[1]
+
+
+def test_energy_closed_form():
+    """Hand-derived energy must match exact closed-form values.
+
+    Self-energy of a triangular is
+    ``2(p^2+q^2)/(3d) - 2(p^3+q^3)/(5 d^2)`` with ``d=b-a, p=c-a, q=b-c``;
+    for the symmetric case ``p=q`` this is exactly ``7d/30``. The generic
+    suite never checks energy against a known value, so pin it here.
+    """
+    # symmetric triangle on [0, 1]: self-energy = 7/30
+    d_sym = Triangular(lower=[[0.0]], mode=[[0.5]], upper=[[1.0]])
+    assert np.isclose(d_sym.energy().values[0, 0], 7 / 30)
+
+    # asymmetric triangle (0, 1, 3): 2*5/9 - 2*9/45 = 32/45
+    d_asym = Triangular(lower=[[0.0]], mode=[[1.0]], upper=[[3.0]])
+    assert np.isclose(d_asym.energy().values[0, 0], 32 / 45)
+
+    # cross-energy at the lower limit equals mean - lower (X >= lower a.s.)
+    mean = d_asym.mean().values[0, 0]
+    assert np.isclose(d_asym.energy(np.array([[0.0]])).values[0, 0], mean - 0.0)

--- a/skpro/distributions/triangular.py
+++ b/skpro/distributions/triangular.py
@@ -1,0 +1,173 @@
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+"""Triangular probability distribution."""
+
+__author__ = ["Ashish-Kumar-Dash"]
+__all__ = ["Triangular"]
+
+import numpy as np
+import pandas as pd
+from scipy.stats import rv_continuous, triang
+
+from skpro.distributions.adapters.scipy import _ScipyAdapter
+
+
+class Triangular(_ScipyAdapter):
+    r"""Triangular distribution.
+
+    Most methods wrap ``scipy.stats.triang``.
+
+    The Triangular distribution is parametrized by lower limit :math:`a`,
+    mode :math:`c`, and upper limit :math:`b`, with
+    :math:`a \leq c \leq b` and :math:`a < b`, such that the pdf is
+
+    .. math::
+
+        f(x; a, c, b) =
+        \begin{cases}
+            \dfrac{2(x - a)}{(b - a)(c - a)}, & a \leq x < c \\[1ex]
+            \dfrac{2(b - x)}{(b - a)(b - c)}, & c \leq x \leq b \\[1ex]
+            0, & \text{otherwise}
+        \end{cases}
+
+    Parameters
+    ----------
+    lower : float or array of float (1D or 2D)
+        lower limit of the distribution; must satisfy ``lower < upper``
+    mode : float or array of float (1D or 2D)
+        mode (peak) of the distribution; must satisfy ``lower <= mode <= upper``
+    upper : float or array of float (1D or 2D)
+        upper limit of the distribution; must satisfy ``lower < upper``
+    index : pd.Index, optional, default = RangeIndex
+    columns : pd.Index, optional, default = RangeIndex
+
+    Examples
+    --------
+    >>> from skpro.distributions import Triangular
+
+    >>> d = Triangular(lower=0, mode=1, upper=3)
+    """
+
+    _tags = {
+        "authors": ["Ashish-Kumar-Dash"],
+        "capabilities:exact": [
+            "mean",
+            "var",
+            "energy",
+            "pdf",
+            "log_pdf",
+            "cdf",
+            "ppf",
+        ],
+        "distr:measuretype": "continuous",
+        "broadcast_init": "on",
+    }
+
+    def __init__(self, lower, mode, upper, index=None, columns=None):
+        self.lower = lower
+        self.mode = mode
+        self.upper = upper
+
+        super().__init__(index=index, columns=columns)
+
+    def _get_scipy_object(self) -> rv_continuous:
+        return triang
+
+    def _get_scipy_param(self):
+        lower = self._bc_params["lower"]
+        mode = self._bc_params["mode"]
+        upper = self._bc_params["upper"]
+
+        scale = upper - lower
+        c = (mode - lower) / scale
+        return [c], {"loc": lower, "scale": scale}
+
+    def _energy_self(self):
+        r"""Energy of self, w.r.t. self.
+
+        :math:`\mathbb{E}[|X-Y|]`, where :math:`X, Y` are i.i.d. copies of self.
+
+        Returns
+        -------
+        2D np.ndarray, same shape as ``self``
+            energy values w.r.t. the given points
+        """
+        a = self._bc_params["lower"]
+        c = self._bc_params["mode"]
+        b = self._bc_params["upper"]
+
+        d = b - a
+        p = c - a
+        q = b - c
+
+        energy_arr = 2 * (p**2 + q**2) / (3 * d) - 2 * (p**3 + q**3) / (
+            5 * d**2
+        )
+
+        if energy_arr.ndim > 0:
+            energy_arr = np.sum(energy_arr, axis=1)
+        return energy_arr
+
+    def _energy_x(self, x):
+        r"""Energy of self, w.r.t. a constant frame x.
+
+        :math:`\mathbb{E}[|X-x|]`, where :math:`X` is a copy of self,
+        and :math:`x` is a constant.
+
+        Parameters
+        ----------
+        x : 2D np.ndarray, same shape as ``self``
+            values to compute energy w.r.t. to
+
+        Returns
+        -------
+        2D np.ndarray, same shape as ``self``
+            energy values w.r.t. the given points
+        """
+        a = self._bc_params["lower"]
+        c = self._bc_params["mode"]
+        b = self._bc_params["upper"]
+
+        d = b - a
+        p = c - a
+        q = b - c
+        mu = (a + b + c) / 3
+
+        # guard degenerate mode-at-boundary cases; the guarded branch is never
+        # selected there (its region is empty), so the value is discarded
+        pp = np.where(p == 0, 1.0, p)
+        qq = np.where(q == 0, 1.0, q)
+
+        # I_F(x) = integral of the CDF from a to x, piecewise by region
+        i_below = np.zeros_like(x + a * 0.0)
+        i_left = (x - a) ** 3 / (3 * d * pp)
+        i_mid = (
+            p**2 / (3 * d) - q**2 / (3 * d) + (x - c) + (b - x) ** 3 / (3 * d * qq)
+        )
+        i_above = (b - mu) + (x - b)
+        i_f = np.select([x <= a, x <= c, x <= b], [i_below, i_left, i_mid], i_above)
+
+        # E|X - x| = 2 I_F(x) - I_F(b) + (b - x),  with I_F(b) = b - mu
+        energy_arr = 2 * i_f - (b - mu) + (b - x)
+
+        if energy_arr.ndim > 0:
+            energy_arr = np.sum(energy_arr, axis=1)
+        return energy_arr
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator."""
+        params1 = {
+            "lower": [[0, -1], [1, 0], [2, 1]],
+            "mode": [[1, 0], [2, 1], [3, 2]],
+            "upper": [[3, 2], [4, 3], [5, 4]],
+        }
+        params2 = {
+            "lower": 0,
+            "mode": 1,
+            "upper": 3,
+            "index": pd.Index([1, 2, 5]),
+            "columns": pd.Index(["a", "b"]),
+        }
+        params3 = {"lower": -2, "mode": 4, "upper": 4}
+
+        return [params1, params2, params3]


### PR DESCRIPTION
  #### What does this implement/fix? Explain your changes.

  Adds the `Triangular` distribution, parametrized by `(lower, mode, upper)`,  wrapping `scipy.stats.triang`.

  - `mean`, `var`, `pdf`, `log_pdf`, `cdf`, `ppf` are wrapped via `_ScipyAdapter`;  the `(lower, mode, upper) -> scipy (c, loc, scale)` mapping is done in  `_get_scipy_param`.
  - `energy` (self and cross) is hand-derived in closed form via the CDF-integral identities. Degenerate triangles (`mode == lower`, `mode == upper`) are handled explicitly.
  - Derivation recorded in `energy_formulae.md` with an MC cross-check table row.

  #### Does your contribution introduce a new dependency? If yes, which one?

  No. `scipy` is a core dependency.

  #### What should a reviewer concentrate their feedback on?

  - The `_energy_x` piecewise `I_F(x)` and the degenerate-denominator guard (`np.where(p == 0, ...)`) — the guarded branch is never selected on its own support, but worth a second look.
  - The `(lower, mode, upper) -> (c, loc, scale)` mapping in `_get_scipy_param`.

  #### Did you add any tests for the change?

  Yes, `tests/test_triangular.py` 
  
   #### Any other comments?

  - Energy is derived from the CDF (`E|X-Y| = 2∫F(1-F)`, `E|X-x| = 2·I_F(x) - I_F(b) + (b-x)`). 
  - Energy asserts are closed-form/deterministic
