### PR TITLE
[DOC] fix docstring example formatting in distributions

### DIFF
--- a/skpro/distributions/alpha.py
+++ b/skpro/distributions/alpha.py
@@ -39,7 +39,7 @@ class Alpha(_ScipyAdapter):
     Examples
     --------
     >>> from skpro.distributions import Alpha
-
+    >>>
     >>> distr = Alpha(a=[[1, 2], [3, 4]])
     """
 

--- a/skpro/distributions/beta.py
+++ b/skpro/distributions/beta.py
@@ -32,9 +32,8 @@ class Beta(_ScipyAdapter):
     Examples
     --------
     >>> from skpro.distributions.beta import Beta
-
+    >>>
     >>> d = Beta(beta=[[1, 1], [2, 3], [4, 5]], alpha=2)
-
     """
 
     _tags = {

--- a/skpro/distributions/binomial.py
+++ b/skpro/distributions/binomial.py
@@ -27,7 +27,7 @@ class Binomial(_ScipyAdapter):
     Examples
     --------
     >>> from skpro.distributions.binomial import Binomial
-
+    >>>
     >>> d = Binomial(n=[[10, 10], [20, 30], [40, 50]], p=0.5)
     """
 

--- a/skpro/distributions/cauchy.py
+++ b/skpro/distributions/cauchy.py
@@ -42,7 +42,7 @@ class Cauchy(_ScipyAdapter):
     Examples
     --------
     >>> from skpro.distributions.cauchy import Cauchy
-
+    >>>
     >>> c = Cauchy(mu=0, scale=1)
     """
 

--- a/skpro/distributions/delta.py
+++ b/skpro/distributions/delta.py
@@ -31,7 +31,7 @@ class Delta(BaseDistribution):
     Examples
     --------
     >>> from skpro.distributions.delta import Delta
-
+    >>>
     >>> delta = Delta(c=[[0, 1], [2, 3], [4, 5]])
     >>> this_is_always_c = delta.sample()
     """

--- a/skpro/distributions/erlang.py
+++ b/skpro/distributions/erlang.py
@@ -31,7 +31,7 @@ class Erlang(_ScipyAdapter):
     Examples
     --------
     >>> from skpro.distributions.erlang import Erlang
-
+    >>>
     >>> d = Erlang(rate=[[1, 1], [2, 3], [4, 5]], k=2)
     """
 

--- a/skpro/distributions/fisk.py
+++ b/skpro/distributions/fisk.py
@@ -30,7 +30,7 @@ class Fisk(_ScipyAdapter):
     Examples
     --------
     >>> from skpro.distributions.fisk import Fisk
-
+    >>>
     >>> d = Fisk(beta=[[1, 1], [2, 3], [4, 5]], alpha=2)
     """
 

--- a/skpro/distributions/gamma.py
+++ b/skpro/distributions/gamma.py
@@ -35,9 +35,8 @@ class Gamma(_ScipyAdapter):
     Examples
     --------
     >>> from skpro.distributions.gamma import Gamma
-
+    >>>
     >>> d = Gamma(beta=[[1, 1], [2, 3], [4, 5]], alpha=2)
-
     """  # noqa: E501
 
     _tags = {

--- a/skpro/distributions/gompertz.py
+++ b/skpro/distributions/gompertz.py
@@ -33,7 +33,7 @@ class Gompertz(_ScipyAdapter):
     Examples
     --------
     >>> from skpro.distributions.gompertz import Gompertz
-
+    >>>
     >>> d = Gompertz(c=[[1, 1], [2, 3], [4, 5]], scale=2)
     """
 

--- a/skpro/distributions/gumbel.py
+++ b/skpro/distributions/gumbel.py
@@ -37,7 +37,7 @@ class Gumbel(_ScipyAdapter):
     Examples
     --------
     >>> from skpro.distributions.gumbel import Gumbel
-
+    >>>
     >>> d = Gumbel(mu=[[1, 1], [2, 3], [4, 5]], beta=2, skew="right")
     """
 

--- a/skpro/distributions/halfcauchy.py
+++ b/skpro/distributions/halfcauchy.py
@@ -40,7 +40,7 @@ class HalfCauchy(_ScipyAdapter):
     Examples
     --------
     >>> from skpro.distributions.halfcauchy import HalfCauchy
-
+    >>>
     >>> hc = HalfCauchy(beta=1)
     """
 

--- a/skpro/distributions/halflogistic.py
+++ b/skpro/distributions/halflogistic.py
@@ -41,7 +41,7 @@ class HalfLogistic(_ScipyAdapter):
     Examples
     --------
     >>> from skpro.distributions.halflogistic import HalfLogistic
-
+    >>>
     >>> hl = HalfLogistic(beta=1)
     """
 

--- a/skpro/distributions/halfnormal.py
+++ b/skpro/distributions/halfnormal.py
@@ -36,7 +36,7 @@ class HalfNormal(_ScipyAdapter):
     Examples
     --------
     >>> from skpro.distributions.halfnormal import HalfNormal
-
+    >>>
     >>> hn = HalfNormal(sigma=1)
     """
 

--- a/skpro/distributions/inversegamma.py
+++ b/skpro/distributions/inversegamma.py
@@ -32,7 +32,7 @@ class InverseGamma(_ScipyAdapter):
     Examples
     --------
     >>> from skpro.distributions.inversegamma import InverseGamma
-
+    >>>
     >>> d = InverseGamma(beta=[[1, 1], [2, 3], [4, 5]], alpha=2)
     """  # noqa: E501
 

--- a/skpro/distributions/inversegaussian.py
+++ b/skpro/distributions/inversegaussian.py
@@ -35,7 +35,7 @@ class InverseGaussian(_ScipyAdapter):
     Examples
     --------
     >>> from skpro.distributions.inversegaussian import InverseGaussian
-
+    >>>
     >>> d = InverseGaussian(mu=1.0, scale=1.0)
     """
 

--- a/skpro/distributions/laplace.py
+++ b/skpro/distributions/laplace.py
@@ -37,7 +37,7 @@ class Laplace(BaseDistribution):
     Examples
     --------
     >>> from skpro.distributions import Laplace
-
+    >>>
     >>> n = Laplace(mu=[[0, 1], [2, 3], [4, 5]], scale=1)
     """
 

--- a/skpro/distributions/loggamma.py
+++ b/skpro/distributions/loggamma.py
@@ -35,7 +35,7 @@ class LogGamma(_ScipyAdapter):
     Examples
     --------
     >>> from skpro.distributions.loggamma import LogGamma
-
+    >>>
     >>> d = LogGamma(c=[[1, 2], [3, 4], [5, 6]])
     """
 

--- a/skpro/distributions/loglaplace.py
+++ b/skpro/distributions/loglaplace.py
@@ -40,7 +40,7 @@ class LogLaplace(_ScipyAdapter):
     Examples
     --------
     >>> from skpro.distributions.loglaplace import LogLaplace
-
+    >>>
     >>> ll = LogLaplace(scale=1)
     """
 

--- a/skpro/distributions/lognormal.py
+++ b/skpro/distributions/lognormal.py
@@ -29,7 +29,7 @@ class LogNormal(BaseDistribution):
     Examples
     --------
     >>> from skpro.distributions.lognormal import LogNormal
-
+    >>>
     >>> n = LogNormal(mu=[[0, 1], [2, 3], [4, 5]], sigma=1)
     """
 

--- a/skpro/distributions/negative_binomial.py
+++ b/skpro/distributions/negative_binomial.py
@@ -26,7 +26,7 @@ class NegativeBinomial(_ScipyAdapter):
     Examples
     --------
     >>> from skpro.distributions import NegativeBinomial
-
+    >>>
     >>> distr = NegativeBinomial(mu=1.0, alpha=1.0)
     """
 

--- a/skpro/distributions/normal.py
+++ b/skpro/distributions/normal.py
@@ -34,7 +34,7 @@ class Normal(BaseDistribution):
     Examples
     --------
     >>> from skpro.distributions.normal import Normal
-
+    >>>
     >>> n = Normal(mu=[[0, 1], [2, 3], [4, 5]], sigma=1)
     """  # noqa E501
 

--- a/skpro/distributions/normal_mixture.py
+++ b/skpro/distributions/normal_mixture.py
@@ -51,7 +51,7 @@ class NormalMixture(BaseDistribution):
     --------
     >>> from skpro.distributions.normal_mixture import NormalMixture
     >>> import numpy as np
-
+    >>>
     >>> # 3 samples, 2 components, 2 outputs
     >>> pi = np.array([[0.3, 0.7], [0.5, 0.5], [0.8, 0.2]])
     >>> mu = np.array([[[0, 1], [3, 4]],

--- a/skpro/distributions/pareto.py
+++ b/skpro/distributions/pareto.py
@@ -32,7 +32,7 @@ class Pareto(BaseDistribution):
     Examples
     --------
     >>> from skpro.distributions.pareto import Pareto
-
+    >>>
     >>> n = Pareto(scale=[[1, 1.5], [2, 2.5], [3, 4]], alpha=3)
     """
 

--- a/skpro/distributions/poisson.py
+++ b/skpro/distributions/poisson.py
@@ -22,7 +22,7 @@ class Poisson(_ScipyAdapter):
     Examples
     --------
     >>> from skpro.distributions import Poisson
-
+    >>>
     >>> distr = Poisson(mu=[[1, 1], [2, 3], [4, 5]])
     """
 

--- a/skpro/distributions/qpd.py
+++ b/skpro/distributions/qpd.py
@@ -56,7 +56,7 @@ class QPD_Johnson(_DelegatedDistribution):
     Examples
     --------
     >>> from skpro.distributions.qpd import QPD_Johnson  # doctest: +SKIP
-
+    >>>
     >>> qpd = QPD_Johnson(
     ...         alpha=0.2,
     ...         qv_low=[1, 2],
@@ -64,7 +64,7 @@ class QPD_Johnson(_DelegatedDistribution):
     ...         qv_high=[5, 6],
     ...         lower=0
     ...       )  # doctest: +SKIP
-
+    >>>
     >>> qpd.mean()  # doctest: +SKIP
     """
 

--- a/skpro/distributions/qpd_empirical.py
+++ b/skpro/distributions/qpd_empirical.py
@@ -59,7 +59,7 @@ class QPD_Empirical(Empirical):
     --------
     >>> import pandas as pd
     >>> from skpro.distributions import QPD_Empirical
-
+    >>>
     >>> spl_idx = pd.MultiIndex.from_product(
     ...     [[0.2, 0.5, 0.8], [0, 1, 2]], names=["alpha", "sample"]
     ... )

--- a/skpro/distributions/qpd_histogram.py
+++ b/skpro/distributions/qpd_histogram.py
@@ -68,7 +68,7 @@ class HistogramQPD(_DelegatedDistribution):
     --------
     >>> import pandas as pd
     >>> from skpro.distributions import HistogramQPD
-
+    >>>
     >>> quantile_idx = pd.MultiIndex.from_product(
     ...     [[0.1, 0.5, 0.9], [0, 1, 2]], names=["quantile", "sample"]
     ... )

--- a/skpro/distributions/t.py
+++ b/skpro/distributions/t.py
@@ -29,7 +29,7 @@ class TDistribution(BaseDistribution):
     Examples
     --------
     >>> from skpro.distributions.t import TDistribution
-
+    >>>
     >>> n = TDistribution(mu=[[0, 1], [2, 3], [4, 5]], sigma=1, df=10)
     """
 

--- a/skpro/distributions/truncated_normal.py
+++ b/skpro/distributions/truncated_normal.py
@@ -34,7 +34,7 @@ class TruncatedNormal(_ScipyAdapter):
     Examples
     --------
     >>> from skpro.distributions.truncated_normal import TruncatedNormal
-
+    >>>
     >>> d = TruncatedNormal(\
             mu=[[0, 1], [2, 3], [4, 5]],\
             sigma= 1,\

--- a/skpro/distributions/uniform.py
+++ b/skpro/distributions/uniform.py
@@ -30,7 +30,7 @@ class Uniform(BaseDistribution):
     Examples
     --------
     >>> from skpro.distributions import Uniform
-
+    >>>
     >>> u = Uniform(lower=0, upper=5)
     """
 

--- a/skpro/distributions/weibull.py
+++ b/skpro/distributions/weibull.py
@@ -32,7 +32,7 @@ class Weibull(BaseDistribution):
     Examples
     --------
     >>> from skpro.distributions.weibull import Weibull
-
+    >>>
     >>> w = Weibull(scale=[[1, 1], [2, 3], [4, 5]], k=1)
     """
 


### PR DESCRIPTION
Fixes the docstring example formatting in a larger number of distributions - same issue with missing `>>>` leading to fragmentation of the example box.