### PR TITLE
[ENH] add test that all classes have docstrings and at least one doctest example

### DIFF
--- a/skpro/distributions/uniform.py
+++ b/skpro/distributions/uniform.py
@@ -13,7 +13,7 @@ class Uniform(BaseDistribution):
     The uniform distribution is parameterized by lower and upper bounds of interval,
     :math:`a` and :math`b`, such that the pdf is
 
-    .. math:: f(x) = \frac{1}{b - a} \text{ for } a \leq x \leq b, \text{ and } 0 \text{ otherwise}  # noqa E501
+    .. math:: f(x) = \frac{1}{b - a} \text{ for } a \leq x \leq b, \text{ and } 0 \text{ otherwise}
 
     The lower bound :math:`a` is represented by the parameter ``lower``,
     and the upper bound :math:`b` by the parameter ``upper``.
@@ -32,7 +32,7 @@ class Uniform(BaseDistribution):
     >>> from skpro.distributions import Uniform
     >>>
     >>> u = Uniform(lower=0, upper=5)
-    """
+    """  # noqa E501
 
     _pdf_formula_doc = r"""
     For lower bound :math:`a` and upper bound :math:`b`, the pdf is

--- a/skpro/tests/test_all_estimators.py
+++ b/skpro/tests/test_all_estimators.py
@@ -169,6 +169,14 @@ class BaseFixtureGenerator(_BaseFixtureGenerator):
 class TestAllObjects(PackageConfig, BaseFixtureGenerator, _TestAllObjects):
     """Generic tests for all objects in the mini package."""
 
+    def test_class_has_doctest_example(self, object_class):
+        """Check that the class has a docstring, with doctest example in it."""
+        docstring = object_class.__doc__
+
+        assert docstring is not None, f"{object_class.__name__} has no docstring"
+        msg = f"{object_class.__name__} docstring has no doctest example"
+        assert ">>>" in docstring, msg
+
     def test_doctest_examples(self, object_class):
         """Runs doctests for estimator class."""
         run_doctest(object_class, name=f"class {object_class.__name__}")


### PR DESCRIPTION
This PR adds a suite test to all `skbase` compatible objects to check that it has a docstring, and that the docstring contains at least one doctest example.

Also fixes a broken formula in `Uniform`.