### PR TITLE
[BUG] fix missing `Cauchy` import in distributions `__init__`

### DIFF
--- a/skpro/distributions/__init__.py
+++ b/skpro/distributions/__init__.py
@@ -72,6 +72,7 @@ from skpro.distributions.beta import Beta
 from skpro.distributions.binomial import Binomial
 from skpro.distributions.burr_iii import BurrIII
 from skpro.distributions.burr_xii import BurrXII
+from skpro.distributions.cauchy import Cauchy
 from skpro.distributions.chi_squared import ChiSquared
 from skpro.distributions.compose import IID
 from skpro.distributions.delta import Delta

--- a/skpro/distributions/tests/test_registration.py
+++ b/skpro/distributions/tests/test_registration.py
@@ -1,0 +1,23 @@
+"""Test that every distribution in ``__all__`` is importable from the package."""
+
+import pytest
+
+import skpro.distributions as distributions
+from skpro.tests.test_switch import run_test_module_changed
+
+
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
+def test_all_names_importable():
+    """Every name in ``__all__`` must be importable from ``skpro.distributions``.
+
+    Regression test: ``Cauchy`` was listed in ``__all__`` but its import line was
+    missing from ``__init__.py``, so ``from skpro.distributions import Cauchy``
+    raised ``ImportError`` while the class existed in ``cauchy.py``.
+    """
+    missing = [
+        name for name in distributions.__all__ if not hasattr(distributions, name)
+    ]
+    assert not missing, f"names in __all__ but not importable: {missing}"


### PR DESCRIPTION
  #### What does this implement/fix? Explain your changes.

 `Cauchy` is listed in `skpro/distributions/__init__.py` `__all__`, and the class exists in `cauchy.py`, but the corresponding import line was missing. As a result `from skpro.distributions import Cauchy` raised `ImportError`, the class was effectively unreachable through the public API.

 - Add the missing `from skpro.distributions.cauchy import Cauchy`.
 - Add a regression test asserting every name in `__all__` is importable from the package, so this class of `__all__`/import drift is caught for any distribution, not just `Cauchy`.

  #### Does your contribution introduce a new dependency? If yes, which one?

  No.

  #### Did you add any tests for the change?

 Yes, `distributions/tests/test_registration.py::test_all_names_importable`. It fails before the fix (`missing: ['Cauchy']`) and passes after.
