### PR TITLE
[DOC] Add formula docs for `Uniform` distribution

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -258,6 +258,14 @@
       ]
     },
     {
+      "login": "Vidit-lab",
+      "name": "Vidit Shrimali",
+      "profile": "https://github.com/Vidit-lab",
+      "contributions": [
+        "doc"
+      ]
+    },
+    {
       "login": "kabirvashisht4-glitch",
       "name": "Kabir Vashisht",
       "contributions": [

--- a/skpro/distributions/tests/test_docstring_injection.py
+++ b/skpro/distributions/tests/test_docstring_injection.py
@@ -7,6 +7,7 @@ from skpro.distributions.exponential import Exponential
 from skpro.distributions.laplace import Laplace
 from skpro.distributions.normal import Normal
 from skpro.distributions.rayleigh import Rayleigh
+from skpro.distributions.uniform import Uniform
 from skpro.distributions.weibull import Weibull
 
 # 1. The methods we modified in BaseDistribution
@@ -26,7 +27,7 @@ TARGET_METHODS = [
 ]
 
 # 2. Classes where we implemented formula hooks
-HOOKED_CLASSES = [Normal, Rayleigh, Exponential, Laplace]
+HOOKED_CLASSES = [Normal, Rayleigh, Exponential, Laplace, Uniform]
 
 # 3. Classes where we DID NOT implement hooks (Control group)
 UNHOOKED_CLASSES = [Weibull]

--- a/skpro/distributions/uniform.py
+++ b/skpro/distributions/uniform.py
@@ -34,22 +34,34 @@ class Uniform(BaseDistribution):
     >>> u = Uniform(lower=0, upper=5)
     """
 
-    _pdf_formula_doc = r"""
-    For lower bound :math:`a` and upper bound :math:`b`, the pdf is
+    _formula_docs = {
+        "pdf": r"""
+    For lower bound :math:`a` and upper bound :math:`b`,
+    the probability density function is given by:
 
     .. math::
-        f(x) = \frac{1}{b - a}, \quad a \le x \le b
-    """
-
-    _log_pdf_formula_doc = r"""
-    For lower bound :math:`a` and upper bound :math:`b`, the log-pdf is
+        f(x) =
+        \begin{cases}
+            \frac{1}{b - a}, & a \le x \le b \\
+            0, & \text{otherwise}
+        \end{cases}
+    """,
+        #
+        "log_pdf": r"""
+    For lower bound :math:`a` and upper bound :math:`b`,
+    the log-density is given by:
 
     .. math::
-        \log f(x) = -\log(b - a), \quad a \le x \le b
-    """
-
-    _cdf_formula_doc = r"""
-    For lower bound :math:`a` and upper bound :math:`b`, the cdf is
+        \log f(x) =
+        \begin{cases}
+            -\log(b - a), & a \le x \le b \\
+            -\infty, & \text{otherwise}
+        \end{cases}
+    """,
+        #
+        "cdf": r"""
+    For lower bound :math:`a` and upper bound :math:`b`,
+    the cumulative distribution function is given by:
 
     .. math::
         F(x) =
@@ -58,10 +70,48 @@ class Uniform(BaseDistribution):
             \frac{x - a}{b - a}, & a \le x \le b \\
             1, & x > b
         \end{cases}
-    """
+    """,
+        #
+        "ppf": r"""
+    The quantile function (inverse cdf) is:
+
+    .. math::
+        F^{-1}(p; a, b) = a + p (b - a), \quad 0 \le p \le 1
+    """,
+        #
+        "mean": r"""
+    The expected value is:
+
+    .. math::
+        \mathbb{E}[X] = \frac{a + b}{2}
+    """,
+        #
+        "var": r"""
+    The variance is:
+
+    .. math::
+        \text{Var}(X) = \frac{(b - a)^2}{12}
+    """,
+        #
+        "energy": r"""
+    The self-energy is:
+
+    .. math::
+        \mathbb{E}[|X - Y|] = \frac{b - a}{3}
+
+    The energy w.r.t. a constant :math:`x` is:
+
+    .. math::
+        \mathbb{E}[|X - x|] =
+        \begin{cases}
+            \left| x - \frac{a + b}{2} \right|, & x < a \text{ or } x > b \\
+            \frac{(b - x)^2 + (a - x)^2}{2(b - a)}, & a \le x \le b
+        \end{cases}
+    """,
+    }
 
     _tags = {
-        "authors": ["an20805"],
+        "authors": ["an20805", "Vidit-lab"],
         "capabilities:approx": ["pdfnorm"],
         "capabilities:exact": ["pdf", "log_pdf", "cdf", "ppf", "mean", "var", "energy"],
         "distr:measuretype": "continuous",


### PR DESCRIPTION

#### Reference Issues/PRs
Part of #1120

#### What does this implement/fix? Explain your changes.
Populates the `_formula_docs` dictionary for `Uniform` (`skpro/distributions/uniform.py`) covering all seven exact methods (`pdf`, `log_pdf`, `cdf`, `ppf`, `mean`, `var`, `energy`). 

Refactors standalone formula attributes (`_pdf_formula_doc`, `_log_pdf_formula_doc`, and `_cdf_formula_doc`) into the single `_formula_docs` structure.

##### Mathematical References & Derivations
Since the closed-form math for `_pdf`, `_log_pdf`, `_cdf`, `_ppf`, `_mean`, `_var`, `_energy_self`, and `_energy_x` is already implemented in `uniform.py`, the formulas in `_formula_docs` document these existing operations:

1. **Standard Properties (`pdf`, `log_pdf`, `cdf`, `ppf`, `mean`, `var`)**:
   - Reference: Bertsekas, D. P., & Tsitsiklis, J. N. (2008). *Introduction to Probability* (2nd ed.). Athena Scientific, Chapter 3 (Continuous Random Variables).

2. **Self-Energy ($\mathbb{E}[|X - Y|]$)**:

   For $X, Y \stackrel{\text{i.i.d.}}{\sim} U(a,b)$ with joint density $f(x, y) = \frac{1}{(b - a)^2}$:

   $$\mathbb{E}[|X - Y|] = \frac{1}{(b - a)^2} \int_{a}^{b} \int_{a}^{b} |x - y| \, dx \, dy$$

   Exploiting symmetry across $x = y$:

   $$\mathbb{E}[|X - Y|] = \frac{2}{(b - a)^2} \int_{a}^{b} \left( \int_{a}^{x} (x - y) \, dy \right) dx = \frac{2}{(b - a)^2} \int_{a}^{b} \frac{(x - a)^2}{2} \, dx = \frac{b - a}{3}$$

   Matches `_energy_self` return value `(upper - lower) / 3`.

3. **Point Energy ($\mathbb{E}[|X - x|]$)**:

   Evaluated for constant $x$:

   $$\mathbb{E}[|X - x|] = \int_{a}^{b} |t - x| \frac{1}{b - a} \, dt$$

   For $x \in [a, b]$, splitting the integral at $t = x$ yields:

   $$\mathbb{E}[|X - x|] = \frac{(b - x)^2 + (a - x)^2}{2(b - a)}$$

   For $x < a$ or $x > b$, direct evaluation yields $\left| x - \frac{a + b}{2} \right|$.

   Matches `_energy_x` logic.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
- LaTeX rendering formatting inside `_formula_docs`.

#### Did you add any tests for the change?
Added `Uniform` to `HOOKED_CLASSES` in `test_docstring_injection.py`.

#### Any other comments?
None.

#### PR checklist
- [x] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/.all-contributorsrc) in the `skpro` root directory.
- [x] The PR title starts with [DOC].