### PR TITLE
[DOC] add explicit formulae to _formula_docs for Logistic and Weibull distributions

### DIFF
--- a/skpro/distributions/logistic.py
+++ b/skpro/distributions/logistic.py
@@ -56,6 +56,60 @@ class Logistic(BaseDistribution):
         "broadcast_init": "on",
     }
 
+    # documentation hooks for formula injection
+    _formula_docs = {
+        "pdf": r"""
+    The probability density function is given by:
+
+    .. math::
+        f(x) = \frac{\exp\left(-\frac{x - \mu}{s}\right)}
+        {s \left(1 + \exp\left(-\frac{x - \mu}{s}\right)\right)^2}
+    """,
+        #
+        "log_pdf": r"""
+    The log-density is given by:
+
+    .. math::
+        \log f(x) = -\frac{x - \mu}{s} - \log(s)
+        - 2 \log\left(1 + \exp\left(-\frac{x - \mu}{s}\right)\right)
+    """,
+        #
+        "cdf": r"""
+    The cumulative distribution function is given by:
+
+    .. math::
+        F(x) = \frac{1}{1 + \exp\left(-\frac{x - \mu}{s}\right)}
+    """,
+        #
+        "ppf": r"""
+    The quantile function (inverse cdf) is:
+
+    .. math::
+        F^{-1}(p; \mu, s) = \mu + s \log\left(\frac{p}{1 - p}\right)
+    """,
+        #
+        "mean": r"""
+    The expected value is:
+
+    .. math::
+        \mathbb{E}[X] = \mu
+    """,
+        #
+        "var": r"""
+    The variance is:
+
+    .. math::
+        \text{Var}(X) = \frac{s^2 \pi^2}{3}
+    """,
+        #
+        "energy": r"""
+    The self-energy is:
+
+    .. math::
+        \mathbb{E}[|X - Y|] = 2s
+    """,
+    }
+
     def __init__(self, mu, scale, index=None, columns=None):
         self.mu = mu
         self.scale = scale

--- a/skpro/distributions/tests/test_docstring_injection.py
+++ b/skpro/distributions/tests/test_docstring_injection.py
@@ -7,7 +7,6 @@ from skpro.distributions.exponential import Exponential
 from skpro.distributions.gamma import Gamma
 from skpro.distributions.laplace import Laplace
 from skpro.distributions.logistic import Logistic
-from skpro.distributions.lognormal import LogNormal
 from skpro.distributions.normal import Normal
 from skpro.distributions.rayleigh import Rayleigh
 from skpro.distributions.weibull import Weibull
@@ -36,7 +35,6 @@ HOOKED_CLASSES = [
     Laplace,
     Logistic,
     Weibull,
-    LogNormal,
 ]
 
 # 3. Classes where we DID NOT implement hooks (Control group)

--- a/skpro/distributions/tests/test_docstring_injection.py
+++ b/skpro/distributions/tests/test_docstring_injection.py
@@ -4,7 +4,10 @@
 import pytest
 
 from skpro.distributions.exponential import Exponential
+from skpro.distributions.gamma import Gamma
 from skpro.distributions.laplace import Laplace
+from skpro.distributions.logistic import Logistic
+from skpro.distributions.lognormal import LogNormal
 from skpro.distributions.normal import Normal
 from skpro.distributions.rayleigh import Rayleigh
 from skpro.distributions.weibull import Weibull
@@ -26,10 +29,18 @@ TARGET_METHODS = [
 ]
 
 # 2. Classes where we implemented formula hooks
-HOOKED_CLASSES = [Normal, Rayleigh, Exponential, Laplace]
+HOOKED_CLASSES = [
+    Normal,
+    Rayleigh,
+    Exponential,
+    Laplace,
+    Logistic,
+    Weibull,
+    LogNormal,
+]
 
 # 3. Classes where we DID NOT implement hooks (Control group)
-UNHOOKED_CLASSES = [Weibull]
+UNHOOKED_CLASSES = [Gamma]
 
 
 @pytest.mark.parametrize("dist_cls", HOOKED_CLASSES + UNHOOKED_CLASSES)

--- a/skpro/distributions/weibull.py
+++ b/skpro/distributions/weibull.py
@@ -57,6 +57,63 @@ class Weibull(BaseDistribution):
         "broadcast_init": "on",
     }
 
+    # documentation hooks for formula injection
+    _formula_docs = {
+        "pdf": r"""
+    The probability density function is given by:
+
+    .. math::
+        f(x) = \frac{k}{\lambda} \left(\frac{x}{\lambda}\right)^{k - 1}
+        \exp\left(-\left(\frac{x}{\lambda}\right)^k\right), \quad x \ge 0
+    """,
+        #
+        "log_pdf": r"""
+    The log-density is given by:
+
+    .. math::
+        \log f(x) = \log(k) - \log(\lambda)
+        + (k - 1) \log\left(\frac{x}{\lambda}\right)
+        - \left(\frac{x}{\lambda}\right)^k, \quad x \ge 0
+    """,
+        #
+        "cdf": r"""
+    The cumulative distribution function is given by:
+
+    .. math::
+        F(x) = 1 - \exp\left(-\left(\frac{x}{\lambda}\right)^k\right), \quad x \ge 0
+    """,
+        #
+        "ppf": r"""
+    The quantile function (inverse cdf) is:
+
+    .. math::
+        F^{-1}(p; \lambda, k) = \lambda \left(-\log(1 - p)\right)^{1/k}
+    """,
+        #
+        "mean": r"""
+    The expected value is:
+
+    .. math::
+        \mathbb{E}[X] = \lambda \Gamma\left(1 + \frac{1}{k}\right)
+    """,
+        #
+        "var": r"""
+    The variance is:
+
+    .. math::
+        \text{Var}(X) = \lambda^2 \left[\Gamma\left(1 + \frac{2}{k}\right)
+        - \Gamma\left(1 + \frac{1}{k}\right)^2\right]
+    """,
+        #
+        "energy": r"""
+    The self-energy is:
+
+    .. math::
+        \mathbb{E}[|X - Y|] = 2 \lambda \Gamma\left(1 + \frac{1}{k}\right)
+        \left(1 - 2^{-1/k}\right)
+    """,
+    }
+
     def __init__(self, scale, k, index=None, columns=None):
         self.scale = scale
         self.k = k


### PR DESCRIPTION
#### Reference Issues/PRs

Towards #1120.

Does not overlap with #1123 (Uniform, @Vidit-lab) or #968 (Pareto). Claimed on the issue before starting.

#### What does this implement/fix? Explain your changes.

Populates `_formula_docs` for two distributions that previously had none:

* `Logistic` (`skpro/distributions/logistic.py`)
* `Weibull` (`skpro/distributions/weibull.py`)

Each dict covers all seven applicable keys: `pdf`, `log_pdf`, `cdf`, `ppf`, `mean`, `var`, `energy`, following the `Normal` example and the extension template.

I picked these two because they are native `BaseDistribution` implementations with elementary closed-form `ppf` and exact `mean`/`var`, so every key is fillable without guessing. I looked at Poisson, Binomial and Beta first and skipped them: they are `_ScipyAdapter` wrappers whose `ppf` has no closed form.

**This PR also has to touch `skpro/distributions/tests/test_docstring_injection.py`.** That test used `Weibull` as the `UNHOOKED_CLASSES` control group, so adding formulae to `Weibull` made `test_unhooked_clean_fallback` fail on its `".. math::" not in doc` assertion. `Weibull` moves into `HOOKED_CLASSES` alongside `Logistic`, and `Gamma` becomes the new control - it has no `_formula_docs` and is unclaimed on #1120 at the time of writing. Happy to use a different control if you would prefer one less likely to be claimed.

#### References for the formulae

No AI-generated formulae.

Core `pdf`/`log_pdf`/`cdf`/`ppf`/`mean`/`var` are standard results from Johnson, Kotz & Balakrishnan, *Continuous Univariate Distributions*, 2nd ed. - Vol. 2 Ch. 23 (Logistic) and Vol. 1 Ch. 21 (Weibull); cross-checked against the NIST/SEMATECH e-Handbook 1.3.6.6.

The two energy formulae, stated explicitly since they need more than a citation:

* Logistic, `E|X-Y| = 2s` - already stated and derived in this repo, in the existing `Logistic._energy_self` docstring (`logistic.py` L223-233).
* Weibull, `E|X-Y| = 2*lambda*Gamma(1 + 1/k)*(1 - 2**(-1/k))` - derived from the fact that for iid `X, Y ~ Weibull(lambda, k)`, `min(X, Y) ~ Weibull(lambda * 2**(-1/k), k)`, so `E|X-Y| = 2*(E[X] - E[min])`.

Both reproduce the **Analytic** column already tabulated in this repo's own `skpro/distributions/energy_formulae.md` - `Logistic(0,1) = 2.000000` and `Weibull(1,2) = 0.519140` - which I treat as independent confirmation rather than my own arithmetic checking itself.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

* The choice of `Gamma` as the replacement control group in `test_docstring_injection.py`.
* Whether the `energy` key should be included at all, or left out until there is a dedicated review of energy formulae. Removing it is a clean deletion of one key per distribution; the other six are independent.
* Parameterisation, which I matched to the code rather than to any single textbook convention: `Logistic.scale` is the true scale `s` (so the sd is `s*pi/sqrt(3)`), and `Weibull.scale` is the multiplicative scale `lambda`, matching `scipy.stats.weibull_min(c=k, scale=lambda)`. Neither is a rate. Weibull's documented support is `x >= 0` because `_pdf` and `_cdf` both multiply by `(x >= 0)`.

#### Did you add any tests for the change?

No new tests. The existing `test_docstring_injection.py` already covers exactly this change: `test_hooked_math_injection` now asserts that `Logistic` and `Weibull` render `.. math::`, and `test_placeholder_removal_universal` asserts no `{formula_doc}` leak. 95 tests pass locally.

Separately from the test suite, I verified every formula numerically against each class's own `_pdf`/`_log_pdf`/`_cdf`/`_ppf`/`_mean`/`_var` over several parameter settings (max deviation ~1e-15), and the energy closed forms against quadrature of `2 * integral F(t)(1-F(t)) dt`.

#### Any other comments?

**Two docstring errors in `logistic.py` that I did not touch here**, since they are bugs rather than missing formulae, and I would rather not smuggle behaviour-adjacent corrections into a docs PR:

1. The class docstring at L17 gives the cdf as `F(x) = 1/(1 + exp((x - mu)/s))` - the minus sign is missing, so that is the survival function, not the cdf. The code is correct.
2. `_var` at L79 writes `\pi^3` where the code correctly computes `pi**2`.

Happy to fold both into this PR if you would prefer, or I will open a separate `[BUG]` issue.

**On LogNormal**, which I also claimed on the issue: `lognormal.py` is the only one of the three files with CRLF line endings, and editing it through the GitHub web editor normalises them to LF, turning a ~60 line addition into a 265-line whitespace diff. Rather than mix a line-ending change into a docs PR, I am leaving it for a follow-up done as a local commit. Worth noting that the CRLF endings in that one file may be unintentional in an otherwise LF repo.