### PR TITLE
[DOC] add `Gompertz` to distributions API reference

### DIFF
--- a/docs/source/api_reference/distributions.rst
+++ b/docs/source/api_reference/distributions.rst
@@ -67,6 +67,7 @@ Continuous support - non-negative reals
     Fisk
     Gamma
     GeneralizedPareto
+    Gompertz
     GumbelL
     GumbelR
     Levy


### PR DESCRIPTION


  #### Reference Issues/PRs

  None (found during a distribution-module audit).

  #### What does this implement/fix? Explain your changes.

  `Gompertz` is registered in `skpro/distributions/__init__.py` `__all__` and is importable, but it was missing from
  `docs/source/api_reference/distributions.rst`, so it did not appear on the rendered API reference page.

  Add `Gompertz` to the continuous / non-negative-support autosummary block (alphabetically, between `GeneralizedPareto` and `GumbelL`).

  Docs-only; no code or behavior change.

  #### Does your contribution introduce a new dependency? If yes, which one?

  No.

  #### What should a reviewer concentrate their feedback on?

  Just that `Gompertz` is placed in the correct support section, nothing else changed.

  #### Did you add any tests for the change?

  No 

  #### PR checklist

  - [x] Title starts with [DOC].
  - [x] Added to the API reference (`docs/source/api_reference/distributions.rst`).
  - [x] pre-commit clean on the changed file.
