### PR TITLE
[DOC] add missing `Examples` sections to distribution docstrings

### DIFF
--- a/skpro/distributions/burr_iii.py
+++ b/skpro/distributions/burr_iii.py
@@ -24,6 +24,12 @@ class BurrIII(_ScipyAdapter):
         Shape parameter
     scale : float
         Scale parameter
+
+    Examples
+    --------
+    >>> from skpro.distributions import BurrIII
+    >>>
+    >>> d = BurrIII(c=2, d=3, scale=1)
     """
 
     _tags = {

--- a/skpro/distributions/burr_xii.py
+++ b/skpro/distributions/burr_xii.py
@@ -24,6 +24,12 @@ class BurrXII(_ScipyAdapter):
         Shape parameter
     scale : float
         Scale parameter
+
+    Examples
+    --------
+    >>> from skpro.distributions import BurrXII
+    >>>
+    >>> d = BurrXII(c=2, d=3, scale=1)
     """
 
     _tags = {

--- a/skpro/distributions/f_dist.py
+++ b/skpro/distributions/f_dist.py
@@ -27,6 +27,12 @@ class FDist(_ScipyAdapter):
         Degrees of freedom numerator
     dfd : float
         Degrees of freedom denominator
+
+    Examples
+    --------
+    >>> from skpro.distributions import FDist
+    >>>
+    >>> d = FDist(dfn=5, dfd=2)
     """
 
     _tags = {

--- a/skpro/distributions/fatigue_life.py
+++ b/skpro/distributions/fatigue_life.py
@@ -25,6 +25,12 @@ class FatigueLife(_ScipyAdapter):
         Shape parameter
     scale : float
         Scale parameter
+
+    Examples
+    --------
+    >>> from skpro.distributions import FatigueLife
+    >>>
+    >>> d = FatigueLife(c=2, scale=1)
     """
 
     _tags = {

--- a/skpro/distributions/gumbel_l.py
+++ b/skpro/distributions/gumbel_l.py
@@ -30,8 +30,8 @@ class GumbelL(_ScipyAdapter):
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
 
-    Example
-    -------
+    Examples
+    --------
     >>> from skpro.distributions import GumbelL
     >>> gumbel_l_dist = GumbelL(mu=0.0, sigma=1.0)
     >>> gumbel_l_dist.mean()

--- a/skpro/distributions/gumbel_r.py
+++ b/skpro/distributions/gumbel_r.py
@@ -30,8 +30,8 @@ class GumbelR(_ScipyAdapter):
     index : pd.Index, optional, default = RangeIndex
     columns : pd.Index, optional, default = RangeIndex
 
-    Example
-    -------
+    Examples
+    --------
     >>> from skpro.distributions import GumbelR
     >>> gumbel_r_dist = GumbelR(mu=0.0, sigma=1.0)
     >>> gumbel_r_dist.mean()

--- a/skpro/distributions/left_truncated.py
+++ b/skpro/distributions/left_truncated.py
@@ -18,6 +18,11 @@ class LeftTruncated(TruncatedDistribution):
     lower : int
         The lower bound below which values are truncated (excluded from sampling).
 
+    Examples
+    --------
+    >>> from skpro.distributions import LeftTruncated, Poisson
+    >>>
+    >>> d = LeftTruncated(Poisson(mu=2), lower=0)
     """
 
     def __init__(

--- a/skpro/distributions/skellam.py
+++ b/skpro/distributions/skellam.py
@@ -24,6 +24,12 @@ class Skellam(_ScipyAdapter):
         Mean of the first Poisson distribution
     mu2 : float
         Mean of the second Poisson distribution
+
+    Examples
+    --------
+    >>> from skpro.distributions import Skellam
+    >>>
+    >>> d = Skellam(mu1=3, mu2=2)
     """
 
     _tags = {

--- a/skpro/distributions/truncated_pareto.py
+++ b/skpro/distributions/truncated_pareto.py
@@ -30,6 +30,12 @@ class TruncatedPareto(BaseDistribution):
         Lower truncation bound
     upper : float
         Upper truncation bound
+
+    Examples
+    --------
+    >>> from skpro.distributions import TruncatedPareto
+    >>>
+    >>> d = TruncatedPareto(b=2, scale=1, lower=1, upper=10)
     """
 
     _tags = {


### PR DESCRIPTION
  #### Reference Issues/PRs

  None (found during a distribution-module audit).

  #### What does this implement/fix? Explain your changes.

  Nine distributions were out of line with the repo convention that each class docstring has an `Examples` section (which runs as a doctest under `--doctest-modules`):

  - **Seven had no `Examples`/doctest at all** — `BurrIII`, `BurrXII`, `FDist`,  `FatigueLife`, `LeftTruncated`, `Skellam`, `TruncatedPareto`. Added a minimal runnable `Examples` section (import + construct) to each.
  - **`GumbelL` and `GumbelR`** already had working doctests, but under a non-standard `Example` (singular) header, so they didn't register as the numpydoc `Examples` section. Fixed the header to `Examples`.

  Docs-only; no code or behavior change.

  #### Does your contribution introduce a new dependency? If yes, which one?

  No.

  #### What should a reviewer concentrate their feedback on?

  - That each example uses a valid, representative parameter set.
  - `LeftTruncated`'s example composes another distribution  (`LeftTruncated(Poisson(mu=2), lower=0)`), confirm that's the clearest illustration.

  #### Did you add any tests for the change?

  The added `Examples` blocks are themselves doctests 

  #### PR checklist

  - [x] Title starts with [DOC].
  - [x] Illustrative `Examples` section in each affected docstring (runs as doctest).
  - [x] `pytest --doctest-modules` passes on all nine files.
  - [x] pre-commit clean on changed files.
