### PR TITLE
[MNT] remove extraneous material from package wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,22 +110,11 @@ isort = "^docs/source/examples/"
 zip-safe = true
 
 [tool.setuptools.package-data]
-sktime = [
+skpro = [
     "*.csv",
     "*.csv.gz",
     "*.txt",
 ]
 
 [tool.setuptools.packages.find]
-exclude = [
-    "tests",
-    "tests.*",
-    "docs",
-    "docs.*",
-    "examples",
-    "examples.*",
-    "build_tools",
-    "build_tools.*",
-    "extension_templates",
-    "extension_templates.*",
-]
+include = ["skpro", "skpro.*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,4 +117,15 @@ sktime = [
 ]
 
 [tool.setuptools.packages.find]
-exclude = ["tests", "tests.*"]
+exclude = [
+    "tests",
+    "tests.*",
+    "docs",
+    "docs.*",
+    "examples",
+    "examples.*",
+    "build_tools",
+    "build_tools.*",
+    "extension_templates",
+    "extension_templates.*",
+]


### PR DESCRIPTION
Mirror of https://github.com/sktime/sktime/issues/10891
Explicitly excludes folders from repository root that should not be shipped with release package wheels:

* `build_tools` (for maintainers only)
* `docs` (for developers with a clone only)
* `examples` (consumption via clone, binder/colab resp online docs only)
* `extension_templates` (for developers with a clone only)

Mechanism: changing to explicit include (also future-proof) as opposed to widening exclude statement, in `tool.setuptools.packages.find`.