### PR TITLE
[MNT] add documentation link checker to CI

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,63 @@
+name: Docs link check
+
+on:
+  pull_request:
+    branches:
+      - main
+      - 'release**'
+    paths:
+      - 'docs/**'
+      - 'skpro/**/*.py'
+      - 'pyproject.toml'
+      - '.github/workflows/linkcheck.yml'
+  schedule:
+    - cron: '0 0 * * 6'
+
+  # Allows workflows to be manually triggered
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: linkcheck-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  linkcheck:
+    name: docs link check
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: repository checkout step
+        uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: python environment step
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install skpro and docs dependencies
+        shell: bash
+        run: uv pip install .[docs] --no-cache-dir
+        env:
+          UV_SYSTEM_PYTHON: 1
+
+      - name: Show dependencies
+        run: uv pip list
+
+      - name: Run sphinx linkcheck
+        run: python -m sphinx -b linkcheck -j auto docs/source docs/_build/linkcheck
+
+      - name: Upload linkcheck report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: linkcheck-report
+          path: docs/_build/linkcheck/
+          retention-days: 7

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -291,6 +291,25 @@ Generated using nbsphinx_. The Jupyter notebook can be found here_.
 .. _nbsphinx: https://nbsphinx.readthedocs.io/
 """
 
+# -- Options for linkcheck builder -------------------------------------------
+
+# entries are regular expressions matched against the full URL, not globs
+linkcheck_ignore = [
+    # blocks non-browser clients with HTTP 999
+    r"https://www\.linkedin\.com/.*",
+]
+
+# the changelog links every pull request and contributor through sphinx-issues,
+# generated from numbers and user names.
+linkcheck_exclude_documents = [r"changelog"]
+
+linkcheck_retries = 3
+linkcheck_timeout = 30
+linkcheck_workers = 10
+
+# anchors on JS-rendered pages cannot be resolved from the raw HTML
+linkcheck_anchors = False
+
 # -- Options for intersphinx extension ---------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Adds a CI job that checks the external links in the documentation, using Sphinx's
built-in `linkcheck` builder.

Two changes:

**1. New workflow, `.github/workflows/linkcheck.yml`**

The job installs the `docs` extra and runs:

```
python -m sphinx -b linkcheck -j auto docs/source docs/_build/linkcheck
```

The `linkcheck` builder exits with a non-zero status when it finds a broken link, so
a broken link fails the job and reports it at `output.txt`.

This is a separate workflow from `test.yml`, because it sets
`paths-ignore: ['docs/**']`, so a job added to `test.yml` would not run on a
documentation-only pull request.

Triggers:

- Pull requests that touch `docs/`, `skpro/**/*.py`, `pyproject.toml`, or the workflow
  itself. Source files are included because docstrings are API reference pages.
- A weekly cron, matching the schedule already used by `update_contributors.yml`.

- `workflow_dispatch`, for manual runs.

**2. `linkcheck` options in `docs/source/conf.py`**

- `linkcheck_exclude_documents = [r"changelog"]`. The changelog holds 506 `:pr:` roles
  and 617 `:user:` roles, which `sphinx-issues` renders as roughly 570 unique
  github.com URLs. Checking them hits GitHub rate limits.
- `linkcheck_ignore` for `linkedin.com`, which returns HTTP 999 to non-browser clients.
- `linkcheck_anchors = False`, because anchors on pages rendered by JavaScript cannot be
  resolved from the raw HTML.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Did you add any tests for the change?

It was verified by running the checker locally against the current `main`:

```
working 44   redirected 14   ignored 507   unchecked 189   broken 0
```


#### Any other comments?


#### PR checklist

##### For all contributions
- [ ] I've added myself to the list of contributors with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
