### PR TITLE
[ENH] add tag skip mechanism to test framework, skip estimators with missing docstrings

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -41,6 +41,7 @@ Enhancements
 * [ENH] expand distfitter module with 5 new distribution fitters (:pr:`1110`) :user:`patelchaitany`
 * [ENH] ``NaiveProbaRegressor`` using distribution fitter (:pr:`1108`) :user:`patelchaitany`
 * [ENH] ``TruncatedPareto``: add closed-form ``mean`` and ``var`` (:pr:`1114`) :user:`binggao1230`
+* [ENH] add tag skip mechanism to test framework, skip estimators with missing docstrings (:pr:`1133`) :user:`fkiraly`
 
 Maintenance
 ~~~~~~~~~~~

--- a/skpro/metrics/_aucc.py
+++ b/skpro/metrics/_aucc.py
@@ -60,6 +60,12 @@ class AUCalibration(BaseDistrMetric):
           the metric is computed per variable marginal, results in many scores per row
     """  # noqa: E501
 
+    _tags = {
+          # CI and test flags
+          # -----------------
+          "tests:skip_by_name": ["test_class_has_doctest_example"],
+      }
+
     def __init__(self, multioutput="uniform_average", multivariate=False):
         self.multivariate = multivariate
         super().__init__(multioutput=multioutput)

--- a/skpro/metrics/_aucc.py
+++ b/skpro/metrics/_aucc.py
@@ -61,10 +61,10 @@ class AUCalibration(BaseDistrMetric):
     """  # noqa: E501
 
     _tags = {
-          # CI and test flags
-          # -----------------
-          "tests:skip_by_name": ["test_class_has_doctest_example"],
-      }
+        # CI and test flags
+        # -----------------
+        "tests:skip_by_name": ["test_class_has_doctest_example"],
+    }
 
     def __init__(self, multioutput="uniform_average", multivariate=False):
         self.multivariate = multivariate

--- a/skpro/metrics/_constraint_violation.py
+++ b/skpro/metrics/_constraint_violation.py
@@ -63,6 +63,9 @@ class ConstraintViolation(BaseProbaMetric):
     _tags = {
         "scitype:y_pred": "pred_interval",
         "lower_is_better": True,
+        # CI and test flags
+        # -----------------
+        "tests:skip_by_name": ["test_class_has_doctest_example"],
     }
 
     def __init__(

--- a/skpro/metrics/_crps.py
+++ b/skpro/metrics/_crps.py
@@ -42,6 +42,12 @@ class CRPS(BaseDistrMetric):
           the score is computed per variable marginal, results in many scores per row
     """  # noqa: E501
 
+    _tags = {
+        # CI and test flags
+        # -----------------
+        "tests:skip_by_name": ["test_class_has_doctest_example"],
+    }
+
     def __init__(self, multioutput="uniform_average", multivariate=False):
         self.multivariate = multivariate
         super().__init__(multioutput=multioutput)

--- a/skpro/metrics/_empirical_coverage.py
+++ b/skpro/metrics/_empirical_coverage.py
@@ -60,6 +60,9 @@ class EmpiricalCoverage(BaseProbaMetric):
     _tags = {
         "scitype:y_pred": "pred_interval",
         "lower_is_better": False,
+        # CI and test flags
+        # -----------------
+        "tests:skip_by_name": ["test_class_has_doctest_example"],
     }
 
     def __init__(

--- a/skpro/metrics/_interval_width.py
+++ b/skpro/metrics/_interval_width.py
@@ -53,6 +53,9 @@ class IntervalWidth(BaseProbaMetric):
     _tags = {
         "scitype:y_pred": "pred_interval",
         "lower_is_better": True,
+        # CI and test flags
+        # -----------------
+        "tests:skip_by_name": ["test_class_has_doctest_example"],
     }
 
     def __init__(

--- a/skpro/metrics/_logloss.py
+++ b/skpro/metrics/_logloss.py
@@ -38,6 +38,12 @@ class LogLoss(BaseDistrMetric):
           the log-loss is computed per variable marginal, results in many scores per row
     """
 
+    _tags = {
+        # CI and test flags
+        # -----------------
+        "tests:skip_by_name": ["test_class_has_doctest_example"],
+    }
+
     def __init__(self, multioutput="uniform_average", multivariate=False):
         self.multivariate = multivariate
         super().__init__(multioutput=multioutput)

--- a/skpro/metrics/_logloss_linearized.py
+++ b/skpro/metrics/_logloss_linearized.py
@@ -45,6 +45,12 @@ class LinearizedLogLoss(BaseDistrMetric):
           the score is computed per variable marginal, results in many scores per row
     """
 
+    _tags = {
+        # CI and test flags
+        # -----------------
+        "tests:skip_by_name": ["test_class_has_doctest_example"],
+    }
+
     def __init__(self, range=1, multioutput="uniform_average", multivariate=False):
         self.range = range
         self.multivariate = multivariate

--- a/skpro/metrics/_squared_loss.py
+++ b/skpro/metrics/_squared_loss.py
@@ -46,6 +46,12 @@ class SquaredDistrLoss(BaseDistrMetric):
           the score is computed per variable marginal, results in many scores per row
     """
 
+    _tags = {
+        # CI and test flags
+        # -----------------
+        "tests:skip_by_name": ["test_class_has_doctest_example"],
+    }
+
     def __init__(self, multioutput="uniform_average", multivariate=False):
         self.multivariate = multivariate
         super().__init__(multioutput=multioutput)

--- a/skpro/metrics/survival/_c_harrell.py
+++ b/skpro/metrics/survival/_c_harrell.py
@@ -107,6 +107,9 @@ class ConcordanceHarrell(BaseSurvDistrMetric):
         "capability:survival": True,
         "scitype:y_pred": "pred_proba",
         "lower_is_better": False,
+        # CI and test flags
+        # -----------------
+        "tests:skip_by_name": ["test_class_has_doctest_example"],
     }
 
     def __init__(

--- a/skpro/metrics/survival/_spll.py
+++ b/skpro/metrics/survival/_spll.py
@@ -57,6 +57,9 @@ class SPLL(BaseSurvDistrMetric):
         "capability:survival": True,
         "scitype:y_pred": "pred_proba",
         "lower_is_better": True,
+        # CI and test flags
+        # -----------------
+        "tests:skip_by_name": ["test_class_has_doctest_example"],
     }
 
     def __init__(self, multioutput="uniform_average", multivariate=False):

--- a/skpro/regression/adapters/sklearn/_sklearn_proba.py
+++ b/skpro/regression/adapters/sklearn/_sklearn_proba.py
@@ -31,6 +31,9 @@ class SklearnProbaReg(BaseProbaRegressor):
     _tags = {
         "capability:multioutput": False,
         "capability:missing": True,
+        # CI and test flags
+        # -----------------
+        "tests:skip_by_name": ["test_class_has_doctest_example"],
     }
 
     def __init__(self, estimator, inner_type="pd.DataFrame"):

--- a/skpro/regression/dummy.py
+++ b/skpro/regression/dummy.py
@@ -51,6 +51,9 @@ class DummyProbaRegressor(BaseProbaRegressor):
         "capability:missing": True,
         "X_inner_mtype": "pd_DataFrame_Table",
         "y_inner_mtype": "pd_DataFrame_Table",
+        # CI and test flags
+        # -----------------
+        "tests:skip_by_name": ["test_class_has_doctest_example"],
     }
 
     def __init__(self, strategy="empirical"):

--- a/skpro/regression/gp/_sklearn.py
+++ b/skpro/regression/gp/_sklearn.py
@@ -105,6 +105,12 @@ class GaussianProcess(_DelegateWithFittedParamForwarding):
         The log-marginal-likelihood of ``self.kernel_.theta``.
     """
 
+    _tags = {
+        # CI and test flags
+        # -----------------
+        "tests:skip_by_name": ["test_class_has_doctest_example"],
+    }
+
     def __init__(
         self,
         kernel=None,

--- a/skpro/regression/linear/_glm.py
+++ b/skpro/regression/linear/_glm.py
@@ -205,6 +205,9 @@ class GLMRegressor(BaseProbaRegressor):
         "capability:missing": False,
         "X_inner_mtype": "pd_DataFrame_Table",
         "y_inner_mtype": "pd_DataFrame_Table",
+        # CI and test flags
+        # -----------------
+        "tests:skip_by_name": ["test_class_has_doctest_example"],
     }
 
     def _str_to_sm_family(self, dist, link):

--- a/skpro/regression/linear/_sklearn.py
+++ b/skpro/regression/linear/_sklearn.py
@@ -88,6 +88,12 @@ class ARDRegression(_DelegateWithFittedParamForwarding):
         zero mean. Set to np.zeros(n_features) otherwise.
     """
 
+    _tags = {
+        # CI and test flags
+        # -----------------
+        "tests:skip_by_name": ["test_class_has_doctest_example"],
+    }
+
     def __init__(
         self,
         max_iter=300,
@@ -292,6 +298,12 @@ class BayesianRidge(_DelegateWithFittedParamForwarding):
         If `fit_intercept=True`, offset subtracted for centering data to a
         zero mean. Set to np.zeros(n_features) otherwise.
     """
+
+    _tags = {
+        # CI and test flags
+        # -----------------
+        "tests:skip_by_name": ["test_class_has_doctest_example"],
+    }
 
     def __init__(
         self,

--- a/skpro/regression/linear/_sklearn_poisson.py
+++ b/skpro/regression/linear/_sklearn_poisson.py
@@ -69,6 +69,9 @@ class PoissonRegressor(BaseProbaRegressor):
         "capability:missing": False,
         "X_inner_mtype": "pd_DataFrame_Table",
         "y_inner_mtype": "pd_DataFrame_Table",
+        # CI and test flags
+        # -----------------
+        "tests:skip_by_name": ["test_class_has_doctest_example"],
     }
 
     def __init__(

--- a/skpro/regression/online/_dont_refit.py
+++ b/skpro/regression/online/_dont_refit.py
@@ -26,7 +26,12 @@ class OnlineDontRefit(_DelegatedProbaRegressor):
         clone of the regressor passed in the constructor, fitted on all data
     """
 
-    _tags = {"capability:update": False}
+    _tags = {
+        "capability:update": False,
+        # CI and test flags
+        # -----------------
+        "tests:skip_by_name": ["test_class_has_doctest_example"],
+    }
 
     def __init__(self, estimator):
         self.estimator = estimator

--- a/skpro/regression/online/_refit.py
+++ b/skpro/regression/online/_refit.py
@@ -28,7 +28,12 @@ class OnlineRefit(_DelegatedProbaRegressor):
         clone of the regressor passed in the constructor, fitted on all data
     """
 
-    _tags = {"capability:update": True}
+    _tags = {
+        "capability:update": True,
+        # CI and test flags
+        # -----------------
+        "tests:skip_by_name": ["test_class_has_doctest_example"],
+    }
 
     def __init__(self, estimator):
         self.estimator = estimator

--- a/skpro/regression/online/_refit_every.py
+++ b/skpro/regression/online/_refit_every.py
@@ -33,7 +33,12 @@ class OnlineRefitEveryN(_DelegatedProbaRegressor):
         clone of the regressor passed in the constructor, fitted on all data
     """
 
-    _tags = {"capability:update": True}
+    _tags = {
+        "capability:update": True,
+        # CI and test flags
+        # -----------------
+        "tests:skip_by_name": ["test_class_has_doctest_example"],
+    }
 
     def __init__(self, estimator, N=1):
         self.estimator = estimator

--- a/skpro/survival/compose/_reduce_cond_unc.py
+++ b/skpro/survival/compose/_reduce_cond_unc.py
@@ -32,7 +32,12 @@ class ConditionUncensored(BaseProbaRegressor):
         fitted probabilistic regressor, clone of ``regressor``
     """
 
-    _tags = {"capability:survival": True}
+    _tags = {
+        "capability:survival": True,
+        # CI and test flags
+        # -----------------
+        "tests:skip_by_name": ["test_class_has_doctest_example"],
+    }
 
     def __init__(self, estimator):
         self.estimator = estimator

--- a/skpro/survival/compose/_reduce_uncensored.py
+++ b/skpro/survival/compose/_reduce_uncensored.py
@@ -28,7 +28,12 @@ class FitUncensored(_DelegatedProbaRegressor):
         clone of estimator
     """
 
-    _tags = {"capability:survival": True}
+    _tags = {
+        "capability:survival": True,
+        # CI and test flags
+        # -----------------
+        "tests:skip_by_name": ["test_class_has_doctest_example"],
+    }
 
     _delegate_name = "estimator_"
 

--- a/skpro/survival/coxph/_coxph_statsmodels.py
+++ b/skpro/survival/coxph/_coxph_statsmodels.py
@@ -58,6 +58,9 @@ class CoxPH(BaseSurvReg):
         "capability:missing": False,
         "capability:survival": True,
         "python_dependencies": ["statsmodels"],
+        # CI and test flags
+        # -----------------
+        "tests:skip_by_name": ["test_class_has_doctest_example"],
     }
 
     def __init__(

--- a/skpro/tests/test_all_estimators.py
+++ b/skpro/tests/test_all_estimators.py
@@ -116,6 +116,19 @@ class BaseFixtureGenerator(_BaseFixtureGenerator):
 
         return obj_list
 
+    def is_excluded(self, test_name, est):
+        """Shorthand to check whether test test_name is excluded for estimator est."""
+        # there are two conditions for exclusion:
+        # 1. the estimator is excluded in the legacy excluded_tests list
+        # 2. the excluded test appears in the "tests:skip_by_name" tag
+        cond1 = test_name in self.excluded_tests.get(est.__name__, [])
+        excl_tag = est.get_class_tag("tests:skip_by_name", [])
+        if excl_tag is None:
+            excl_tag = []
+        cond2 = test_name in excl_tag
+        excluded = cond1 or cond2
+        return excluded
+
     # which sequence the conditional fixtures are generated in
     fixture_sequence = [
         "object_class",


### PR DESCRIPTION
This PR adds a tag skip mechanism to the test framework in `TestAllObjects`, and adds some tag skips to estimators with missing docstrings that would trip the tests.

Parallels the test system state in `sktime`.