### PR TITLE
[ENH] add more doctest skip tags to estimators without docstrings

### DIFF
--- a/skpro/regression/bayesian/_linear_conjugate.py
+++ b/skpro/regression/bayesian/_linear_conjugate.py
@@ -70,27 +70,27 @@ class BayesianConjugateLinearRegressor(BaseProbaRegressor):
     ... )  # doctest: +SKIP
     >>> from sklearn.datasets import load_diabetes  # doctest: +SKIP
     >>> from sklearn.model_selection import train_test_split  # doctest: +SKIP
-
+    >>>
     >>> # Load dataset
     >>> X, y = load_diabetes(return_X_y=True, as_frame=True)  # doctest: +SKIP
     >>> X_train, X_test, y_train, y_test = train_test_split(X, y)  # doctest: +SKIP
-
+    >>>
     >>> # Center the training data
     >>> X_train -= X_train.mean(axis=0)  # doctest: +SKIP
-
+    >>>
     >>> # Initialize model
     >>> bayes_model = BayesianConjugateLinearRegressor(
     ...     coefs_prior_mu=None,
     ...     coefs_prior_cov=np.eye(X_train.shape[1]),
     ...     noise_precision=1.0,
     ... )  # doctest: +SKIP
-
+    >>>
     >>> # Fit the model
     >>> bayes_model.fit(X_train, y_train)  # doctest: +SKIP
-
+    >>>
     >>> # Predict probabilities (returns an skpro Normal distribution)
     >>> y_test_pred_proba = bayes_model.predict_proba(X_test)  # doctest: +SKIP
-
+    >>>
     >>> # Predict point estimates (mean of the predicted distribution)
     >>> y_test_pred = bayes_model.predict(X_test)  # doctest: +SKIP
     """

--- a/skpro/regression/bayesian/_linear_mcmc.py
+++ b/skpro/regression/bayesian/_linear_mcmc.py
@@ -36,7 +36,7 @@ class BayesianLinearRegressor(BaseProbaRegressor):
     >>> from sklearn.model_selection import train_test_split  # doctest: +SKIP
     >>> X, y = load_diabetes(return_X_y=True, as_frame=True)  # doctest: +SKIP
     >>> X_train, X_test, y_train, y_test = train_test_split(X, y)  # doctest: +SKIP
-
+    >>>
     >>> bayes_model = BayesianLinearRegressor()  # doctest: +SKIP
     >>> bayes_model.fit(X_train, y_train)  # doctest: +SKIP
     >>> y_test_pred_proba = bayes_model.predict_proba(X_test)  # doctest: +SKIP

--- a/skpro/survival/additive/_aalen_lifelines.py
+++ b/skpro/survival/additive/_aalen_lifelines.py
@@ -50,8 +50,14 @@ class AalenAdditive(_LifelinesAdapter, BaseSurvReg):
         The durations provided
     """
 
-    _tags = {"authors": ["CamDavidsonPilon", "rocreguant", "fkiraly"]}
-    # CamDavidsonPilon, rocreguant credit for interfaced estimator
+    _tags = {
+        "authors": ["CamDavidsonPilon", "rocreguant", "fkiraly"],
+        # CamDavidsonPilon, rocreguant credit for interfaced estimator
+        #
+        # CI and test flags
+        # -----------------
+        "tests:skip_by_name": ["test_class_has_doctest_example"],
+    }
 
     def __init__(
         self,

--- a/skpro/survival/aft/_aft_lifelines_fisk.py
+++ b/skpro/survival/aft/_aft_lifelines_fisk.py
@@ -79,8 +79,14 @@ class AFTFisk(_LifelinesAdapter, BaseSurvReg):
         the concordance index of the model.
     """
 
-    _tags = {"authors": ["CamDavidsonPilon", "fkiraly"]}
-    # CamDavidsonPilon, credit for interfaced estimator
+    _tags = {
+        "authors": ["CamDavidsonPilon", "fkiraly"],
+        # CamDavidsonPilon, credit for interfaced estimator
+        #
+        # CI and test flags
+        # -----------------
+        "tests:skip_by_name": ["test_class_has_doctest_example"],
+    }
 
     def __init__(
         self,

--- a/skpro/survival/aft/_aft_lifelines_lognormal.py
+++ b/skpro/survival/aft/_aft_lifelines_lognormal.py
@@ -76,8 +76,14 @@ class AFTLogNormal(_LifelinesAdapter, BaseSurvReg):
         the concordance index of the model.
     """
 
-    _tags = {"authors": ["CamDavidsonPilon", "fkiraly"]}
-    # CamDavidsonPilon, credit for interfaced estimator
+    _tags = {
+        "authors": ["CamDavidsonPilon", "fkiraly"],
+        # CamDavidsonPilon, credit for interfaced estimator
+        #
+        # CI and test flags
+        # -----------------
+        "tests:skip_by_name": ["test_class_has_doctest_example"],
+    }
 
     def __init__(
         self,

--- a/skpro/survival/aft/_aft_lifelines_weibull.py
+++ b/skpro/survival/aft/_aft_lifelines_weibull.py
@@ -86,8 +86,14 @@ class AFTWeibull(_LifelinesAdapter, BaseSurvReg):
         the concordance index of the model.
     """
 
-    _tags = {"authors": ["CamDavidsonPilon", "fkiraly"]}
-    # CamDavidsonPilon, credit for interfaced estimator
+    _tags = {
+        "authors": ["CamDavidsonPilon", "fkiraly"],
+        # CamDavidsonPilon, credit for interfaced estimator
+        #
+        # CI and test flags
+        # -----------------
+        "tests:skip_by_name": ["test_class_has_doctest_example"],
+    }
 
     def __init__(
         self,

--- a/skpro/survival/coxph/_coxnet_sksurv.py
+++ b/skpro/survival/coxph/_coxnet_sksurv.py
@@ -99,7 +99,7 @@ class CoxNet(_SksurvAdapter, BaseSurvReg):
     >>> from sklearn.model_selection import train_test_split  # doctest: +SKIP
     >>> X, y = load_diabetes(return_X_y=True, as_frame=True)  # doctest: +SKIP
     >>> X_train, X_test, y_train, y_test = train_test_split(X, y)  # doctest: +SKIP
-
+    >>>
     >>> reg_proba = CoxNet()  # doctest: +SKIP
     >>> reg_proba.fit(X_train, y_train)  # doctest: +SKIP
     >>> y_pred = reg_proba.predict_proba(X_test)  # doctest: +SKIP

--- a/skpro/survival/coxph/_coxph_lifelines.py
+++ b/skpro/survival/coxph/_coxph_lifelines.py
@@ -145,8 +145,14 @@ class CoxPHlifelines(_LifelinesAdapter, BaseSurvReg):
       Statistics in Medicine, 21(15), 2175–2197. doi:10.1002/sim.1203
     """
 
-    _tags = {"authors": ["CamDavidsonPilon", "JoseLlanes", "mathurinm", "fkiraly"]}
-    # CamDavidsonPilon, JoseLlanes, mathurinm credit for interfaced estimator
+    _tags = {
+        "authors": ["CamDavidsonPilon", "JoseLlanes", "mathurinm", "fkiraly"],
+        # CamDavidsonPilon, JoseLlanes, mathurinm credit for interfaced estimator
+        #
+        # CI and test flags
+        # -----------------
+        "tests:skip_by_name": ["test_class_has_doctest_example"],
+    }
 
     def __init__(
         self,


### PR DESCRIPTION
This PR adds doctest skip tags for estimators without docstrings, to avoid test failures due to missing docstrings.