### PR TITLE
[BUG] fix column names passed to `scikit-learn`  in `ConditionUncensored` to be unique

### DIFF
--- a/skpro/survival/compose/_reduce_cond_unc.py
+++ b/skpro/survival/compose/_reduce_cond_unc.py
@@ -85,6 +85,11 @@ class ConditionUncensored(BaseProbaRegressor):
         else:
             C = C.copy().astype("float")
         X_and_C = pd.concat([X, C], axis=1)
+
+        X_colnames = [f"X__{col}" for col in X.columns]
+        C_colnames = [f"C__{col}" for col in C.columns]
+
+        X_and_C.columns = X_colnames + C_colnames
         return X_and_C
 
     def _predict(self, X):


### PR DESCRIPTION
Fixes an unreported bug for column names passed to `scikit-learn`  in `ConditionUncensored` to be unique.

Non-uniqueness was not a problem with previous `scikit-learn` versions, but uniqueness is now enforced.