### PR TITLE
[DOC] add usage examples to `ARDRegression` and `BayesianRidge` docstrings

### DIFF
--- a/skpro/regression/linear/_sklearn.py
+++ b/skpro/regression/linear/_sklearn.py
@@ -86,13 +86,18 @@ class ARDRegression(_DelegateWithFittedParamForwarding):
     X_offset_ : float
         If `fit_intercept=True`, offset subtracted for centering data to a
         zero mean. Set to np.zeros(n_features) otherwise.
-    """
 
-    _tags = {
-        # CI and test flags
-        # -----------------
-        "tests:skip_by_name": ["test_class_has_doctest_example"],
-    }
+    Examples
+    --------
+    >>> from sklearn.datasets import load_diabetes
+    >>> from sklearn.model_selection import train_test_split
+    >>> from skpro.regression.linear import ARDRegression
+    >>> X, y = load_diabetes(return_X_y=True, as_frame=True)
+    >>> X_train, X_test, y_train, y_test = train_test_split(X, y)
+    >>> reg = ARDRegression()
+    >>> reg = reg.fit(X_train, y_train)
+    >>> y_pred = reg.predict_proba(X_test)
+    """
 
     def __init__(
         self,
@@ -297,13 +302,18 @@ class BayesianRidge(_DelegateWithFittedParamForwarding):
     X_offset_ : ndarray of shape (n_features,)
         If `fit_intercept=True`, offset subtracted for centering data to a
         zero mean. Set to np.zeros(n_features) otherwise.
-    """
 
-    _tags = {
-        # CI and test flags
-        # -----------------
-        "tests:skip_by_name": ["test_class_has_doctest_example"],
-    }
+    Examples
+    --------
+    >>> from sklearn.datasets import load_diabetes
+    >>> from sklearn.model_selection import train_test_split
+    >>> from skpro.regression.linear import BayesianRidge
+    >>> X, y = load_diabetes(return_X_y=True, as_frame=True)
+    >>> X_train, X_test, y_train, y_test = train_test_split(X, y)
+    >>> reg = BayesianRidge()
+    >>> reg = reg.fit(X_train, y_train)
+    >>> y_pred = reg.predict_proba(X_test)
+    """
 
     def __init__(
         self,


### PR DESCRIPTION
### Reference Issues/PRs

Towards #1135.

### What does this implement/fix? Explain your changes.

Adds a numpydoc `Examples` section to the two sklearn linear adapters in `skpro/regression/linear/_sklearn.py`:

- `ARDRegression`
- `BayesianRidge`

Both examples follow the `MultipleQuantileRegressor` template referenced in #1135: load a small built-in dataset, split, fit, and call a probabilistic prediction method. As instructed in the issue, the now-obsolete

```python
"tests:skip_by_name": ["test_class_has_doctest_example"],
```

tag is removed from both classes, so `test_class_has_doctest_example` now runs for them.

### Verification

Run locally against the changed classes:

- `pytest --doctest-modules skpro/regression/linear/_sklearn.py` → 2 passed
- `test_class_has_doctest_example` and `test_doctest_examples` for `ARDRegression` and `BayesianRidge` → 4 passed
- `black`, `isort`, `flake8` on the changed file → clean

### Any other comments?

Scope is limited to the two estimators in this module; other estimators listed in #1135 remain available for separate PRs.