### PR TITLE
[DOC] Docstring of estimators

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -296,6 +296,15 @@
         "bug",
         "code"
       ]
+    },
+    {
+      "login": "Ayushagrawal-cse",
+      "name": "Ayush Agrawal",
+      "avatar_url": "https://avatars.githubusercontent.com/u/191835489?v=4&size=64",
+      "profile": "https://www.linkedin.com/in/bgp-ayush-agrawal/",
+      "contributions": [
+        "doc"
+      ]
     }
   ]
 }

--- a/skpro/regression/adapters/sklearn/_sklearn_proba.py
+++ b/skpro/regression/adapters/sklearn/_sklearn_proba.py
@@ -26,14 +26,25 @@ class SklearnProbaReg(BaseProbaRegressor):
     inner_type : str, one of "pd.DataFrame", "np.ndarray", default="pd.DataFrame"
         Type of X passed to ``fit`` and ``predict`` methods of the wrapped estimator.
         Type of y passed to ``fit`` method of the wrapped estimator.
+
+    Examples
+    --------
+    ``SklearnProbaReg`` adapts a scikit-learn regressor that provides
+    predictive uncertainty to the ``skpro`` probabilistic regression interface.
+
+    >>> import pandas as pd
+    >>> from sklearn.gaussian_process import GaussianProcessRegressor
+    >>> from skpro.regression.adapters.sklearn import SklearnProbaReg
+    >>> X = pd.DataFrame({"x": [1, 2, 3]})
+    >>> y = pd.DataFrame({"y": [2, 4, 6]})
+    >>> reg = SklearnProbaReg(GaussianProcessRegressor())
+    >>> reg = reg.fit(X, y)
+    >>> y_pred = reg.predict_proba(X)
     """
 
     _tags = {
         "capability:multioutput": False,
         "capability:missing": True,
-        # CI and test flags
-        # -----------------
-        "tests:skip_by_name": ["test_class_has_doctest_example"],
     }
 
     def __init__(self, estimator, inner_type="pd.DataFrame"):

--- a/skpro/regression/dummy.py
+++ b/skpro/regression/dummy.py
@@ -38,6 +38,16 @@ class DummyProbaRegressor(BaseProbaRegressor):
     distribution_ : skpro.distribution
         Normal distribution or Empirical distribution, depending on chosen strategy.
         Scalar version of the distribution that is returned by ``predict_proba``.
+
+    Examples
+    --------
+    >>> from skpro.regression.dummy import DummyProbaRegressor
+    >>> X = pd.DataFrame({"x": [1, 2, 3]})
+    >>> y = pd.DataFrame({"y": [2, 4, 6]})
+    >>> reg = DummyProbaRegressor()
+    >>> reg.fit(X, y)
+    DummyProbaRegressor()
+    >>> y_pred = reg.predict_proba(X)
     """
 
     _tags = {
@@ -51,9 +61,6 @@ class DummyProbaRegressor(BaseProbaRegressor):
         "capability:missing": True,
         "X_inner_mtype": "pd_DataFrame_Table",
         "y_inner_mtype": "pd_DataFrame_Table",
-        # CI and test flags
-        # -----------------
-        "tests:skip_by_name": ["test_class_has_doctest_example"],
     }
 
     def __init__(self, strategy="empirical"):

--- a/skpro/regression/gp/_sklearn.py
+++ b/skpro/regression/gp/_sklearn.py
@@ -103,13 +103,20 @@ class GaussianProcess(_DelegateWithFittedParamForwarding):
 
     log_marginal_likelihood_value_ : float
         The log-marginal-likelihood of ``self.kernel_.theta``.
-    """
 
-    _tags = {
-        # CI and test flags
-        # -----------------
-        "tests:skip_by_name": ["test_class_has_doctest_example"],
-    }
+    Examples
+    --------
+    ``GaussianProcess`` provides a probabilistic regression interface based on
+    scikit-learn's ``GaussianProcessRegressor``.
+
+    >>> import pandas as pd
+    >>> from skpro.regression.gp import GaussianProcess
+    >>> X = pd.DataFrame({"x": [1, 2, 3]})
+    >>> y = pd.DataFrame({"y": [2, 4, 6]})
+    >>> reg = GaussianProcess()
+    >>> reg = reg.fit(X, y)
+    >>> y_pred_proba = reg.predict_proba(X)
+    """
 
     def __init__(
         self,

--- a/skpro/regression/online/_dont_refit.py
+++ b/skpro/regression/online/_dont_refit.py
@@ -24,13 +24,27 @@ class OnlineDontRefit(_DelegatedProbaRegressor):
     ----------
     estimator_ : skpro regressor, descendant of BaseProbaRegressor
         clone of the regressor passed in the constructor, fitted on all data
+
+    Examples
+    --------
+    ``OnlineDontRefit`` can wrap a probabilistic regressor to create a
+    no-op online regressor that can be fitted normally and used for
+    prediction without refitting during updates.
+
+    >>> import pandas as pd
+    >>> from skpro.regression.dummy import DummyProbaRegressor
+    >>> from skpro.regression.online import OnlineDontRefit
+    >>> X = pd.DataFrame({"x": [1, 2, 3]})
+    >>> y = pd.DataFrame({"y": [2, 4, 6]})
+    >>> estimator = DummyProbaRegressor()
+    >>> reg = OnlineDontRefit(estimator)
+    >>> reg.fit(X, y)
+    OnlineDontRefit(estimator=DummyProbaRegressor())
+    >>> y_pred_proba = reg.predict_proba(X)
     """
 
     _tags = {
         "capability:update": False,
-        # CI and test flags
-        # -----------------
-        "tests:skip_by_name": ["test_class_has_doctest_example"],
     }
 
     def __init__(self, estimator):


### PR DESCRIPTION
## Reference Issues/PRs

Fix #1135

#### What does this implement/fix? Explain your changes.

Adds executable NumPyDoc-style `Examples` sections to the following estimators:

- `DummyProbaRegressor`
- `SklearnProbaReg`
- `GaussianProcess`
- `OnlineDontRefit`

The corresponding `tests:skip_by_name` entries for `test_class_has_doctest_example` were removed so that the doctest example
test can run for these estimators.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

Please review the clarity and correctness of the new usage examples and whether they follow the existing NumPyDoc documentation style.

#### Did you add any tests for the change?

The new `Examples` sections were verified using standalone doctests with `python -m doctest`.

#### Any other comments?

No new dependencies or estimator behavior changes were introduced.

#### PR checklist

##### For all contributions

- [x] I've added myself to the list of contributors with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].