### PR TITLE
[BUG] fix DummyProbaRegressor._predict_var returning std dev instead of variance (#975)

### DIFF
--- a/skpro/regression/dummy.py
+++ b/skpro/regression/dummy.py
@@ -81,6 +81,7 @@ class DummyProbaRegressor(BaseProbaRegressor):
         self._y_columns = y.columns
         self._mu = np.mean(y.values)
         self._sigma = np.std(y.values)
+        self._var = np.var(y.values)
         if self.strategy == "empirical":
             self.distribution_ = Empirical(y)
         if self.strategy == "normal":
@@ -129,7 +130,7 @@ class DummyProbaRegressor(BaseProbaRegressor):
         X_ind = X.index
         X_n_rows = X.shape[0]
         y_pred = pd.DataFrame(
-            np.ones(X_n_rows) * self._sigma, index=X_ind, columns=self._y_columns
+            np.ones(X_n_rows) * self._var, index=X_ind, columns=self._y_columns
         )
         return y_pred
 

--- a/skpro/regression/tests/test_dummy.py
+++ b/skpro/regression/tests/test_dummy.py
@@ -1,0 +1,53 @@
+"""Tests for DummyProbaRegressor."""
+# copyright: skpro developers, BSD-3-Clause License (see LICENSE file)
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from skpro.regression.dummy import DummyProbaRegressor
+
+
+@pytest.mark.parametrize("strategy", ["empirical", "normal"])
+def test_dummy_predict_var_returns_variance_not_std(strategy):
+    """predict_var must return the variance of y, not its standard deviation.
+
+    Regression test for bug #975: ``_predict_var`` filled predictions with
+    ``self._sigma`` (the standard deviation) instead of the variance, producing
+    a unit-mismatched result (sigma instead of sigma**2).
+    """
+    rng = np.random.default_rng(42)
+    X = pd.DataFrame({"feature": rng.normal(size=50)})
+    y = pd.DataFrame({"target": rng.normal(loc=3.0, scale=7.0, size=50)})
+
+    reg = DummyProbaRegressor(strategy=strategy)
+    reg.fit(X, y)
+
+    X_test = pd.DataFrame({"feature": rng.normal(size=10)})
+    pred_var = reg.predict_var(X_test)
+
+    expected_var = np.var(y.values)
+    std_dev = np.std(y.values)
+
+    # every row carries the same constant variance prediction
+    assert np.allclose(pred_var.values, expected_var)
+    # guard against the regression: variance must not equal the std dev
+    assert not np.allclose(pred_var.values, std_dev)
+
+
+@pytest.mark.parametrize("strategy", ["empirical", "normal"])
+def test_dummy_predict_var_shape_and_index(strategy):
+    """predict_var output must align with X index and y columns."""
+    rng = np.random.default_rng(0)
+    X = pd.DataFrame({"feature": rng.normal(size=30)})
+    y = pd.DataFrame({"target": rng.normal(size=30)})
+
+    reg = DummyProbaRegressor(strategy=strategy)
+    reg.fit(X, y)
+
+    X_test = pd.DataFrame({"feature": rng.normal(size=5)}, index=[10, 11, 12, 13, 14])
+    pred_var = reg.predict_var(X_test)
+
+    assert pred_var.shape == (5, 1)
+    assert list(pred_var.index) == [10, 11, 12, 13, 14]
+    assert list(pred_var.columns) == ["target"]


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #975.

Supersedes #982, which was self-closed by its author only because a repo restructure produced too many rebase conflicts; the author noted the fix was still valid and needed a fresh PR against current `main`. This is that fresh PR.

#### What does this implement/fix? Explain your changes.

`DummyProbaRegressor._predict_var` filled its predictions with `self._sigma`, the **standard deviation** of the training labels, instead of the **variance**. Since `_fit` stores `self._sigma = np.std(y.values)`, `predict_var` returned σ rather than σ² for both the `"empirical"` and `"normal"` strategies — a unit mismatch that makes any downstream use of `predict_var` on this baseline numerically incorrect.

Changes:

- `_fit`: additionally store `self._var = np.var(y.values)` (the existing `self._sigma` is left untouched, since it is still correctly used as the `sigma` argument to `Normal` in both `_fit` and `_predict_proba`).
- `_predict_var`: fill predictions with `self._var` instead of `self._sigma`.

#### Testing

Added `skpro/regression/tests/test_dummy.py` with regression tests that assert, for both strategies, that `predict_var` equals `np.var(y)` (and is **not** equal to the standard deviation), plus a shape/index-alignment check. The new tests fail on the unfixed code and pass with the fix.

Run locally:

```
python -m pytest skpro/regression/tests/test_dummy.py
```

#### PR checklist

- [x] Added/updated tests that would fail without the fix.
- [x] The change is a minimal, targeted bug fix in a single module.