### PR TITLE
[ENH] ensure conditional execution of object-specific tests

### DIFF
--- a/skpro/distributions/base/tests/test_multiindex.py
+++ b/skpro/distributions/base/tests/test_multiindex.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pytest
 
 from skpro.distributions.normal import Normal
+from skpro.tests.test_switch import run_test_module_changed
 
 
 @pytest.fixture
@@ -16,6 +17,10 @@ def normal_dist():
     return Normal(np.array([[1, 2], [2, 3], [4, 5], [6, 7]]), 2, index=ix)
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
 def test_loc_partial_level(normal_dist):
     result = normal_dist.loc[1]
     expected_index = pd.MultiIndex.from_tuples([(1, 2), (1, 3)])
@@ -23,6 +28,10 @@ def test_loc_partial_level(normal_dist):
     assert result.mean().shape == (2, 2)
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
 def test_loc_full_tuple(normal_dist):
     result = normal_dist.loc[(2, 2)]
     expected_index = pd.MultiIndex.from_tuples([(2, 2)])
@@ -30,6 +39,10 @@ def test_loc_full_tuple(normal_dist):
     assert result.mean().shape == (1, 2)
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
 def test_loc_list_of_keys(normal_dist):
     result = normal_dist.loc[[(1, 2), (2, 3)]]
     expected_index = pd.MultiIndex.from_tuples([(1, 2), (2, 3)])
@@ -37,6 +50,10 @@ def test_loc_list_of_keys(normal_dist):
     assert result.mean().shape == (2, 2)
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
 def test_iloc_single_row(normal_dist):
     result = normal_dist.iloc[0]
     expected_index = pd.MultiIndex.from_tuples([(1, 2)])
@@ -44,6 +61,10 @@ def test_iloc_single_row(normal_dist):
     assert result.mean().shape == (1, 2)
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
 def test_iloc_multiple_rows(normal_dist):
     result = normal_dist.iloc[[0, 3]]
     expected_index = pd.MultiIndex.from_tuples([(1, 2), (2, 3)])
@@ -51,6 +72,10 @@ def test_iloc_multiple_rows(normal_dist):
     assert result.mean().shape == (2, 2)
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
 def test_iloc_column_slice(normal_dist):
     result = normal_dist.iloc[:, 1]
     expected_index = normal_dist.index
@@ -58,6 +83,10 @@ def test_iloc_column_slice(normal_dist):
     np.testing.assert_array_equal(result.index, expected_index)
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
 def test_loc_row_col(normal_dist):
     result = normal_dist.loc[(1, 2), :]
     expected_index = pd.MultiIndex.from_tuples([(1, 2)])

--- a/skpro/distributions/tests/test_normal_mixture.py
+++ b/skpro/distributions/tests/test_normal_mixture.py
@@ -3,10 +3,16 @@
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from skpro.distributions.normal_mixture import NormalMixture
+from skpro.tests.test_switch import run_test_for_class
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(NormalMixture),
+    reason="run test only if tested object has changed",
+)
 def test_pi_is_normalized_per_row():
     """Mixture weights should be normalized row-wise at construction."""
     pi = np.array([[0.3, 0.7], [1.0, 2.0]])
@@ -17,6 +23,10 @@ def test_pi_is_normalized_per_row():
     assert np.allclose(d._pi.sum(axis=1), 1.0)
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(NormalMixture),
+    reason="run test only if tested object has changed",
+)
 def test_mean_and_var_match_closed_form_scalar():
     """Mean/variance should match closed-form mixture formulas in scalar case."""
     pi = np.array([0.5, 0.5])
@@ -34,6 +44,10 @@ def test_mean_and_var_match_closed_form_scalar():
     assert np.isclose(d.var(), expected_var)
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(NormalMixture),
+    reason="run test only if tested object has changed",
+)
 def test_single_component_reduces_to_normal_pdf_and_cdf():
     """With one active component, pdf/cdf should match that Normal component."""
     pi = np.array([[1.0, 0.0]])
@@ -49,6 +63,10 @@ def test_single_component_reduces_to_normal_pdf_and_cdf():
     assert np.isclose(cdf, 0.5)
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(NormalMixture),
+    reason="run test only if tested object has changed",
+)
 def test_rowwise_weights_change_rowwise_mean():
     """Per-sample weights should produce different means per row."""
     pi = np.array([[0.9, 0.1], [0.1, 0.9]])
@@ -62,6 +80,10 @@ def test_rowwise_weights_change_rowwise_mean():
     assert np.isclose(means[1], 9.0)
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(NormalMixture),
+    reason="run test only if tested object has changed",
+)
 def test_sampling_mean_matches_theoretical_mean():
     """Large-sample mean should approximate theoretical mixture mean."""
     pi = np.array([[0.5, 0.5]])
@@ -78,6 +100,10 @@ def test_sampling_mean_matches_theoretical_mean():
     assert abs(sample_mean - theoretical_mean) < 0.1
 
 
+@pytest.mark.skipif(
+    not run_test_for_class(NormalMixture),
+    reason="run test only if tested object has changed",
+)
 def test_energy_returns_non_negative_dataframe():
     """Energy outputs should be non-negative and keep expected tabular shape."""
     pi = np.array([[1.0, 0.0]])

--- a/skpro/distributions/tests/test_proba_basic.py
+++ b/skpro/distributions/tests/test_proba_basic.py
@@ -27,6 +27,10 @@ def test_proba_example():
     assert one_row.shape == (1, 2)
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
 @pytest.mark.parametrize("subsetter", ["loc", "iloc"])
 def test_proba_subsetters_loc_iloc(subsetter):
     """Test one subsetting case for BaseDistribution."""
@@ -57,6 +61,10 @@ def test_proba_subsetters_loc_iloc(subsetter):
     assert nss.shape == ()
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
 def test_proba_subsetters_at_iat():
     """Test one subsetting case for BaseDistribution."""
     from skpro.distributions.normal import Normal
@@ -75,6 +83,10 @@ def test_proba_subsetters_at_iat():
     assert nss == n.loc[1, 1]
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
 def test_proba_index_coercion():
     """Test index coercion for BaseDistribution."""
     from skpro.distributions.normal import Normal
@@ -105,6 +117,10 @@ def test_proba_index_coercion():
     assert n.columns.equals(pd.Index([1, 2, 3]))
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
 @pytest.mark.skipif(
     not _check_soft_dependencies("matplotlib", severity="none"),
     reason="skip if matplotlib is not available",
@@ -142,6 +158,10 @@ def test_proba_plotting(fun):
 
 
 @pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
+@pytest.mark.skipif(
     not _check_soft_dependencies("matplotlib", severity="none"),
     reason="skip if matplotlib is not available",
 )
@@ -171,6 +191,10 @@ def test_discrete_pmf_plotting():
         assert len(markerline.get_xdata()) > 5, "Should plot at multiple support points"
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
 def test_to_df_parametric():
     """Tests coercion to DataFrame via get_params_df and to_df."""
     from skpro.distributions.normal import Normal
@@ -223,6 +247,10 @@ def test_to_df_parametric():
         assert ix not in ["index", "columns"]
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.distributions"),
+    reason="run only if skpro.distributions has been changed",
+)
 def test_head_tail():
     """Test head and tail utility functions."""
     from skpro.distributions.normal import Normal

--- a/skpro/regression/tests/test_bandwidth.py
+++ b/skpro/regression/tests/test_bandwidth.py
@@ -12,8 +12,13 @@ from skpro.regression._bandwidth import (
     bw_scott_1d,
     bw_silverman_1d,
 )
+from skpro.tests.test_switch import run_test_module_changed
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.regression"),
+    reason="run only if skpro.regression has been changed",
+)
 def test_bandwidth_1d_methods_return_finite_positive_values():
     """Test all methods return finite positive bandwidths on non-degenerate data."""
     rng = np.random.default_rng(42)
@@ -25,6 +30,10 @@ def test_bandwidth_1d_methods_return_finite_positive_values():
         assert h > 0
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.regression"),
+    reason="run only if skpro.regression has been changed",
+)
 def test_bandwidth_weight_handling():
     """Test weighted inputs for Scott and Silverman."""
     rng = np.random.default_rng(0)
@@ -39,6 +48,10 @@ def test_bandwidth_weight_handling():
     assert h_silverman > 0
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.regression"),
+    reason="run only if skpro.regression has been changed",
+)
 def test_bw_helpers_match_dispatcher():
     """Test helper functions match generic dispatcher outputs."""
     rng = np.random.default_rng(7)
@@ -49,6 +62,10 @@ def test_bw_helpers_match_dispatcher():
     assert np.isclose(bw_isj_1d(y), bandwidth_1d(y, method="isj"))
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.regression"),
+    reason="run only if skpro.regression has been changed",
+)
 def test_bandwidth_runtime_smoke_comparison():
     """Performance smoke test for selector runtime and ISJ comparison."""
     rng = np.random.default_rng(123)
@@ -73,6 +90,10 @@ def test_bandwidth_runtime_smoke_comparison():
     assert times["isj"] > min(times["scott"], times["silverman"])
 
 
+@pytest.mark.skipif(
+    not run_test_module_changed("skpro.regression"),
+    reason="run only if skpro.regression has been changed",
+)
 def test_legacy_aliases_rejected():
     """Legacy aliases should be rejected to enforce canonical naming."""
     with pytest.raises(ValueError, match="Unknown method"):

--- a/skpro/regression/tests/test_mapie_v1.py
+++ b/skpro/regression/tests/test_mapie_v1.py
@@ -1,13 +1,27 @@
 import pandas as pd
 import pytest
-from skbase.utils.dependencies import _check_soft_dependencies
 from sklearn.datasets import make_regression
 from sklearn.linear_model import LinearRegression
 
+from skpro.regression.conformal import (
+    MapieConformalizedQuantileRegressor,
+    MapieCrossConformalRegressor,
+    MapieSplitConformalRegressor,
+)
+from skpro.regression.jackknife import MapieJackknifeAfterBootstrapRegressor
+from skpro.tests.test_switch import run_test_for_class
+
+MAPIE_REGRESSORS = [
+    MapieSplitConformalRegressor,
+    MapieCrossConformalRegressor,
+    MapieJackknifeAfterBootstrapRegressor,
+    MapieConformalizedQuantileRegressor,
+]
+
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mapie>=1.0", severity="none"),
-    reason="mapie>=1.0 not installed",
+    not run_test_for_class(MAPIE_REGRESSORS),
+    reason="run test only if tested object has changed",
 )
 def test_mapie_v1_imports():
     """Test imports from the new conformal/jackknife modules."""
@@ -25,8 +39,8 @@ def test_mapie_v1_imports():
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mapie>=1.0", severity="none"),
-    reason="mapie>=1.0 not installed",
+    not run_test_for_class(MAPIE_REGRESSORS),
+    reason="run test only if tested object has changed",
 )
 def test_mapie_v1_imports_from_top_level():
     """Test imports from top-level regression module."""
@@ -44,8 +58,8 @@ def test_mapie_v1_imports_from_top_level():
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies("mapie>=1.0", severity="none"),
-    reason="mapie>=1.0 not installed",
+    not run_test_for_class(MAPIE_REGRESSORS),
+    reason="run test only if tested object has changed",
 )
 @pytest.mark.parametrize(
     "estimator_class",

--- a/skpro/regression/tests/test_ondil.py
+++ b/skpro/regression/tests/test_ondil.py
@@ -1,14 +1,14 @@
 import numpy as np
 import pandas as pd
 import pytest
-from skbase.utils.dependencies import _check_soft_dependencies
 
 from skpro.regression.ondil import OndilOnlineGamlss
+from skpro.tests.test_switch import run_test_for_class
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies(["ondil"], severity="none"),
-    reason="skip test if ondil is not installed in environment",
+    not run_test_for_class(OndilOnlineGamlss),
+    reason="run test only if tested object has changed",
 )
 def test_ondil_instantiation_and_get_test_params():
     """Basic smoke test for the Ondil wrapper.
@@ -31,8 +31,8 @@ def test_ondil_instantiation_and_get_test_params():
 
 
 @pytest.mark.skipif(
-    not _check_soft_dependencies(["ondil"], severity="none"),
-    reason="skip test if ondil is not installed in environment",
+    not run_test_for_class(OndilOnlineGamlss),
+    reason="run test only if tested object has changed",
 )
 def test_ondil_fit_smoke():
     """Try a light-weight fit call on tiny data to validate wiring.

--- a/skpro/regression/tests/test_pipeline_transform_chain.py
+++ b/skpro/regression/tests/test_pipeline_transform_chain.py
@@ -1,12 +1,18 @@
 import numpy as np
 import pandas as pd
+import pytest
 from sklearn.linear_model import LinearRegression
 from sklearn.preprocessing import FunctionTransformer
 
 from skpro.regression.compose import Pipeline
 from skpro.regression.residual import ResidualDouble
+from skpro.tests.test_switch import run_test_for_class
 
 
+@pytest.mark.skipif(
+    not run_test_for_class([Pipeline, ResidualDouble]),
+    reason="run test only if tested object has changed",
+)
 def test_transformer_chaining_in_predict():
     """Ensure transformers are applied sequentially in pipeline."""
 


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #997.

#### What does this implement/fix? Explain your changes.

A number of recently added tests are specific to a single estimator, distribution, or
module, but carry no conditional skip. They are therefore collected and executed in
every CI job, on every pull request, even when the code they cover is untouched. This
adds CI runtime without adding signal.

This PR adds the conditional skip decorators to those tests, using the existing
switches in `skpro/tests/test_switch.py`. No new machinery is introduced.

`run_test_for_class(ClassName)` is used for tests tied to specific objects:

| File | Tests | Object(s) |
| --- | --- | --- |
| `skpro/distributions/tests/test_normal_mixture.py` | 6 | `NormalMixture` |
| `skpro/regression/tests/test_mapie_v1.py` | 3 | the four MAPIE v1 regressors |
| `skpro/regression/tests/test_ondil.py` | 2 | `OndilOnlineGamlss` |
| `skpro/regression/tests/test_pipeline_transform_chain.py` | 1 | `Pipeline`, `ResidualDouble` |

`run_test_module_changed("skpro.<module>")` is used for tests that exercise a module or
base layer rather than one concrete class:

| File | Tests | Module |
| --- | --- | --- |
| `skpro/distributions/base/tests/test_multiindex.py` | 7 | `skpro.distributions` |
| `skpro/distributions/tests/test_proba_basic.py` | 7 | `skpro.distributions` |
| `skpro/regression/tests/test_bandwidth.py` | 5 | `skpro.regression` |

Both follow the decorator form already used across the test suite:

```python
@pytest.mark.skipif(
    not run_test_for_class(ClassName),
    reason="run test only if tested object has changed",
)
```

Besides change detection, `run_test_for_class` also checks the estimator's
`python_dependencies` tag. It therefore subsumes the explicit `_check_soft_dependencies`
guards that `test_mapie_v1.py` and `test_ondil.py` used, and those redundant guards are
removed in favour of the single switch.

Test logic is unchanged throughout. Only decorators, and the imports they need, are added.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

* The split between `run_test_for_class` and `run_test_module_changed`. The four
  object-specific files map cleanly onto single classes; `test_multiindex.py`,
  `test_proba_basic.py` and `test_bandwidth.py` cover a base layer or a module rather
  than one class, so the module-level switch is used there instead. Happy to move any of
  them to the class-level switch if you would prefer the finer granularity.
* The module granularity chosen for `test_bandwidth.py`. It is guarded on
  `skpro.regression`, following the existing convention of guarding on the top-level
  subpackage; `skpro.regression._bandwidth` would be tighter if you prefer.
* Removal of the `_check_soft_dependencies` decorators in `test_mapie_v1.py` and
  `test_ondil.py`, now covered by `run_test_for_class` via the `python_dependencies` tag.
  Verified below that those tests still skip when the dependency is absent.
* In `test_proba_basic.py`, `test_proba_example` is deliberately left untouched, as it is
  already unconditionally skipped via `pytest.mark.skip` pending #918. A conditional
  guard on top of that would be dead code.

#### Did you add any tests for the change?

No new tests are added. This PR changes only when existing tests run, so it is verified
by running the affected files in both switch states.

The seven affected test files, with the switch off (default):

```
31 passed, 9 skipped
```

The nine skips are the soft dependency skips for `mapie` and `ondil`, which are not
installed in the environment, plus the pre-existing `test_proba_example` skip. This
confirms that the dependency guards removed in favour of `run_test_for_class` still take
effect.

The same files with `--only_changed_modules True`:

```
24 passed, 16 skipped
```

The additional skips all report `run test only if tested object has changed`, which
confirms the new decorators engage. The module-level tests still run here because the
test files themselves live inside the modules they guard on and are modified by this PR,
which is the intended behaviour of `run_test_module_changed`.

Linting on the changed files, matching the `pre-commit` configuration:

```
flake8      -> passed
isort       -> passed
pydocstyle  -> passed
black       -> no new findings
```

The single pre-existing `black` finding on `test_bandwidth.py` is identical before and
after this change, and originates from a newer `black` than the pinned 23.7.0.

#### Any other comments?

With `--only_changed_modules True`, `run_test_for_class` runs a test only if the class,
one of its local parent classes, its covering test classes, its `tests:libs` modules, or
its dependency specifications in `pyproject.toml` have changed relative to `main`, and
only if its soft dependencies are installed. `run_test_module_changed` applies the
equivalent check at module granularity. When the flag is off, behaviour is unchanged and
everything still runs, so local runs and scheduled full runs are unaffected.

#### PR checklist

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/sktime/skpro/blob/main/CONTRIBUTORS.md) with any new badges I've earned :-)
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
